### PR TITLE
chore: update MCP URLs in migrate-posthog skill

### DIFF
--- a/skills/migrate-posthog/SKILL.md
+++ b/skills/migrate-posthog/SKILL.md
@@ -152,7 +152,7 @@ Test: `mcp__confidence__listClients`
 
 If not available, install it:
 ```
-claude mcp add confidence --transport http --url https://mcp.confidence.spotify.com/mcp/flags
+claude mcp add confidence --transport http --url https://mcp.confidence.dev/mcp/flags
 ```
 
 The user will be prompted to authenticate via OAuth in their browser.
@@ -163,7 +163,7 @@ Test: `mcp__confidence-docs__searchDocumentation`
 
 If not available, install it:
 ```
-claude mcp add confidence-docs --transport http --url https://mcp.confidence.spotify.com/mcp/docs
+claude mcp add confidence-docs --transport http --url https://mcp.confidence.dev/mcp/docs
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Update Confidence MCP URLs from `mcp.confidence.spotify.com` to `mcp.confidence.dev` to match the n8n-migration-confidence project

## Context

The n8n-migration-confidence project had the correct public URLs. This syncs the confidence-ai-plugins skill to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)