### PR TITLE
chore: bump plugin version to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "confidence",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "owner": {
     "name": "Spotify Confidence"
   },
   "plugins": [
     {
       "name": "confidence",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Access Confidence feature flags, experiments, and migration tools directly from Claude Code.",
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "confidence",
   "description": "Access Confidence feature flags, experiments, and migration tools directly from Claude Code.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Spotify Confidence",
     "url": "https://confidence.spotify.com"


### PR DESCRIPTION
## Summary
- Bumps marketplace and plugin version from 0.1.0 to 0.2.0
- Updates version in both `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`

## Test plan
- [ ] Verify `claude plugin update confidence@confidence` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)