### PR TITLE
fix: correct MCP server URLs to confidence.dev

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,11 @@
   "mcpServers": {
     "confidence-flags": {
       "type": "http",
-      "url": "https://mcp.confidence.spotify.com/mcp/flags"
+      "url": "https://mcp.confidence.dev/mcp/flags"
     },
     "confidence-docs": {
       "type": "http",
-      "url": "https://mcp.confidence.spotify.com/mcp/docs"
+      "url": "https://mcp.confidence.dev/mcp/docs"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix MCP server URLs from `mcp.confidence.spotify.com` to `mcp.confidence.dev`
- Both `confidence-flags` and `confidence-docs` endpoints were unreachable at the old domain

## Test plan
- [ ] Authenticate confidence-flags MCP via `/mcp` dialog in Claude Code
- [ ] Authenticate confidence-docs MCP via `/mcp` dialog in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)