### PR TITLE
docs: add missing marketplace step to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ Official Confidence plugin for AI clients. Access feature flags, experiments, an
 
 ### Claude Code
 
-1. Install the plugin:
+1. Add the Confidence marketplace:
+    ```bash
+    claude marketplace add https://raw.githubusercontent.com/spotify/confidence-ai-plugins/main/.claude-plugin/marketplace.json
+    ```
+
+2. Install the plugin:
     ```bash
     claude plugin install confidence
     ```
 
-2. Authenticate via OAuth:
+3. Authenticate via OAuth:
     ```bash
     claude
     # Then use /mcp to connect to the Confidence MCP servers

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Official Confidence plugin for AI clients. Access feature flags, experiments, an
 
 1. Add the Confidence marketplace:
     ```bash
-    claude marketplace add https://raw.githubusercontent.com/spotify/confidence-ai-plugins/main/.claude-plugin/marketplace.json
+    claude marketplace add spotify/confidence-ai-plugins
     ```
 
 2. Install the plugin:


### PR DESCRIPTION
## Summary
- Added the missing `claude marketplace add spotify/confidence-ai-plugins` step before `claude plugin install confidence` in the README installation instructions

## Test plan
- [ ] Verify `claude marketplace add spotify/confidence-ai-plugins` works
- [ ] Verify `claude plugin install confidence` succeeds after adding marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)