### PR TITLE
feat(migrate-statsig): Statsig→Confidence migration kit — Phase 1: flag definitions

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Confidence",
     "shortDescription": "Feature flags, experiments, and migration tools",
-    "longDescription": "Access Confidence feature flags, experiments, and migration tools directly from Codex. Create, list, resolve, and target feature flags. Migrate from PostHog or Optimizely to Confidence SDK.",
+    "longDescription": "Access Confidence feature flags, experiments, and migration tools directly from Codex. Create, list, resolve, and target feature flags. Migrate from PostHog, Eppo, or Statsig to Confidence SDK.",
     "developerName": "Spotify Confidence",
     "category": "Productivity",
     "capabilities": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ This plugin integrates Confidence with Claude Code, providing tools for feature 
 
 - `/confidence:migrate-posthog <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from PostHog to Confidence SDK
 - `/confidence:migrate-eppo <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Eppo to Confidence SDK
-- `/confidence:migrate-statsig <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Statsig to Confidence SDK
+- `/confidence:migrate-statsig <plan flag | execute <plan-file>>` — Migrate feature flag definitions from Statsig to Confidence (Phase 1; code transformation ships separately)
 
 ## Skills
 
 - **migrate-posthog** — Auto-triggers when the user asks to migrate PostHog flags or transform SDK code to Confidence
 - **migrate-eppo** — Auto-triggers when the user asks to migrate Eppo flags or transform SDK code to Confidence
-- **migrate-statsig** — Auto-triggers when the user asks to migrate Statsig gates/configs/experiments or transform SDK code to Confidence
+- **migrate-statsig** — Auto-triggers when the user asks to migrate Statsig gates/configs/experiments to Confidence
 
 ## MCP Servers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,13 @@ This plugin integrates Confidence with Claude Code, providing tools for feature 
 
 - `/confidence:migrate-posthog <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from PostHog to Confidence SDK
 - `/confidence:migrate-eppo <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Eppo to Confidence SDK
+- `/confidence:migrate-statsig <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Statsig to Confidence SDK
 
 ## Skills
 
 - **migrate-posthog** — Auto-triggers when the user asks to migrate PostHog flags or transform SDK code to Confidence
 - **migrate-eppo** — Auto-triggers when the user asks to migrate Eppo flags or transform SDK code to Confidence
+- **migrate-statsig** — Auto-triggers when the user asks to migrate Statsig gates/configs/experiments or transform SDK code to Confidence
 
 ## MCP Servers
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,4 +12,4 @@ You are a helpful assistant that can manage Confidence feature flags and experim
 - Always check that the user is authenticated before performing flag operations.
 - Use the confidence-docs tools to answer questions about SDK integration, OpenFeature setup, and best practices.
 - When creating flags, confirm the flag name and schema with the user before proceeding.
-- For migrations from PostHog or Optimizely, guide the user through the migration plan before executing changes.
+- For migrations from PostHog, Eppo, or Statsig, guide the user through the migration plan before executing changes.

--- a/README.md
+++ b/README.md
@@ -83,12 +83,13 @@ This plugin provides access to Confidence tools across these categories:
 
 - **Feature flags** — Create, list, update, archive, resolve, and target feature flags
 - **Documentation** — Search Confidence docs and SDK integration guides
-- **Migration** — Migrate feature flags from PostHog or Eppo to Confidence
+- **Migration** — Migrate feature flags from PostHog, Eppo, or Statsig to Confidence
 
 ## Slash Commands
 
 - `/confidence:migrate-posthog` — Migrate feature flags from PostHog to Confidence SDK
 - `/confidence:migrate-eppo` — Migrate feature flags from Eppo to Confidence SDK
+- `/confidence:migrate-statsig` — Migrate feature flags from Statsig to Confidence SDK
 
 ## Example Usage
 
@@ -99,6 +100,8 @@ This plugin provides access to Confidence tools across these categories:
 > /confidence:migrate-posthog plan code
 > /confidence:migrate-eppo plan flag
 > /confidence:migrate-eppo plan code
+> /confidence:migrate-statsig plan flag
+> /confidence:migrate-statsig plan code
 ```
 
 ## MCP Servers

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ This plugin provides access to Confidence tools across these categories:
 > /confidence:migrate-eppo plan flag
 > /confidence:migrate-eppo plan code
 > /confidence:migrate-statsig plan flag
-> /confidence:migrate-statsig plan code
 ```
 
 ## MCP Servers

--- a/commands/migrate-statsig.md
+++ b/commands/migrate-statsig.md
@@ -1,0 +1,9 @@
+---
+name: migrate-statsig
+description: Migrate feature flags from Statsig to Confidence
+argument-hint: [plan flag | plan code | execute <plan-file>]
+---
+
+All migration instructions are maintained in `skills/migrate-statsig/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/migrate-statsig/SKILL.md` and follow those instructions to handle this command.

--- a/commands/migrate-statsig.md
+++ b/commands/migrate-statsig.md
@@ -1,7 +1,7 @@
 ---
 name: migrate-statsig
 description: Migrate feature flags from Statsig to Confidence
-argument-hint: [plan flag | plan code | execute <plan-file>]
+argument-hint: [plan flag | execute <plan-file>]
 ---
 
 All migration instructions are maintained in `skills/migrate-statsig/SKILL.md` to prevent divergence.

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -351,7 +351,12 @@ matched rule's `passPercentage` doesn't pass), the gate returns `false`.
   see "Experiment `allocation` < 100".
 - `controlGroupID` — which group is control (informational)
 - `targetingGateID` — restrict the experiment to users who pass this
-  gate. Confidence has no cross-flag gate dependency — see "Blocked".
+  gate. **This is how the modern Statsig console expresses experiment
+  targeting** (inline rules are legacy; the Console API can't even write
+  them). Treat it exactly like a `passes_gate` condition: fetch the
+  referenced gate and **inline its conditions** into the experiment's
+  Confidence targeting (or share it as a segment on the REST backend).
+  Only block if the referenced gate is itself unmigratable.
 - `inlineTargetingRules[]` — inline targeting (same rule/condition shape
   as gates). Combine with `allocation`.
 - `layerID` — if set, the experiment belongs to a layer (see Layers
@@ -574,8 +579,9 @@ Extract from each item:
 - For **gates / dynamic configs**: the ordered `rules[]`. For each rule:
   `passPercentage`, `conditions[]`, and (configs only) `returnValue`
 - For **experiments**: `groups[]` (`name`, `size`, `parameterValues`),
-  `allocation`, `controlGroupID`, `targetingGateID`,
-  `inlineTargetingRules[]`, `layerID`
+  `allocation`, `controlGroupID`, `targetingGateID` (fetch the referenced
+  gate — its conditions get inlined; see the Experiment object notes),
+  `inlineTargetingRules[]` (legacy), `layerID`
 - `holdoutIDs[]` (gates/configs/experiments) → record each holdout; it
   maps to a Confidence holdback (a surface step — see "Holdouts (item 5)").
   **Dedupe the list** — the live Console API returns duplicated entries
@@ -1144,12 +1150,12 @@ These genuinely have no clean Confidence translation on **any** backend:
 
 These are **not** blocked outright — they downgrade gracefully:
 
-- **`passes_gate` / `fails_gate`** — Confidence has no flag-to-flag
-  dependency, but the referenced gate's conditions can be **inlined** (or
-  turned into a shared segment on the REST backend) and composed with
-  `and` / `not`. Only block if the referenced gate is itself
-  unmigratable. Note the inlining in the plan (it won't auto-update if
-  the source gate changes).
+- **`passes_gate` / `fails_gate` / experiment `targetingGateID`** —
+  Confidence has no flag-to-flag dependency, but the referenced gate's
+  conditions can be **inlined** (or turned into a shared segment on the
+  REST backend) and composed with `and` / `not`. Only block if the
+  referenced gate is itself unmigratable. Note the inlining in the plan
+  (it won't auto-update if the source gate changes).
 - **Large `id_list` segments** — use a **REST materialized segment**
   (BigQuery). Only block (`References an id_list segment too large to
   inline`) if the REST backend / BigQuery isn't available.

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -279,7 +279,11 @@ The migration uses these endpoints. All require both
 
 **Convention.** Field names are `camelCase`. IDs are strings (e.g.
 `a_gate`). Condition `targetValue` is sometimes a scalar and sometimes an
-array — normalize to an array when translating.
+array — normalize to an array when translating. Verified against the
+live Console API: a single value comes back as a **scalar** (and numeric
+comparisons carry **numbers**, e.g. `28` not `"28"`), multiple values as
+an array; `passes_gate` / `passes_segment` / `fails_segment` conditions
+have **no `operator` key at all**.
 
 ### Statsig's three configurable types
 
@@ -573,7 +577,9 @@ Extract from each item:
   `allocation`, `controlGroupID`, `targetingGateID`,
   `inlineTargetingRules[]`, `layerID`
 - `holdoutIDs[]` (gates/configs/experiments) → record each holdout; it
-  maps to a Confidence holdback (a surface step — see "Holdouts (item 5)")
+  maps to a Confidence holdback (a surface step — see "Holdouts (item 5)").
+  **Dedupe the list** — the live Console API returns duplicated entries
+  (one attached holdout can appear twice).
 - Any `passes_segment` / `fails_segment` / `in_segment_list` /
   `not_in_segment_list` conditions → record the referenced segment id;
   fetch it in Step 1c
@@ -783,6 +789,8 @@ proto3 → JSON (camelCase keys).
 | Timestamp `>=` | `"rangeRule": { "startInclusive": { "timestampValue": "2022-11-17T15:16:17Z" } }` |
 | starts with | `"startsWithRule": { "value": "prefix" }` |
 | ends with | `"endsWithRule": { "value": "suffix" }` |
+| list attr: any item matches | `"anyRule": { "rule": { "setRule": { "values": [...] } } }` (inner rule may be `eqRule`/`setRule`/`rangeRule`/`startsWithRule`/`endsWithRule`; no match on empty/missing list) |
+| list attr: every item matches | `"allRule": { "rule": { ... } }` (same inner rules; matches on empty/missing list) |
 | attribute is set (exists) | `{ "attribute": { "attributeName": "X" } }` (attribute criterion with **no** inner rule) |
 
 **Value types.** A `Value` is a oneof: `boolValue`, `numberValue`,
@@ -1028,8 +1036,20 @@ Statsig operators: `any`, `none`, `any_case_sensitive`,
 `version_gte`, `version_lt`, `version_lte`, `version_eq`, `version_neq`,
 `str_starts_with_any`, `str_ends_with_any`, `str_contains_any`,
 `str_contains_none`, `str_matches`, `eq`, `neq`, `before`, `after`,
-`on`, `in_segment_list`, `not_in_segment_list`, plus null checks
-(`is null` / `is not null`).
+`on`, `in_segment_list`, `not_in_segment_list`, array operators
+(`array_contains_any`, `array_contains_none`, `array_contains_all`,
+`not_array_contains_all`), plus null checks (`is null` / `is not null`).
+
+**Per-type operator validity (verified against the live Console API).**
+Statsig validates operators per condition `type`, and the practical
+operator sets are narrower than the union above. Notably,
+`str_starts_with_any` / `str_ends_with_any` are **rejected** for
+`email`, `custom_field`, `url`, `locale`, `user_agent`, and
+`browser_name` — prefix/suffix matching on those types arrives as an
+anchored `str_matches` regex (decompose it per the regex rule below →
+`startsWithRule` / `endsWithRule`) or as `str_contains_any` (BLOCKED —
+see the workaround). `custom_field` additionally accepts numeric,
+version, time, and the array operators.
 
 | Statsig operator | Confidence payload strategy |
 |---|---|
@@ -1055,6 +1075,10 @@ Statsig operators: `any`, `none`, `any_case_sensitive`,
 | `on` (time) | `eqRule.value.timestampValue` |
 | `in_segment_list` | small list → `setRule` on entity; large → REST materialized segment (BigQuery) |
 | `not_in_segment_list` | small list → `setRule` on entity wrapped in `not`; large → REST materialized segment, referenced under `not` |
+| `array_contains_any` | one criterion `anyRule { rule: { setRule { values } } }` on the list attribute, expression `ref` |
+| `array_contains_none` | same `anyRule` criterion, expression `not` wrapping `ref` |
+| `array_contains_all` | one criterion `anyRule { rule: { eqRule v } }` **per target value**, expression `and` of `ref`s (each value must be present; Confidence `allRule` means "every input item matches" — NOT the same thing) |
+| `not_array_contains_all` | the `array_contains_all` construction, expression wrapped in `not` |
 | `is null` | ruleless presence criterion under `not`: `{ "attribute": { "attributeName": "X" } }`, expression `not` wrapping `ref` |
 | `is not null` | ruleless presence criterion, expression `ref` |
 | `str_matches` (regex) | decompose like below; else BLOCKED |
@@ -1141,8 +1165,9 @@ pass to US/CA, then "Everyone" at 0% — becomes `addTargetingRule` calls
 plus a catch-all (the split lives entirely in `variantAllocations`;
 there is no separate rollout field):
 
-1. Rule 1: `email str_ends_with_any ["@spotify.com"]` →
-   payload `endsWithRule "@spotify.com"`,
+1. Rule 1: `email str_matches ".*@spotify\.com$"` (suffix regex — how
+   email suffix targeting actually arrives; see per-type validity) →
+   decomposes to payload `endsWithRule "@spotify.com"`,
    `variantAllocations { "enabled": 100 }`
 2. Rule 2: `country any ["US","CA"]` (passPercentage 50) → payload
    `setRule [US, CA]`, `variantAllocations { "enabled": 50, "disabled": 50 }`

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -599,6 +599,9 @@ curl -sS -H "STATSIG-API-KEY: $STATSIG_API_KEY" \
 - An **`id_list`** / `user_store_id_list` segment is a literal list of
   unit IDs. If small (≤ ~50), inline as a `setRule` on the entity field.
   If large, mark the referencing condition BLOCKED (see "Blocked").
+- An **`analysis_list`** segment is an analysis-only audience with no
+  targeting rules — it has no Confidence targeting equivalent. Mark the
+  referencing condition BLOCKED for manual review.
 
 **Unit ID.** Statsig randomizes on the entity named by `idType`
 (`userID`, `stableID`, or a custom ID). Record each item's `idType`; the
@@ -925,6 +928,9 @@ backend:
     if small (≤ ~50 ids), inline as a `setRule` on the entity field
     (wrapped in `not` for `not_in`). If large, use a REST materialized
     segment, or mark the condition BLOCKED.
+  - **`analysis_list` segment**: analysis-only, no targeting rules to
+    inline and no Confidence equivalent on either backend — mark the
+    condition BLOCKED for manual review.
 
 ## Multivariant / Group Split Handling
 

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -1098,9 +1098,19 @@ These genuinely have no clean Confidence translation on **any** backend:
   Reason: `Depends on experiment-group assignment; migrate manually.`
 - **`javascript`** — arbitrary JS expression. Reason: `Uses a custom
   JavaScript condition; no Confidence equivalent.`
-- **Unnormalizable version strings** — `v`-prefixed or build-metadata
-  versions that can't be reduced to 2–4-segment form. Reason: `Version
-  comparison on '<attribute>' uses a format Confidence can't parse.`
+- **Version *range* comparisons on an un-normalizable format** — only
+  `version_gt/gte/lt/lte`, and only when the value can't be reduced to
+  the supported 2–4 numeric segments. `v`-prefix and `+build` metadata
+  ARE normalizable: strip them on **both** the criterion and the runtime
+  context value (the skill strips them; the app must send the cleaned
+  value too). Truly blocked only for non-numeric schemes (date/calendar
+  versions, git hashes, named releases). Two escape hatches before
+  blocking: (a) **version equality/set** (`version_eq` / `version_neq` /
+  `any` / `none`) needs no parsing — use an `eqRule`/`setRule` on the raw
+  strings; (b) for ranges, send a **numeric build number** in context and
+  use a numeric `rangeRule`. Reason (last resort): `Version range on
+  '<attribute>' uses a non-numeric format; use exact match or a numeric
+  build number instead.`
 
 These are **not** blocked outright — they downgrade gracefully:
 

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Migrate feature flags from Statsig to Confidence SDK. Use when the user says /migrate-statsig, asks to migrate Statsig gates/configs/experiments, or transform SDK code to Confidence.
+description: Migrate feature flag definitions from Statsig to Confidence. Use when the user says /migrate-statsig or asks to migrate Statsig gates/configs/experiments to Confidence.
 ---
 
 # Statsig to Confidence Migration
@@ -9,16 +9,6 @@ skill is fully self-contained: it defines both the Statsig-specific
 migration logic AND all the Confidence-side conventions it relies on
 (payload formats, naming rules, the flag setup sequence, the execute
 flow, etc.).
-
-## SDK Preference
-
-**ALWAYS prefer OpenFeature with local resolve.**
-
-| Priority | Approach | When to use |
-|----------|----------|-------------|
-| 1st | Local resolve | Default for all new integrations |
-| 2nd | Remote resolve | Only if local resolve not supported for platform |
-| Avoid | Direct SDK | Being phased out |
 
 ## Plan Philosophy
 
@@ -36,15 +26,14 @@ flow, etc.).
 | Command | Description |
 |---------|-------------|
 | `/migrate-statsig plan flags` | Phase 1: plan flag definitions migration |
-| `/migrate-statsig plan code` | Phase 2: plan code transformation |
 | `/migrate-statsig execute <plan-file>` | Execute a plan interactively |
 
 ---
 
-## Migration Overview (MUST display at start of `plan flags` or `plan code`)
+## Migration Overview (MUST display at start of `plan flags`)
 
-**Every time** the user runs `plan flags` or `plan code`, display this
-overview FIRST — before doing any work.
+**Every time** the user runs `plan flags`, display this overview FIRST
+— before doing any work.
 
 ```
 ═══════════════════════════════════════════════════════════════
@@ -69,20 +58,11 @@ overview FIRST — before doing any work.
   │                                                        │
   │  Result: All flags live in Confidence, ready to resolve│
   ├─────────────────────────────────────────────────────────┤
-  │  PHASE 2 — Code Transformation                         │
+  │  PHASE 2 — Code Transformation (ships separately)      │
   │                                                        │
-  │  Once flags exist in Confidence, migrate the code that │
-  │  evaluates them. Each flag = one PR.                   │
-  │                                                        │
-  │  Steps:                                                │
-  │    1. Detect language & framework                      │
-  │    2. Fetch Confidence SDK guide                       │
-  │    3. Scan codebase for Statsig usage                  │
-  │    4. Generate transform rules (Statsig → Confidence)  │
-  │    5. Generate plan grouped by flag                    │
-  │    6. Execute: transform code flag by flag, one PR each│
-  │                                                        │
-  │  Result: Code uses Confidence SDK, Statsig removed     │
+  │  Once flags exist in Confidence, the code that         │
+  │  evaluates them is migrated flag-by-flag, one PR each. │
+  │  Phase 2 is delivered as a follow-up to this skill.    │
   └─────────────────────────────────────────────────────────┘
 
   Why flags first?
@@ -95,15 +75,8 @@ overview FIRST — before doing any work.
 ═══════════════════════════════════════════════════════════════
 ```
 
-After displaying the overview, indicate which phase the user is about
-to enter:
-
-- For `plan flags`: "Starting **Phase 1** — Flag Definitions"
-- For `plan code`: "Starting **Phase 2** — Code Transformation.
-  Make sure Phase 1 (flag definitions) is complete first — the flags
-  need to exist in Confidence before the code can resolve them."
-
-Then proceed with the normal workflow for that phase.
+After displaying the overview, say: "Starting **Phase 1** — Flag
+Definitions", then proceed with the normal workflow.
 
 ---
 
@@ -116,17 +89,6 @@ Test: `mcp__confidence__listClients`
 If not available, install it:
 ```
 claude mcp add confidence --transport http --url https://mcp.confidence.dev/mcp/flags
-```
-
-The user will be prompted to authenticate via OAuth in their browser.
-
-### Confidence Docs MCP (required for `plan code` only)
-
-Test: `mcp__confidence-docs__searchDocumentation`
-
-If not available, install it:
-```
-claude mcp add confidence-docs --transport http --url https://mcp.confidence.dev/mcp/docs
 ```
 
 The user will be prompted to authenticate via OAuth in their browser.
@@ -491,8 +453,8 @@ Example after Step 1 completes:
 
 ## Plan Files: Resume Check & Progressive Updates
 
-Both plan flags and plan code use a progressive plan file. Created at
-Step 1, updated after each step, so a closed session can resume.
+`plan flags` uses a progressive plan file. Created at Step 1, updated
+after each step, so a closed session can resume.
 
 ### Resume check (MUST do first)
 
@@ -500,7 +462,6 @@ Before starting any plan workflow, check for an existing in-progress
 plan:
 
 - `plan flags` → `.claude/plans/statsig-flag-migration-*.md`
-- `plan code`  → `.claude/plans/statsig-code-migration-*.md`
 
 If a plan file exists, read its `## Generation Status` section:
 
@@ -1499,30 +1460,6 @@ with:
    - Show summary: created vs skipped
 ```
 
-### For code plans
-
-**Each flag = one PR.** The code migration creates a separate pull
-request for each flag, keeping changes small and reviewable.
-
-```
-1. READ the plan file
-2. SDK SETUP (Section 1 of plan) — one-time, before any flag
-   - Show install command from plan
-   - ASK: "Install SDK now? [Yes / Skip / I already did]"
-   - Show wrapper file path + API surface from plan
-   - ASK: "Create the Confidence wrapper now? [Yes / Skip / I already did]"
-3. FOR EACH FLAG in the files list:
-   a. Create a branch: `migrate/<flag-key>-to-confidence`
-   b. Show flag name + all files using it
-   c. ASK: "Transform this flag's files? [Yes / Skip / Pause]"
-   d. If Yes → apply transform rules from plan to all files for this flag
-   e. Run lint + typecheck on changed files
-   f. Commit changes
-   g. Create PR titled: "feat: migrate <flag-key> from Statsig to Confidence"
-   h. CHECKPOINT: "PR created. [Continue to next flag / Pause]?"
-4. COMPLETION — show summary + list all PRs created
-```
-
 ### Flag Setup Sequence (MUST complete all steps before resolving)
 
 **Pick the backend from the flag's `Backend` field first.** The sequence
@@ -1654,340 +1591,15 @@ one — this verifies the waterfall order is preserved.
 
 ---
 
-## Plan Code: Steps
-
-The code phase has 5 steps: Step 1 detect language/framework, Step 2
-fetch the Confidence SDK guide (and signal any resolve-mode change),
-Step 3 scan the codebase for Statsig usage, Step 4 generate transform
-rules, Step 5 generate the plan.
-
-### Step 1: Detect language & framework
-
-```
-Grep: pattern="<Statsig import/symbol patterns from Step 3>"  → Find Statsig usage
-Glob: pattern="package.json" or "build.gradle" or "go.mod" or "requirements.txt" etc
-Read: dependency file  → Determine language/framework
-```
-
-### Step 2: Fetch SDK guide from `confidence-docs` MCP
-
-**Step 2a — pick the target resolve mode.** Confidence has FOUR modes,
-not a local/remote binary. Pick from the language/framework detected in
-Step 1, honoring the "prefer local resolve" policy (see "SDK
-Preference"):
-
-| Target mode | Confidence SDKs | How evaluation works | Network profile |
-|-------------|-----------------|----------------------|-----------------|
-| **In-process** (local resolve) | backend **Java, Go, JS/Node, Rust** | Periodically fetch the resolver **state** (full ruleset); evaluate locally via WASM | No per-eval network call; network only for state refresh |
-| **Cached client** | **Android, iOS, web/browser JS, React, React Native** | Backend resolves; device **prefetches and caches resolved VALUES**. Reads are local + offline. Context change triggers a refetch | Network on init / context change / refresh — NOT per read |
-| **Server-precomputed** | server-rendered React/Next.js (RSC) | Server resolves for a bound subject; client reads resolved values offline | Resolution on the server; client reads are offline |
-| **Remote** (per-call) | backend **Python, Ruby, .NET** | Each resolve is a service call to Confidence | One call per resolve (with default-value fallback on failure) |
-
-Routing:
-
-- Backend **and** language ∈ {Java, Go, JS/Node, Rust} → **in-process**.
-  Fetch the local-resolve guide (server-only):
-
-  ```
-  mcp__confidence-docs__getLocalResolveIntegrationGuide
-    sdk: "JAVA" | "GO" | "JS" | "RUST"
-  ```
-
-- Client app (mobile / browser / React Native) → **cached client**.
-  Backend **Python / Ruby / .NET** → **remote**. Either way fetch:
-
-  ```
-  mcp__confidence-docs__getCodeSnippetAndSdkIntegrationTips
-    sdk: "<detected>"
-  ```
-
-**CRITICAL:** Include the ACTUAL MCP response in the plan, not a
-reference to fetch it. Plans are self-sufficient.
-
-**Step 2b — signal any resolve-mode CHANGE.** Compare the source mode
-(defined in "Source resolve mode (Statsig)" below) to the target mode
-from 2a and, if it shifts, tell the user precisely what changes. Record
-the decision and any change notice in the plan's SDK Setup section and
-re-surface it at execute time. If unchanged, state that explicitly.
-
-### Source resolve mode (Statsig) — feeds the Step 2b signal
-
-Map the Statsig SDK in use to a source mode by surface:
-
-- **Statsig server SDK** (`statsig-node` v3+, Server Core
-  `@statsig/statsig-node-core`, `statsig` Python/Ruby, Java/Go/.NET) →
-  source mode = **in-process eval** (the SDK downloads the project config
-  and evaluates locally, no per-check network call).
-- **Statsig client SDK** (`@statsig/js-client`, `@statsig/react-bindings`,
-  Android/iOS) → **precomputed/cached values**: the server precomputes
-  per-user values that the client reads locally (with `updateUser`
-  triggering a refetch).
-- **Statsig on-device evaluation client SDK**
-  (`@statsig/js-on-device-eval-client`) → **on-device eval** (the client
-  downloads the ruleset and evaluates locally).
-
-Then the Step 2b transitions apply:
-
-- Statsig server → Confidence **in-process** (Java/Go/JS/Rust):
-  unchanged.
-- Statsig server → Confidence **remote** (Python/Ruby/.NET): ⚠️
-  in-process → remote — each resolve becomes a service call.
-- Statsig client (precomputed) → Confidence **cached client**: ✅ similar
-  model — backend resolves, client reads cached values offline; reads
-  stay local/fast.
-- Statsig on-device eval → Confidence **cached client**: ⚠️ on-device →
-  cached client. Reads stay local/offline, but evaluation moves to the
-  backend; the device caches resolved values instead of the ruleset (a
-  payload/security win — the full ruleset is no longer shipped to the
-  client).
-
-### Plan-file path
-
-`.claude/plans/statsig-code-migration-<date>.md`
-
-### Step 3: Scan codebase for Statsig usage
-
-```
-Grep: pattern="statsig|Statsig|StatsigClient|StatsigUser" → Find Statsig imports
-Grep: pattern="checkGate|check_gate" → boolean gate checks
-Grep: pattern="getConfig|get_config|getDynamicConfig|get_dynamic_config" → dynamic configs
-Grep: pattern="getExperiment|get_experiment" → experiments
-Grep: pattern="getLayer|get_layer" → layers
-Grep: pattern="useGateValue|useFeatureGate|useExperiment|useLayer|useDynamicConfig|useStatsigClient" → React hooks
-```
-
-**Scan case-insensitively.** Method names vary by language and SDK
-generation (legacy vs Server Core). Map whatever you find to an
-evaluation TYPE, not a fixed spelling:
-
-| Statsig call | What it returns | Confidence accessor (by value type) |
-|--------------|-----------------|-------------------------------------|
-| `checkGate(user, "g")` / `client.checkGate("g")` | boolean | `getBooleanValue("g.enabled", false, ctx)` |
-| `getConfig(user, "c").get("p", d)` | typed param | `get<Type>Value("c.p", d, ctx)` |
-| `getDynamicConfig(user, "c").get("p", d)` | typed param | `get<Type>Value("c.p", d, ctx)` |
-| `getExperiment(user, "e").get("p", d)` | typed param | `get<Type>Value("e.p", d, ctx)` |
-| `getLayer(user, "l").get("p", d)` | typed param | `get<Type>Value("<exp>.p", d, ctx)` — the layer param resolves through its backing experiment flag |
-| `.getValue()` / `.value` (whole config object) | object | `getObjectValue("c", {}, ctx)` |
-
-**Classify the SDK as client-side or server-side** — this decides the
-evaluation-context model in Step 4:
-
-| Statsig package | Side |
-|-----------------|------|
-| `@statsig/js-client`, `@statsig/react-bindings`, `@statsig/react-native-bindings`, Android/iOS client SDK | **client** |
-| `@statsig/js-on-device-eval-client` | **client (on-device eval)** |
-| `statsig-node`, `@statsig/statsig-node-core`, `statsig` (Python/Ruby), Java/Go/.NET server SDK | **server** |
-
-Group files by the **gate/config/experiment name** they reference (the
-string argument). For each evaluation site, record:
-- The Statsig name and TYPE (gate / config / experiment / layer)
-- **Client vs server side** (from the table above)
-- The value type (boolean for gates; inferred from the `.get(param, default)`
-  call or `default` literal for configs/experiments)
-- The `StatsigUser` argument (so the transform can map `userID`/`custom`
-  to `targetingKey` + attributes)
-- The `default` argument (carried over to the Confidence call)
-- The **Confidence resolve path** (`<flag-key>.<property>`) from the
-  Phase 1 plan's "Confidence resolve path" line. For gates the property
-  is `enabled`. If the item is NOT in the Phase 1 plan, flag it — the
-  code references a flag that was never migrated; do not invent a path.
-
-### Step 4: Generate transform rules
-
-**Two things are NOT 1:1 line replacements — get them right first:**
-
-1. **Name → resolve path.** Confidence flags are structs; every read
-   uses a dot-path `<flag-key>.<property>`. Use the resolve path from the
-   Phase 1 plan everywhere the bare Statsig name appeared. A
-   `getConfig("c").get("p")` becomes `getXValue("c.p", default)` — the
-   parameter folds INTO the path.
-2. **Evaluation-context model depends on client vs server:**
-   - **Server SDKs** pass the `StatsigUser` **per call** — fold
-     `user.userID` → `targetingKey` and `user.custom` / top-level fields
-     → attributes into the evaluation-context argument of each resolve.
-   - **Client SDKs** use **ambient** context — no per-call user argument.
-     Hoist `userID` + attributes ONCE into a
-     `setEvaluationContext`/`setEvaluationContextAndWait` call (at init or
-     where the user becomes known, replacing Statsig's
-     `updateUser` / init user), and the per-call site becomes a bare
-     `get<Type>Value(path, default)`.
-
-**StatsigUser → evaluation context.** Statsig's user object
-(`{ userID, email, country, appVersion, custom: {...}, customIDs: {...} }`)
-maps to a Confidence evaluation context: `userID` → `targetingKey`;
-top-level reserved fields and `custom` entries → attributes of the same
-name; `customIDs` → the corresponding entity fields. Statsig auto-derives
-country/browser/OS/version server-side — in Confidence you MUST pass
-these explicitly, so add them to the context where targeting needs them.
-
-**Server-target mapping (per-call context), JS/TS example:**
-
-| Statsig call | OpenFeature call |
-|--------------|------------------|
-| `statsig.checkGate(user, "g")` | `client.getBooleanValue("g.enabled", false, { targetingKey: user.userID, ...attrs })` |
-| `statsig.getConfig(user, "c").get("p", d)` | `client.get<Type>Value("c.p", d, { targetingKey: user.userID, ...attrs })` |
-| `statsig.getExperiment(user, "e").get("p", d)` | `client.get<Type>Value("e.p", d, { targetingKey: user.userID, ...attrs })` |
-
-The accessor name and signature are language-specific (use the Step 2
-SDK guide):
-- **Go**: PascalCase, context-LAST, `ctx` first:
-  `client.BooleanValue(ctx, "g.enabled", false, evalCtx)` where
-  `evalCtx := openfeature.NewEvaluationContext(user.UserID, attrsMap)`.
-- **Java**: build a `MutableContext(userID)` + `ctx.add(...)`:
-  `client.getBooleanValue("g.enabled", false, ctx)`.
-- **Python (REMOTE target)**: snake_case `get_<type>_value`, context
-  last: `client.get_boolean_value("g.enabled", False, EvaluationContext(targeting_key=user_id, attributes=attrs))`.
-  Use `api.set_provider(ConfidenceOpenFeatureProvider(Confidence(client_secret=...)))`
-  (NOT `set_provider_and_wait`) and delete Statsig's `initialize()` wait.
-
-**Client-target mapping (ambient context):** the per-call site drops its
-user argument; emit a one-time context setup instead.
-
-| Statsig call | Confidence client call | Plus, once |
-|--------------|------------------------|------------|
-| `client.checkGate("g")` | `getBooleanValue("g.enabled", false)` | `setEvaluationContext({ targetingKey: userID, ...attrs })` |
-| `client.getExperiment("e").get("p", d)` | `get<Type>Value("e.p", d)` | (same — set once) |
-
-**React mapping.** Statsig `@statsig/react-bindings` hooks map to
-Confidence's React provider + `useFlag`:
-
-| Statsig (React) | Confidence (React) |
-|-----------------|--------------------|
-| `<StatsigProvider sdkKey user>` | `<ConfidenceProvider>` with evaluation context `{ targetingKey: userID, ...attrs }` |
-| `useGateValue("g")` / `useFeatureGate("g").value` | `useFlag("g.enabled", false)` |
-| `useExperiment("e").get("p", d)` / `.value.p` | `useFlag("e.p", d)` |
-| `useLayer("l").get("p", d)` | `useFlag("<exp>.p", d)` |
-| `useStatsigClient().checkGate("g")` | `useFlag("g.enabled", false)` (or imperative client read) |
-
-**Remove Statsig readiness scaffolding.** Statsig examples gate the
-first check behind `await statsig.initialize(...)` /
-`await client.initializeAsync()` / `StatsigProvider`'s loading state.
-Confidence's `setProviderAndWait` / `setEvaluationContextAndWait` already
-block until flags are ready — delete the hand-rolled wait rather than
-porting it. Drop Statsig's `disableExposureLog` plumbing and manual
-exposure logging (`logEvent` for exposures) — Confidence logs exposure
-automatically.
-
-**Layers caveat.** A Statsig `getLayer("l").get("p", d)` reads a
-parameter that, in Statsig, is owned by whichever experiment is
-currently allocated in that layer. Confidence has no layer; resolve the
-param through the specific experiment flag the Phase 1 plan created for
-it. If a layer parameter is shared across multiple experiments, surface
-it for review rather than guessing which flag owns it.
-
-### Step 5: Generate plan
-
-Save the plan to `.claude/plans/statsig-code-migration-<date>.md` using
-the template below.
-
-**Two Confidence-wide truths every code transform must honor:**
-
-- **Flags are structs — read a property, not the bare name.** Always use
-  `<flag>.<property>` (gates → `.enabled`; configs/experiments →
-  `.<param>`).
-- **Client SDKs use ambient context; server SDKs pass it per call.**
-
-## Plan Code: Template
-
-```markdown
-# Statsig to Confidence Code Migration Plan
-
-**Created:** <date>
-**Scope:** Code transformation only
-**Language:** <detected>
-**Framework:** <detected>
-
----
-
-## Generation Status
-
-| Step | Status | Result |
-|------|--------|--------|
-| 1. Detect language | ○ not started | |
-| 2. Fetch SDK guide | ○ not started | |
-| 3. Scan codebase | ○ not started | |
-| 4. Transform rules | ○ not started | |
-| 5. Group by flag | ○ not started | |
-
-**Overall:** in progress
-
----
-
-## 1. SDK Setup
-
-### Resolve mode
-
-| | |
-|---|---|
-| **Source mode** | <in-process eval / precomputed-cached / on-device eval — per surface> |
-| **Target mode** | <in-process / cached client / server-precomputed / remote — from Step 2a> |
-| **Change** | <unchanged / ⚠️ in-process → remote / ⚠️ on-device → cached client / … — see notice> |
-
-<If changed: one-paragraph notice of what actually shifts. If unchanged: "Resolve mode is preserved.">
-
-### Install
-
-<install commands from MCP response>
-
-### API Reference (from MCP: confidence-docs)
-
-<code examples from MCP response>
-
-### Create Confidence Wrapper
-
-**File:** <appropriate path for detected framework>
-
-**Must match source API surface:**
-
-| Method | Signature |
-|--------|-----------|
-<detected from source SDK usage>
-
----
-
-## 2. Transform Rules
-
-### Source Files
-
-| Find | Replace |
-|------|---------|
-| <Statsig import> | <Confidence import> |
-| <Statsig usage> | <Confidence usage> |
-
-### Test Files
-
-| Find | Replace |
-|------|---------|
-| <Statsig mock> | <Confidence mock> |
-
----
-
-## 3. Files to Transform
-
-<list from codebase scan, grouped by gate/config/experiment name>
-
----
-
-## 4. Progress
-
-| # | Item | Status |
-|---|------|--------|
-| 0 | SDK Setup | :white_circle: |
-```
-
----
-
 ## Required Prerequisites
 
-This skill needs the Confidence-side MCPs listed in "Prerequisites:
-Confidence Side" above (`confidence` for `plan flags`/`execute`,
-`confidence-docs` for `plan code`), plus the Statsig Console API — no
-MCP, just `curl` with `STATSIG-API-KEY: $STATSIG_API_KEY` and
+This skill needs the Confidence MCP listed in "Prerequisites:
+Confidence Side" above, plus the Statsig Console API — no MCP, just
+`curl` with `STATSIG-API-KEY: $STATSIG_API_KEY` and
 `STATSIG-API-VERSION: 20240601`.
 
 | Source | What's used |
 |--------|-------------|
 | Confidence MCP | `listClients`, `createClient`, `getContextSchema`, `addContextField`, `createFlag`, `addFlagToClient`, `unarchiveFlag`, `addTargetingRule`, `resolveFlag` |
-| Confidence Docs MCP (`plan code`) | `getLocalResolveIntegrationGuide`, `getCodeSnippetAndSdkIntegrationTips`, `searchDocumentation`, `getFullSource` |
 | Confidence REST API (`CONFIDENCE_TOKEN`, OPTIONAL — full-fidelity Phase 1) | `POST /v1/segments` + `:allocate`, `POST /v1/materializedSegments` (+ load jobs), `POST /v1/flags/{flag}/rules` + `PATCH …?updateMask=enabled`; token via `POST https://iam.confidence.dev/v1/oauth/token` |
 | Statsig Console API (`STATSIG-API-KEY`) | `GET /console/v1/gates`, `GET /console/v1/gates/{id}`, `GET /console/v1/dynamic_configs[/{id}]`, `GET /console/v1/experiments[/{id}]`, `GET /console/v1/segments/{id}` |

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -131,6 +131,48 @@ claude mcp add confidence-docs --transport http --url https://mcp.confidence.dev
 
 The user will be prompted to authenticate via OAuth in their browser.
 
+### Confidence REST API token (OPTIONAL — for full-fidelity Phase 1)
+
+The MCP `createFlag`/`addTargetingRule` tools cover the common cases but
+**cannot** express a few Statsig constructs faithfully: partial
+experiment allocation, reusable/materialized segments, layer mutual
+exclusion, and holdouts (see "Two execution backends" below). To migrate
+those faithfully, the skill uses the Confidence **management REST API**
+(`https://flags.confidence.dev/v1`), which needs a short-lived access
+token obtained via the client-credentials flow.
+
+Only ask for this if the scan finds features that need it (the plan
+flags them). To set it up:
+
+1. In Confidence, go to **Admin > API Clients**, create a client, and
+   copy its **client ID** and **client secret**.
+2. Exchange them for an access token (valid ~1h):
+   ```bash
+   curl -sS -X POST "https://iam.confidence.dev/v1/oauth/token" \
+     -H "Content-Type: application/json" \
+     -d '{"grantType":"client_credentials","clientId":"<id>","clientSecret":"<secret>"}'
+   # → { "accessToken": "eyJ...", "expiresIn": "86400" }
+   ```
+3. Store the token for the session as `CONFIDENCE_TOKEN` and send it as
+   `Authorization: Bearer $CONFIDENCE_TOKEN`. Never write the token or
+   the client secret to the plan file (same secret-handling rule as the
+   Statsig key).
+
+## Two execution backends (MCP vs REST)
+
+Phase 1 has two ways to write to Confidence. Pick per flag based on what
+the flag needs — the plan records which backend each flag uses.
+
+| Backend | Use when | Auth | Limitations |
+|---------|----------|------|-------------|
+| **MCP** (default) | Gates, dynamic configs, and fully-allocated (`allocation` 100) experiments with inline targeting | OAuth (`mcp__confidence__*`) | No partial allocation, no reusable/materialized segments, no exclusivity, no holdbacks |
+| **REST** (full-fidelity) | Anything needing partial experiment `allocation`, reusable or `id_list` segments, layer mutual exclusion, or holdouts | Bearer token (above) | BigQuery required for materialized segments |
+
+The MCP backend is the tested default. Reach for REST only for the
+specific constructs listed; the operator/handling sections below point to
+the matching REST recipe ("Full-Fidelity Phase 1 via the Confidence REST
+API") wherever it applies.
+
 ## User-Facing Communication Rules
 
 **NEVER expose internal technical details to the user.** The user should
@@ -251,10 +293,13 @@ flags, but they map differently:
 | **Experiment** | A/B/n test with weighted groups | Struct flag; each `group` → a variant, split by `size` in `variantAllocations` (see allocation<100 note) |
 
 > **Layers.** A Statsig **layer** groups several experiments that share a
-> parameter namespace and an allocation budget. Confidence has no layer
-> primitive. Migrate each experiment in the layer as its own Confidence
-> flag and record the shared `layerID` in the plan as a note (mutual
-> exclusion between layer experiments is not reproduced — surface this).
+> parameter namespace and an allocation budget, making them mutually
+> exclusive. Migrate each experiment in the layer as its own Confidence
+> flag. The mutual exclusion maps to a Confidence **exclusivity group**
+> via segment coordination on the **REST** backend — see "Layer mutual
+> exclusion" under "Full-Fidelity Phase 1 via the Confidence REST API".
+> On the MCP backend, mutual exclusion can't be reproduced; record the
+> shared `layerID` as a note and surface the gap.
 
 ### The Feature Gate object (`ExternalGateDto`)
 
@@ -297,9 +342,9 @@ matched rule's `passPercentage` doesn't pass), the gate returns `false`.
   allocated users in this group), `parameterValues` (the value object for
   the group). Group sizes sum to 100 across the experiment.
 - `allocation` (0–100) — percent of eligible users entering the
-  experiment at all. There is no rollout knob in Confidence's
-  `addTargetingRule`, so `allocation` < 100 can't be encoded exactly —
-  see "Experiment `allocation` < 100 (limitation)".
+  experiment at all. The MCP `addTargetingRule` has no rollout knob, so
+  `allocation` < 100 needs the REST backend's segment `proportion` —
+  see "Experiment `allocation` < 100".
 - `controlGroupID` — which group is control (informational)
 - `targetingGateID` — restrict the experiment to users who pass this
   gate. Confidence has no cross-flag gate dependency — see "Blocked".
@@ -307,6 +352,11 @@ matched rule's `passPercentage` doesn't pass), the gate returns `false`.
   as gates). Combine with `allocation`.
 - `layerID` — if set, the experiment belongs to a layer (see Layers
   note above).
+- `holdoutIDs[]` — holdouts applied to this entity (also present on gates
+  and dynamic configs). Each holds a fixed random subset of users out of
+  the entity. Maps to a Confidence **holdback** — see "Holdouts (item 5)"
+  under "Full-Fidelity Phase 1 via the Confidence REST API". Record any
+  holdouts in the plan; they need a (mostly manual) surface step.
 
 **Pagination.** Statsig uses `page` (1-based) + `limit`. The list
 response wraps results under `data` with a `pagination` object:
@@ -522,9 +572,15 @@ Extract from each item:
 - For **experiments**: `groups[]` (`name`, `size`, `parameterValues`),
   `allocation`, `controlGroupID`, `targetingGateID`,
   `inlineTargetingRules[]`, `layerID`
+- `holdoutIDs[]` (gates/configs/experiments) → record each holdout; it
+  maps to a Confidence holdback (a surface step — see "Holdouts (item 5)")
 - Any `passes_segment` / `fails_segment` / `in_segment_list` /
   `not_in_segment_list` conditions → record the referenced segment id;
   fetch it in Step 1c
+- Whether the item needs the **REST backend** (partial `allocation`,
+  reusable/`id_list` segments, a `layerID`, or any `holdoutIDs`) — record
+  the backend on the flag's plan entry so `execute` knows which path to
+  take
 
 **Step 1c — fetch referenced segments (once per unique id).** While
 scanning conditions, collect every segment id referenced by a
@@ -847,21 +903,28 @@ non-entrants).
 
 ## Segments
 
-The Confidence MCP in this plugin does **not** expose a `createSegment`
-tool, so Statsig segments are **inlined** into each referencing flag's
-targeting rather than turned into reusable Confidence segments:
+Confidence **has** reusable segments, but the **MCP** backend in this
+plugin exposes no `createSegment` tool. So the handling depends on the
+backend:
 
-- **`rule_based` segment** (`passes_segment` / `fails_segment`): fetch
-  its definition, translate its `conditions[]` with the operator table,
-  and inline them into the flag's `criteria` + `expression`. For
-  `passes_segment` reference the segment's combined expression directly;
-  for `fails_segment` wrap it in `not`. If the same segment is referenced
-  by many flags, repeat the inlined criteria in each (de-dup is not
-  available without a segment primitive — note this in the plan).
-- **`id_list` segment** (`in_segment_list` / `not_in_segment_list`): if
-  the list is small (≤ ~50 ids), inline as a `setRule` on the entity
-  field (wrapped in `not` for the `not_in` case). If large, mark the
-  condition BLOCKED.
+- **REST backend (preferred for reuse):** create one Confidence segment
+  per Statsig segment and reference it from every flag that uses it — see
+  "Segments (items 2 & 3)" under "Full-Fidelity Phase 1 via the
+  Confidence REST API". This preserves reuse/de-duplication and supports
+  `id_list` segments via materialized segments (BigQuery).
+- **MCP backend (inline fallback):** with no `createSegment` tool,
+  **inline** the segment's conditions into each referencing flag:
+  - **`rule_based` segment** (`passes_segment` / `fails_segment`): fetch
+    its definition, translate its `conditions[]` with the operator table,
+    and inline into the flag's `criteria` + `expression`. For
+    `passes_segment` reference the segment's expression directly; for
+    `fails_segment` wrap it in `not`. Repeat the inlined criteria in each
+    referencing flag (no de-dup without a segment primitive — note in the
+    plan).
+  - **`id_list` segment** (`in_segment_list` / `not_in_segment_list`):
+    if small (≤ ~50 ids), inline as a `setRule` on the entity field
+    (wrapped in `not` for `not_in`). If large, use a REST materialized
+    segment, or mark the condition BLOCKED.
 
 ## Multivariant / Group Split Handling
 
@@ -897,22 +960,20 @@ waterfall. Fold the fail share into the same Confidence rule:
 set of targeting conditions, with the variant split defined inside that
 rule via `variantAllocations`.
 
-### Experiment `allocation` < 100 (limitation)
+### Experiment `allocation` < 100
 
-`variantAllocations` must sum to 100 and there is no rollout knob, so an
-experiment with `allocation` < 100 (only part of eligible users enter,
-the rest get the control/default) **cannot be encoded exactly** with
-integer group shares. Handle it one of two ways and record the choice in
-the plan:
+A fully-allocated experiment (`allocation` 100) is exact on the **MCP**
+backend — just use the group sizes as `variantAllocations`.
 
-- **Approximate** by scaling: each entering group gets
-  `round(size × allocation / 100)`, and the leftover (`100 − Σ`) goes to
-  the **control** variant (the not-entered users). Note that the split
-  is approximate and the control share is inflated by the non-entrants.
-- **Flag for review** if exact allocation fidelity matters.
-
-A fully-allocated experiment (`allocation` 100) is exact — just use the
-group sizes directly.
+For `allocation` < 100 (only part of eligible users enter, the rest get
+control), the MCP backend can't be exact (`variantAllocations` must sum
+to 100, no rollout knob). **Prefer the REST backend**, which represents
+it exactly via a segment `allocation.proportion` + group bucket ranges —
+see "Partial experiment allocation" under "Full-Fidelity Phase 1 via the
+Confidence REST API". If REST isn't available, fall back to the MCP
+approximation: each entering group gets `round(size × allocation / 100)`
+and the leftover (`100 − Σ`) goes to **control** — record that it's
+approximate in the plan.
 
 ## Operator Mapping (Statsig → Confidence)
 
@@ -948,8 +1009,8 @@ array.
 | `time` | `time` | timestamp |
 | `environment_tier` | — | Confidence scopes environments via clients, not targeting; record as a note, usually drop or map to a `tier` attribute |
 | `custom_field` (+ `field`) | `field` value | the custom attribute name |
-| `passes_segment` / `fails_segment` | — | inline the segment (see "Segments") |
-| `passes_gate` / `fails_gate` | — | **BLOCKED** (no cross-flag dependency) |
+| `passes_segment` / `fails_segment` | — | reusable segment (REST) or inline (MCP) — see "Segments" |
+| `passes_gate` / `fails_gate` | — | inline the referenced gate's conditions (or a shared segment); see "Blocked" |
 | `experiment_group` | — | **BLOCKED** (depends on experiment assignment) |
 | `javascript` | — | **BLOCKED** (arbitrary JS) |
 | `target_app` | — | record as a note; usually handled by client scoping |
@@ -986,8 +1047,8 @@ Statsig operators: `any`, `none`, `any_case_sensitive`,
 | `before` (time) | `rangeRule.endExclusive: { timestampValue }` |
 | `after` (time) | `rangeRule.startExclusive: { timestampValue }` |
 | `on` (time) | `eqRule.value.timestampValue` |
-| `in_segment_list` | small list → `setRule` on entity; large → BLOCKED |
-| `not_in_segment_list` | small list → `setRule` on entity wrapped in `not`; large → BLOCKED |
+| `in_segment_list` | small list → `setRule` on entity; large → REST materialized segment (BigQuery) |
+| `not_in_segment_list` | small list → `setRule` on entity wrapped in `not`; large → REST materialized segment, referenced under `not` |
 | `is null` | ruleless presence criterion under `not`: `{ "attribute": { "attributeName": "X" } }`, expression `not` wrapping `ref` |
 | `is not null` | ruleless presence criterion, expression `ref` |
 | `str_matches` (regex) | decompose like below; else BLOCKED |
@@ -1023,28 +1084,35 @@ the literal char). Anything else is BLOCKED.
 
 ### Blocked (manual review)
 
-Only these genuinely have no clean Confidence translation:
+These genuinely have no clean Confidence translation on **any** backend:
 
 - **`str_contains_any` / `str_contains_none`** — Confidence has no
   substring/contains rule. Reason: `Uses a 'contains' match on
-  '<attribute>'; Confidence has no substring rule.`
+  '<attribute>'; Confidence has no substring rule.` (Workaround: change
+  the context field to send a list of strings and use set matching.)
 - **Generic `str_matches` regex** — anything that fails the
   decomposition rule above (character classes, quantifiers, wildcard
   `.`, etc.). Reason: `Uses a regex on '<attribute>' that isn't a
   prefix/suffix/alternation; Confidence has no general regex rule.`
-- **`passes_gate` / `fails_gate`** — depends on another gate's
-  evaluation. Confidence has no cross-flag dependency. Reason: `Depends
-  on gate '<gate>'; Confidence has no flag-to-flag dependency. Inline
-  that gate's conditions or migrate manually.`
 - **`experiment_group`** — depends on another experiment's assignment.
   Reason: `Depends on experiment-group assignment; migrate manually.`
 - **`javascript`** — arbitrary JS expression. Reason: `Uses a custom
   JavaScript condition; no Confidence equivalent.`
-- **Large `id_list` segments** — can't inline thousands of ids. Reason:
-  `References an id_list segment too large to inline.`
 - **Unnormalizable version strings** — `v`-prefixed or build-metadata
   versions that can't be reduced to 2–4-segment form. Reason: `Version
   comparison on '<attribute>' uses a format Confidence can't parse.`
+
+These are **not** blocked outright — they downgrade gracefully:
+
+- **`passes_gate` / `fails_gate`** — Confidence has no flag-to-flag
+  dependency, but the referenced gate's conditions can be **inlined** (or
+  turned into a shared segment on the REST backend) and composed with
+  `and` / `not`. Only block if the referenced gate is itself
+  unmigratable. Note the inlining in the plan (it won't auto-update if
+  the source gate changes).
+- **Large `id_list` segments** — use a **REST materialized segment**
+  (BigQuery). Only block (`References an id_list segment too large to
+  inline`) if the REST backend / BigQuery isn't available.
 
 When a rule/condition is blocked, mark it in Section 4 (per the
 template). A flag is fully blocked only when *every* non-default rule is
@@ -1068,6 +1136,147 @@ there is no separate rollout field):
    omit it and rely on the catch-all
 4. Catch-all (default): no payload → `disabled` at 100%. Reproduces the
    gate's implicit `false`; MUST come last.
+
+---
+
+## Full-Fidelity Phase 1 via the Confidence REST API
+
+Use this path for the constructs the MCP can't express: partial
+experiment `allocation`, reusable / `id_list` segments, layer mutual
+exclusion, and holdouts. It needs the `CONFIDENCE_TOKEN` from
+"Prerequisites: Confidence Side". Base URL `https://flags.confidence.dev/v1`;
+every call sends `-H "Authorization: Bearer $CONFIDENCE_TOKEN"`.
+
+### The REST rule model (different from the MCP model)
+
+A REST flag rule does **not** carry an inline payload + `variantAllocations`.
+Instead it references a **segment** (which holds the targeting + the
+allocation proportion) and assigns variants by **bucket ranges**:
+
+```bash
+curl -sS -X POST "https://flags.confidence.dev/v1/flags/<flag>/rules" \
+  -H "Authorization: Bearer $CONFIDENCE_TOKEN" -H "Content-Type: application/json" \
+  -d '{
+  "segment": "segments/<segment-id>",
+  "assignmentSpec": {
+    "bucketCount": 100,
+    "assignments": [
+      { "variant": { "variant": "flags/<flag>/variants/control" }, "bucketRanges": [{"lower":0,"upper":34}] },
+      { "variant": { "variant": "flags/<flag>/variants/variant-a" }, "bucketRanges": [{"lower":34,"upper":67}] },
+      { "variant": { "variant": "flags/<flag>/variants/variant-b" }, "bucketRanges": [{"lower":67,"upper":100}] }
+    ]
+  },
+  "targetingKeySelector": "user_id"
+}'
+```
+
+Key facts:
+- **Targeting lives in the segment**, not the rule. The rule picks the
+  segment + the variant split (bucket ranges over `bucketCount`).
+- **Allocation/rollout = the segment's `allocation.proportion`** (0.0–1.0):
+  the fraction of the matched audience that is *in* the segment. Users
+  not in the segment fall through to the next rule.
+- Special assignments: `{"fallthrough":{}}` (matched → continue to next
+  rule) and `{"clientDefault":{}}` (serve the caller's default).
+- **Rules start disabled.** Enable each with
+  `PATCH /v1/flags/<flag>/rules/<ruleId>?updateMask=enabled` body
+  `{"enabled":true}`. Order via the `priority` field (lower = first).
+- Flags/variants still need to exist first — you can create them with the
+  MCP `createFlag` (recommended, since it also wires the client) or via
+  `POST /v1/flags`. Either way the REST rules then reference
+  `flags/<flag>/variants/<variant>`.
+
+### Segments (items 2 & 3 — reusable + id_list)
+
+Create once, allocate, reference from many flag rules:
+
+```bash
+# rule_based segment from a Statsig segment / inline audience
+curl -sS -X POST "https://flags.confidence.dev/v1/segments?segmentId=<id>" \
+  -H "Authorization: Bearer $CONFIDENCE_TOKEN" -H "Content-Type: application/json" \
+  -d '{ "displayName": "<name>",
+        "targeting": { "criteria": { ... }, "expression": { ... } },
+        "allocation": { "proportion": { "value": "1.0" } } }'
+# segments MUST be allocated before use in a rule:
+curl -sS -X POST "https://flags.confidence.dev/v1/segments/<id>:allocate" \
+  -H "Authorization: Bearer $CONFIDENCE_TOKEN"
+```
+
+- The `targeting` uses the **same** `criteria` + `expression` payload as
+  the MCP path (the Operator Mapping table is unchanged — only the
+  transport differs).
+- **De-duplicate:** a Statsig `rule_based` segment referenced by N flags
+  becomes ONE Confidence segment, referenced N times. Track the
+  `statsig-segment-id → segments/<id>` map in the plan.
+- **`id_list` segments → materialized segments** (BigQuery only): export
+  the id list to a BigQuery table, then
+  `POST /v1/materializedSegments?materializationId=<id>` and a load job
+  whose `sql` selects the unit-id column. If BigQuery isn't available and
+  the list is large, keep the condition BLOCKED.
+
+### Partial experiment allocation (item 1)
+
+An experiment with `allocation` < 100 maps exactly:
+
+1. Create a segment for the experiment's targeting
+   (`inlineTargetingRules`, or empty `targeting: {}` for "all"), with
+   `allocation.proportion = allocation / 100` (e.g. `"0.5"` for 50%).
+2. Allocate the segment.
+3. Add a flag rule referencing it whose `assignmentSpec` splits the
+   **groups** across the full `0–100` bucket range by `size`
+   (e.g. control `0–34`, variant-a `34–67`, variant-b `67–100`).
+4. Add a trailing catch-all rule (segment with `proportion 1.0`, or the
+   MCP catch-all) serving the **control** group's value — this catches
+   the `1 − proportion` of users who weren't allocated into the
+   experiment.
+
+This reproduces "50% enter, split 34/33/33, the rest get control"
+faithfully, which the MCP `variantAllocations` (sum-to-100, no rollout
+knob) cannot.
+
+### Layer mutual exclusion (item 4)
+
+Statsig **layers** make their experiments mutually exclusive. Map each
+layer to a Confidence **exclusivity group** via segment coordination:
+every experiment in layer `L` gets a segment whose `allocation` carries
+matching coordination tags:
+
+```json
+"allocation": { "proportion": { "value": "0.5" },
+                "exclusivityTags": ["<layer-id>"],
+                "exclusiveTo": ["<layer-id>"] }
+```
+
+Segments sharing an `exclusivityTags`/`exclusiveTo` group never overlap —
+no user lands in two of the layer's experiments. The sum of proportions
+across a coordination group must fit in 100% (allocation can fail
+otherwise — surface that to the user). Record the
+`layer-id → exclusivity tag` mapping in the plan.
+
+### Holdouts (item 5)
+
+Statsig **holdouts** (`holdoutIDs`) hold a fixed random subset of users
+out of a set of experiments. The Confidence analogue is a **holdback**,
+configured as a **surface setting** (Admin → Surfaces), not a flag-API
+object. So holdouts are migrated as a **manual surface step**, not an
+automated API call:
+
+- Record each distinct Statsig holdout in the plan with its size and the
+  experiments it covers.
+- During execute, instruct the user to create a matching holdback on the
+  relevant surface (proportion = the holdout's size) and attach it to the
+  migrated experiments.
+- Approximation without surfaces: model the held-out population as a
+  shared segment and **exclude** it (`not` the segment criterion) from
+  each covered experiment's targeting. Note this lacks the holdback's
+  cross-experiment reuse guarantees.
+
+### Verification
+
+REST-created flags resolve through the same client. Verify with the MCP
+`resolveFlag` (positive + negative + waterfall) exactly as the MCP path
+does — the resolve behavior is identical regardless of which backend
+wrote the rules.
 
 ---
 
@@ -1167,6 +1376,7 @@ by `execute` — no implicit defaults.
 
 **Statsig type:** <Feature Gate / Dynamic Config / Experiment>
 **Description:** <from Statsig if available, otherwise empty>
+**Backend:** <MCP (default) / REST — REST is required for partial allocation, reusable or id_list segments, layer exclusivity, or holdouts>
 **Confidence schema:** <e.g. `{ enabled: boolean }` for a gate; the value shape for a config/experiment>
 **Variants:** <variant list — e.g. "enabled, disabled" for a gate; group names for an experiment>
 **Confidence resolve path:** `<flag-key>.<property>` (Phase 2 reads this; `.enabled` for gates, `.<param>` per config/experiment parameter)
@@ -1176,8 +1386,10 @@ by `execute` — no implicit defaults.
   1. `<rule name>` — <plain-English condition>, pass <X>%, <variant split>
   2. ...
 **Default:** <gate: disabled (no-match catch-all); config: defaultValue → variant; experiment: control catch-all>
-**Rollout/split:** <how passPercentage / group size / allocation are encoded in variantAllocations — note any allocation<100 approximation>
-**Segments inlined:** <none, or list of segment ids whose conditions were inlined>
+**Rollout/split:** <how passPercentage / group size / allocation are encoded — variantAllocations (MCP) or segment proportion + bucketRanges (REST)>
+**Segments:** <none, or list of Confidence segments created (REST) / inlined (MCP) with the statsig-segment-id → segments/<id> mapping>
+**Layer / exclusivity:** <none, or layerID → exclusivity tag (REST)>
+**Holdouts:** <none, or holdout ids → holdback surface step>
 **Null rules emitted:** <none, or "is null on '<attr>' → ruleless presence criterion under `not`; may render empty in the segment editor">
 **Confidence rules:** one targeting rule per Statsig rule, in the same order, plus a final catch-all rule for the default
 **Action:** [ ] Migrate  [ ] Skip
@@ -1188,8 +1400,8 @@ with:
 **Status:** BLOCKED — <one-line reason from the BLOCKED rules above>
 **Action:** [ ] Skip (no migrate option available until the block is resolved)
 
-**MCP Commands:**
-<createFlag, addFlagToClient, addTargetingRule (ONE per Statsig rule, in order, with variant assignments and their split) THEN a final catch-all addTargetingRule (no payload, 100% → default variant), resolveFlag with full parameters — positive AND negative case (negative must land on the catch-all and return the default variant)>
+**Commands:**
+<For MCP backend: createFlag, addFlagToClient, addTargetingRule (ONE per Statsig rule, in order) THEN a final catch-all addTargetingRule (no payload, 100% → default variant). For REST backend: createFlag (MCP, to wire the client), then per segment a POST /v1/segments + :allocate, then POST /v1/flags/<flag>/rules (segment + assignmentSpec) + PATCH enabled=true, in order. Finish with resolveFlag (MCP) — positive AND negative case (negative must land on the catch-all and return the default variant)>
 
 ---
 
@@ -1254,8 +1466,13 @@ request for each flag, keeping changes small and reviewable.
 
 ### Flag Setup Sequence (MUST complete all steps before resolving)
 
-Each flag MUST go through these steps in order. Do NOT call
-`resolveFlag` until ALL prior steps succeed.
+**Pick the backend from the flag's `Backend` field first.** The sequence
+below is the **MCP** path (the default). For a flag marked `Backend: REST`,
+use the **REST sequence** instead (next subsection), then verify with the
+same `resolveFlag` step 4. Either way, do NOT call `resolveFlag` until all
+prior steps succeed.
+
+#### MCP sequence
 
 ```
 STEP 1: createFlag
@@ -1296,6 +1513,34 @@ STEP 4: resolveFlag (verification)
     negative resolve tests pass.
 ```
 
+#### REST sequence (Backend: REST)
+
+For flags needing partial allocation, reusable/`id_list` segments, layer
+exclusivity, or holdouts. Requires `CONFIDENCE_TOKEN` (confirm it's set;
+if not, prompt the user — see prerequisites). Follow the recipes in
+"Full-Fidelity Phase 1 via the Confidence REST API".
+
+```
+STEP 1: createFlag + client  (MCP createFlag — also wires the client and variants)
+STEP 2: For each segment this flag needs (in the plan's Segments list):
+  → POST /v1/segments?segmentId=<id>  (targeting + allocation.proportion
+    + exclusivityTags/exclusiveTo for layered experiments)
+  → POST /v1/segments/<id>:allocate   (MUST allocate before use)
+  → For id_list: POST /v1/materializedSegments + a load job instead
+  → Reuse already-created segments (check the plan's segment map) — do
+    not recreate
+STEP 3: For each Statsig rule, in order:
+  → POST /v1/flags/<flag>/rules  (segment + assignmentSpec bucketRanges
+    + targetingKeySelector)
+  → PATCH /v1/flags/<flag>/rules/<ruleId>?updateMask=enabled  {enabled:true}
+  → Set priority so order matches the Statsig waterfall (lower = first)
+  → Add the trailing catch-all rule LAST (default variant)
+STEP 4: Holdouts (if any): instruct the user to create the matching
+  holdback on the relevant surface and attach it (manual surface step).
+STEP 5: resolveFlag (verification) — identical to the MCP sequence's
+  STEP 4 (positive + negative + waterfall).
+```
+
 ### Rules
 
 - **NEVER auto-continue** — always wait for user at each checkpoint
@@ -1306,11 +1551,12 @@ STEP 4: resolveFlag (verification)
 
 ## Execute: Statsig-Specific Notes
 
-**Inline segments first.** For any flag whose rules reference a
-`rule_based` segment, the inlined criteria are already part of that
-flag's targeting payload in the plan (this plugin's Confidence MCP has no
-`createSegment` tool). No separate segment-creation step is needed —
-just apply the flag's payload as written.
+**Segments first.** REST-backend flags: create + allocate every segment
+the flag references **before** adding its rules (rules reference segments
+by name), reusing any already-created segment per the plan's segment map.
+MCP-backend flags: the `rule_based` segment conditions are already inlined
+into the flag's payload in the plan, so no separate step is needed — apply
+the payload as written.
 
 **Disabled-in-Statsig handling.** If an item's `isEnabled` is false,
 surface that during execute:
@@ -1680,4 +1926,5 @@ MCP, just `curl` with `STATSIG-API-KEY: $STATSIG_API_KEY` and
 |--------|-------------|
 | Confidence MCP | `listClients`, `createClient`, `getContextSchema`, `addContextField`, `createFlag`, `addFlagToClient`, `unarchiveFlag`, `addTargetingRule`, `resolveFlag` |
 | Confidence Docs MCP (`plan code`) | `getLocalResolveIntegrationGuide`, `getCodeSnippetAndSdkIntegrationTips`, `searchDocumentation`, `getFullSource` |
+| Confidence REST API (`CONFIDENCE_TOKEN`, OPTIONAL — full-fidelity Phase 1) | `POST /v1/segments` + `:allocate`, `POST /v1/materializedSegments` (+ load jobs), `POST /v1/flags/{flag}/rules` + `PATCH …?updateMask=enabled`; token via `POST https://iam.confidence.dev/v1/oauth/token` |
 | Statsig Console API (`STATSIG-API-KEY`) | `GET /console/v1/gates`, `GET /console/v1/gates/{id}`, `GET /console/v1/dynamic_configs[/{id}]`, `GET /console/v1/experiments[/{id}]`, `GET /console/v1/segments/{id}` |

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -1,0 +1,1642 @@
+---
+description: Migrate feature flags from Statsig to Confidence SDK. Use when the user says /migrate-statsig, asks to migrate Statsig gates/configs/experiments, or transform SDK code to Confidence.
+---
+
+# Statsig to Confidence Migration
+
+REST-driven, self-sufficient migration from Statsig to Confidence. This
+skill is fully self-contained: it defines both the Statsig-specific
+migration logic AND all the Confidence-side conventions it relies on
+(payload formats, naming rules, the flag setup sequence, the execute
+flow, etc.).
+
+## SDK Preference
+
+**ALWAYS prefer OpenFeature with local resolve.**
+
+| Priority | Approach | When to use |
+|----------|----------|-------------|
+| 1st | Local resolve | Default for all new integrations |
+| 2nd | Remote resolve | Only if local resolve not supported for platform |
+| Avoid | Direct SDK | Being phased out |
+
+## Plan Philosophy
+
+**Plans must be self-sufficient and agent-agnostic.**
+
+| Principle | Meaning |
+|-----------|---------|
+| **Source-boxed** | Every external data fetch uses one explicit channel (the Statsig Console API with curl, the Confidence MCP) — no ad-hoc browsing |
+| **Self-sufficient** | Plan contains ALL information needed — no "query the source for X" at execute time |
+| **Agent-agnostic** | Any agent with the prerequisites can execute the plan without prior context |
+| **Language-agnostic** | Detect framework, fetch SDK guide from `confidence-docs` MCP dynamically |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/migrate-statsig plan flags` | Phase 1: plan flag definitions migration |
+| `/migrate-statsig plan code` | Phase 2: plan code transformation |
+| `/migrate-statsig execute <plan-file>` | Execute a plan interactively |
+
+---
+
+## Migration Overview (MUST display at start of `plan flags` or `plan code`)
+
+**Every time** the user runs `plan flags` or `plan code`, display this
+overview FIRST — before doing any work.
+
+```
+═══════════════════════════════════════════════════════════════
+  Statsig → Confidence Migration
+═══════════════════════════════════════════════════════════════
+
+  The migration happens in two phases: flags first, then code.
+
+  ┌─────────────────────────────────────────────────────────┐
+  │  PHASE 1 — Flag Definitions                            │
+  │                                                        │
+  │  Move all gates, dynamic configs, and experiments from │
+  │  Statsig to Confidence with their rules, rollout       │
+  │  percentages, return values, and variant splits.       │
+  │                                                        │
+  │  Steps:                                                │
+  │    1. Scan Statsig (gates, configs, experiments)       │
+  │    2. Choose a Confidence client (your app)            │
+  │    3. Map the unit ID (idType) to an entity field      │
+  │    4. Generate migration plan with targeting rules     │
+  │    5. Execute: create each flag in Confidence          │
+  │                                                        │
+  │  Result: All flags live in Confidence, ready to resolve│
+  ├─────────────────────────────────────────────────────────┤
+  │  PHASE 2 — Code Transformation                         │
+  │                                                        │
+  │  Once flags exist in Confidence, migrate the code that │
+  │  evaluates them. Each flag = one PR.                   │
+  │                                                        │
+  │  Steps:                                                │
+  │    1. Detect language & framework                      │
+  │    2. Fetch Confidence SDK guide                       │
+  │    3. Scan codebase for Statsig usage                  │
+  │    4. Generate transform rules (Statsig → Confidence)  │
+  │    5. Generate plan grouped by flag                    │
+  │    6. Execute: transform code flag by flag, one PR each│
+  │                                                        │
+  │  Result: Code uses Confidence SDK, Statsig removed     │
+  └─────────────────────────────────────────────────────────┘
+
+  Why flags first?
+  Flags must exist in Confidence before code can resolve them.
+
+  Why one PR per flag?
+  Keeps changes small, reviewable, and independently shippable.
+  If one flag's migration has issues, it doesn't block the others.
+
+═══════════════════════════════════════════════════════════════
+```
+
+After displaying the overview, indicate which phase the user is about
+to enter:
+
+- For `plan flags`: "Starting **Phase 1** — Flag Definitions"
+- For `plan code`: "Starting **Phase 2** — Code Transformation.
+  Make sure Phase 1 (flag definitions) is complete first — the flags
+  need to exist in Confidence before the code can resolve them."
+
+Then proceed with the normal workflow for that phase.
+
+---
+
+## Prerequisites: Confidence Side
+
+### Confidence MCP
+
+Test: `mcp__confidence__listClients`
+
+If not available, install it:
+```
+claude mcp add confidence --transport http --url https://mcp.confidence.dev/mcp/flags
+```
+
+The user will be prompted to authenticate via OAuth in their browser.
+
+### Confidence Docs MCP (required for `plan code` only)
+
+Test: `mcp__confidence-docs__searchDocumentation`
+
+If not available, install it:
+```
+claude mcp add confidence-docs --transport http --url https://mcp.confidence.dev/mcp/docs
+```
+
+The user will be prompted to authenticate via OAuth in their browser.
+
+## User-Facing Communication Rules
+
+**NEVER expose internal technical details to the user.** The user should
+see human-readable descriptions of what's happening, not internal
+implementation details like targeting payload formats, rule types, or
+operator names.
+
+- Do NOT say "creating plan based on eqRule / rangeRule / setRule" etc.
+- Do NOT show raw targeting payloads or JSON structures in conversation
+- Do NOT echo any user-provided secret (API keys, tokens) back into the
+  conversation or write them to the plan file — store them only as
+  environment variables for the session
+- DO say things like: "Creating flag with rule: plan equals 'pro' AND country is US or UK"
+- DO describe rules in plain English: "app version is at least 1.2.0", "country is US or CA"
+- The plan FILE may contain MCP command payloads (for machine execution),
+  but conversation output must be human-friendly
+
+## Prerequisites: Statsig Side
+
+Statsig does not currently publish a Claude MCP server, so the migration
+talks to Statsig's **Console API** directly using `curl` from the Bash
+tool.
+
+### Required
+
+1. A **Statsig Console API key** (NOT a server/client SDK key). Created
+   in the Statsig console under **Project Settings > API Keys**
+   (`console.statsig.com/api_keys`). The key needs read access to gates,
+   dynamic configs, and experiments. Console API keys start with
+   `console-`.
+2. The Console API base URL is `https://statsigapi.net`. This is the
+   same for all projects (Statsig is multi-tenant; the key scopes you to
+   a project).
+
+**Authentication headers:**
+- `STATSIG-API-KEY: <console-api-key>`
+- `STATSIG-API-VERSION: 20240601` (the only published version; optional
+  today, required in future — always send it)
+
+### ASK the user (only if not already provided)
+
+> To read your Statsig gates, configs, and experiments, I need a Statsig
+> **Console API key** (Project Settings > API Keys in the Statsig
+> console — make sure it has read access). It starts with `console-`.
+>
+> Please paste it here, or set it in your shell as `STATSIG_API_KEY`
+> before continuing.
+
+### Storing the key
+
+Once provided, store the key for the session in the environment variable
+`STATSIG_API_KEY` (export it in the Bash session the agent uses) and
+reference it via `$STATSIG_API_KEY` in every `curl` call — never
+hardcode the key into the plan file, the conversation output, or any
+committed file. If the user pastes a key inline, scrub it from the plan
+file and only keep a placeholder like `<your-statsig-console-api-key>`.
+(See also the "never echo secrets" rule in the User-Facing Communication
+Rules above.)
+
+### Smoke test before scanning
+
+```bash
+curl -sS -H "STATSIG-API-KEY: $STATSIG_API_KEY" \
+  -H "STATSIG-API-VERSION: 20240601" \
+  "https://statsigapi.net/console/v1/gates?limit=1&page=1" \
+  | head -c 200
+```
+
+If this returns a `401`/`403` or an HTML error page, stop and surface
+the error to the user — do not start scanning.
+
+### Local testing (no Statsig account needed)
+
+For development and CI smoke tests, this skill ships with a fake Statsig
+Console API server under `skills/migrate-statsig/test-fixtures/`. It
+implements the read endpoints with curated fixtures that exercise every
+operator-mapping branch. See that directory's `README.md` for usage —
+short version is `python3 server.py`, then point this skill at
+`http://127.0.0.1:4000` when prompted for the base URL.
+
+---
+
+## Statsig Console API Reference
+
+The migration uses these endpoints. All require both
+`-H "STATSIG-API-KEY: $STATSIG_API_KEY"` and
+`-H "STATSIG-API-VERSION: 20240601"`. Base URL is
+`https://statsigapi.net`.
+
+> **Source of truth.** Field names and shapes here are taken directly
+> from Statsig's published OpenAPI 3.0 spec at
+> <https://api.statsig.com/openapi/20240601.json> (public, no auth).
+> Refer back to it if you encounter a field that isn't documented below.
+
+| Purpose | Endpoint |
+|---------|----------|
+| List feature gates | `GET /console/v1/gates?limit=<n>&page=<n>` |
+| Get one gate (full definition: rules, conditions) | `GET /console/v1/gates/{id}` |
+| List dynamic configs | `GET /console/v1/dynamic_configs?limit=<n>&page=<n>` |
+| Get one dynamic config (rules, return values, default value) | `GET /console/v1/dynamic_configs/{id}` |
+| List experiments | `GET /console/v1/experiments?limit=<n>&page=<n>` |
+| Get one experiment (groups, allocation, targeting) | `GET /console/v1/experiments/{id}` |
+| Get one segment (rule_based: conditions) | `GET /console/v1/segments/{id}` |
+
+**Convention.** Field names are `camelCase`. IDs are strings (e.g.
+`a_gate`). Condition `targetValue` is sometimes a scalar and sometimes an
+array — normalize to an array when translating.
+
+### Statsig's three configurable types
+
+Statsig has three distinct entity types. All three become Confidence
+flags, but they map differently:
+
+| Statsig type | What it is | Confidence flag shape |
+|--------------|-----------|----------------------|
+| **Feature Gate** | Boolean on/off with a rule waterfall | Boolean flag (`{ enabled }`); each rule → one targeting rule |
+| **Dynamic Config** | Returns a JSON value object; rules pick which value | Struct flag; each rule's `returnValue` → a variant; `defaultValue` → catch-all |
+| **Experiment** | A/B/n test with weighted groups | Struct flag; each `group` → a variant, split by `size`; `allocation` → rolloutPercentage |
+
+> **Layers.** A Statsig **layer** groups several experiments that share a
+> parameter namespace and an allocation budget. Confidence has no layer
+> primitive. Migrate each experiment in the layer as its own Confidence
+> flag and record the shared `layerID` in the plan as a note (mutual
+> exclusion between layer experiments is not reproduced — surface this).
+
+### The Feature Gate object (`ExternalGateDto`)
+
+- `id` (string used in code as the gate name), `name`, `description`
+- `idType` — the **unit ID** the gate randomizes on (`userID`,
+  `stableID`, or a custom ID name). Maps to the Confidence entity / the
+  rule's `targetingKey`.
+- `isEnabled` (boolean) — when `false`, the gate is OFF; migrate it but
+  keep rules at 0% so it stays off.
+- `status` — `In Progress` / `Launched` / `Disabled` / `Archived`
+- `rules[]` — **ordered waterfall (top wins)**. Each rule has:
+  - `name`
+  - `passPercentage` (0–100) — of the users matching this rule's
+    conditions, what percent PASS (return `true`). The rest FAIL
+    (return `false`).
+  - `conditions[]` — ANDed within a rule (each `{ type, operator,
+    targetValue, field, customID }`)
+  - `environments[]` — environments the rule is enabled for (or null =
+    all)
+
+A gate has **no explicit default value**: if no rule matches (or a
+matched rule's `passPercentage` doesn't pass), the gate returns `false`.
+
+### The Dynamic Config object (`DynamicConfigDto`)
+
+- `id`, `name`, `description`, `idType`, `isEnabled`
+- `defaultValue` — the value returned when **no rule matches** (a real
+  server-side default; map it to the catch-all rule's variant)
+- `rules[]` — ordered waterfall. Each rule has `name`, `passPercentage`,
+  `conditions[]`, and a `returnValue` (the value object served to users
+  who match and pass).
+- `schema` — optional value schema
+
+### The Experiment object (`ExternalExperimentDto`)
+
+- `id`, `name`, `description`, `idType`
+- `status` — `active` / `setup` / `decision_made` / `abandoned` /
+  `archived` / `experiment_stopped` / `assignment_stopped`
+- `groups[]` — the variants. Each: `name`, `size` (0–100, the percent of
+  allocated users in this group), `parameterValues` (the value object for
+  the group). Group sizes sum to 100 across the experiment.
+- `allocation` (0–100) — percent of eligible users entering the
+  experiment at all. Maps to the rule's `rolloutPercentage`.
+- `controlGroupID` — which group is control (informational)
+- `targetingGateID` — restrict the experiment to users who pass this
+  gate. Confidence has no cross-flag gate dependency — see "Blocked".
+- `inlineTargetingRules[]` — inline targeting (same rule/condition shape
+  as gates). Combine with `allocation`.
+- `layerID` — if set, the experiment belongs to a layer (see Layers
+  note above).
+
+**Pagination.** Statsig uses `page` (1-based) + `limit`. The list
+response wraps results under `data` with a `pagination` object:
+
+```
+page = 1
+LOOP:
+  resp = GET /console/v1/gates?limit=50&page=<page>
+  process resp.data
+  if resp.pagination.nextPage is null OR resp.data is empty → STOP
+  page += 1 → continue LOOP
+```
+
+Repeat the loop for `gates`, `dynamic_configs`, AND `experiments`.
+
+---
+
+## Step Trackers
+
+### Status markers
+
+- `○ pending` — not started yet
+- `◉ in progress` — currently running
+- `⏸ awaiting user` — blocked on user input (e.g. picking a client or entity)
+- `✓ done` — completed (add brief user-facing result)
+- `⊘ skipped` — skipped by user
+
+Use `⏸ awaiting user` whenever the workflow has asked a question and is
+waiting for an explicit reply. This makes "I'm blocked on you" visible
+to both agent and user, and prevents drifting into auto-progression
+while a question is open.
+
+**Never expose internal/technical details in the tracker.** No
+pagination info, no API page counts, no internal field names. Show only
+what matters to the user. **Update and re-display the tracker** at the
+start and after each step completes.
+
+### Execute progress bar
+
+The execute step tracker includes a progress bar. Use `█` for completed
+and `░` for remaining, 20 characters wide.
+
+```
+  Progress: [██████░░░░░░░░░░░░░░] 5/15 (1 skipped)
+  Current:  pricing-experiment
+```
+
+After each flag completes, show one of:
+
+```
+  ✓ flag-key — MATCH (variant-name)
+  ⊘ flag-key — skipped
+```
+
+### Final summary (Execute)
+
+At the end of execution, show a complete summary:
+
+```
+───── Migration Complete ──────────────────────────────────
+  Progress: [████████████████████] 15/15 done
+  Migrated: 14  |  Skipped: 1  |  Failed: 0
+
+  ✓ flag-key-1                100%   user_id
+  ✓ flag-key-2                50/50  user_id
+  ⊘ flag-key-3                —      skipped
+  ...
+────────────────────────────────────────────────────────────
+```
+
+### Plan Flags step tracker
+
+```
+───── Plan Flags ──────────────────────────────────────────
+  [1] Scan Statsig     ○ pending
+  [2] Choose client    ○ pending
+  [3] Map unit ID      ○ pending
+  [4] Generate plan    ○ pending
+────────────────────────────────────────────────────────────
+```
+
+Example after Step 1 completes:
+```
+───── Plan Flags ──────────────────────────────────────────
+  [1] Scan Statsig     ✓ 8 gates, 3 configs, 4 experiments
+  [2] Choose client    ◉ in progress
+  [3] Map unit ID      ○ pending
+  [4] Generate plan    ○ pending
+────────────────────────────────────────────────────────────
+```
+
+### Execute step tracker
+
+```
+───── Execute Migration ───────────────────────────────────
+  Client: test  |  Unit: user_id  |  Flags: 15
+  Progress: [░░░░░░░░░░░░░░░░░░░░] 0/15
+────────────────────────────────────────────────────────────
+```
+
+---
+
+## Confidence Naming Rules
+
+- **Flag names:** lowercase letters, digits, and hyphens only (`[a-z0-9-]`).
+  Statsig gate/config/experiment IDs often use `snake_case`
+  (`new_checkout_flow`); normalize to hyphens (`new-checkout-flow`) and
+  record the mapping in the plan so the code phase can find the right
+  replacement.
+- **Entity references:** Confidence entity names do NOT support underscores.
+  The entity reference (e.g. `entities/company`) is separate from the context
+  field name (e.g. `company_id`). When creating entity fields with
+  `addContextField`, always provide an explicit `entityReference` with a
+  clean name (no underscores). If omitted, the tool auto-generates one from
+  the field name which will fail.
+
+  | Field name | Entity reference | Works? |
+  |------------|-----------------|--------|
+  | `user_id` | `entities/user` | Yes |
+  | `company_id` | `entities/company` | Yes |
+  | `visitor_id` | `entities/visitor` | Yes |
+  | `company_id` | *(omitted — auto: `entities/company_id`)* | **No** |
+
+## Plan Files: Resume Check & Progressive Updates
+
+Both plan flags and plan code use a progressive plan file. Created at
+Step 1, updated after each step, so a closed session can resume.
+
+### Resume check (MUST do first)
+
+Before starting any plan workflow, check for an existing in-progress
+plan:
+
+- `plan flags` → `.claude/plans/statsig-flag-migration-*.md`
+- `plan code`  → `.claude/plans/statsig-code-migration-*.md`
+
+If a plan file exists, read its `## Generation Status` section:
+
+- If status is `complete` → tell user a plan already exists, ask if
+  they want to start fresh or use the existing one
+- If status is NOT `complete` → **resume from the last incomplete step**.
+  Tell the user: "Found an in-progress plan. Resuming from step <N>."
+- If no plan file exists → start fresh
+
+### Generation Status table
+
+Every plan file MUST include a `## Generation Status` section at the
+top that tracks which steps are done. Status values: `✓ complete`,
+`◉ in progress`, `○ not started`. **After each step completes**, update
+the status table AND write that step's data to the plan file. Do NOT
+wait until the end to write.
+
+## Plan Flag: Steps
+
+The migration follows a 4-step plan flow: Step 1 scan Statsig, Step 2
+choose a Confidence client, Step 3 map the unit ID, Step 4 generate the
+MCP commands.
+
+### Plan-file path
+
+`.claude/plans/statsig-flag-migration-<date>.md`
+
+### Step 1: Scan Statsig
+
+**Step 1a — list all gates, configs, and experiments. CRITICAL:
+paginate until exhausted, for ALL THREE types.**
+
+```
+for type in [gates, dynamic_configs, experiments]:
+  page = 1
+  LOOP:
+    resp = curl GET /console/v1/<type>?limit=50&page=<page>
+    process resp.data
+    if resp.pagination.nextPage is null OR resp.data empty → STOP
+    page += 1 → continue LOOP
+```
+
+```bash
+curl -sS -H "STATSIG-API-KEY: $STATSIG_API_KEY" \
+  -H "STATSIG-API-VERSION: 20240601" \
+  "https://statsigapi.net/console/v1/gates?limit=50&page=1"
+```
+
+Ask once up-front: "Include archived gates/configs/experiments too?
+Default: no". Skip items whose `status` is `Archived` / `archived` unless
+the user opts in.
+
+**Step 1b — fetch each item's full definition (in batches of 5).** The
+list endpoints already return rules for gates/configs, but fetch the
+single-item endpoint to be sure you have the complete `rules[]` /
+`groups[]` / `defaultValue`:
+
+```bash
+curl -sS -H "STATSIG-API-KEY: $STATSIG_API_KEY" \
+  -H "STATSIG-API-VERSION: 20240601" \
+  "https://statsigapi.net/console/v1/gates/<id>"
+```
+
+**After each batch of 5**, write the data to the plan file — append the
+sections to Section 4. This way if the session closes mid-scan, the
+items fetched so far are saved.
+
+Extract from each item:
+
+- `id`, `name`, `description`
+- **Type** (gate / dynamic config / experiment) — determines the
+  Confidence flag shape (see "Statsig's three configurable types")
+- `idType` — the unit ID (becomes the Confidence entity in Step 3)
+- `isEnabled` — disabled items still migrate, but with rollout 0% so
+  they don't activate accidentally; surface this clearly in the plan
+- For **gates / dynamic configs**: the ordered `rules[]`. For each rule:
+  `passPercentage`, `conditions[]`, and (configs only) `returnValue`
+- For **experiments**: `groups[]` (`name`, `size`, `parameterValues`),
+  `allocation`, `controlGroupID`, `targetingGateID`,
+  `inlineTargetingRules[]`, `layerID`
+- Any `passes_segment` / `fails_segment` / `in_segment_list` /
+  `not_in_segment_list` conditions → record the referenced segment id;
+  fetch it in Step 1c
+
+**Step 1c — fetch referenced segments (once per unique id).** While
+scanning conditions, collect every segment id referenced by a
+`passes_segment` / `fails_segment` condition. For each unique id:
+
+```bash
+curl -sS -H "STATSIG-API-KEY: $STATSIG_API_KEY" \
+  -H "STATSIG-API-VERSION: 20240601" \
+  "https://statsigapi.net/console/v1/segments/<id>"
+```
+
+- A **`rule_based`** segment has `rules[]` / `conditions[]` with the same
+  shape as gates. Translate those conditions with the operator table and
+  **inline** them into each referencing flag's targeting (the Confidence
+  MCP in this plugin has no `createSegment` tool — see "Segments").
+- An **`id_list`** / `user_store_id_list` segment is a literal list of
+  unit IDs. If small (≤ ~50), inline as a `setRule` on the entity field.
+  If large, mark the referencing condition BLOCKED (see "Blocked").
+
+**Unit ID.** Statsig randomizes on the entity named by `idType`
+(`userID`, `stableID`, or a custom ID). Record each item's `idType`; the
+user maps it to a Confidence entity field in Step 3. If different items
+use different `idType`s, the plan carries the per-item unit and Step 3
+maps each distinct one.
+
+**After scan completes:** Update Generation Status step 1 to `✓ complete`.
+
+### Step 2: Select Confidence client
+
+```
+mcp__confidence__listClients
+```
+
+**EDUCATE then ASK the user:**
+
+> **What is a client?**
+> A client represents the application that resolves flags — your website,
+> backend service, or mobile app. Each client has its own secret for
+> authentication and can be scoped to environments (dev, staging, prod).
+> Flags are associated with one or more clients, so Confidence knows which
+> application should receive which flags.
+>
+> Think of it like: "Where will these flags be evaluated?"
+>
+> Your existing clients:
+> 1. <client-1>
+> 2. <client-2>
+> ...
+> N. Create a new client
+>
+> Which client should I use as the default for all flags?
+> You can always rearrange them later in the Confidence UI.
+
+**Wait for an explicit pick.** Set the step to `⏸ awaiting user` and
+stop. A re-run of the migration command, an empty message, or any reply
+that is not a number from the list / `new <name>` is **not** consent —
+NEVER infer the recommendation from silence. If the reply is ambiguous,
+re-ask, listing the choices again.
+
+- If user picks existing → use it
+- If user wants new → ASK for name → `mcp__confidence__createClient`
+
+**After client selected:** Write the "Default Client" section to the
+plan file and update Generation Status step 2 to `✓ complete`.
+
+### Step 3: Map Unit ID (Statsig-specific)
+
+This step maps Statsig's `idType` (unit ID) to a Confidence entity field.
+
+**EDUCATE then ASK:**
+
+> **What is a randomization unit (entity)?**
+> An entity is the "thing" that gets randomly assigned to a variant —
+> usually a user. The entity field (like `user_id` or `visitor_id`) is
+> the identifier Confidence uses to ensure **consistent assignment**: the
+> same user always sees the same variant.
+>
+> In Confidence, it maps to the `targetingKey` in the evaluation context.
+>
+> In Statsig, every gate/config/experiment randomizes on a **unit ID**
+> (its `idType`). Your items use: <list distinct idTypes found>.
+>
+> Common choices:
+> - **user_id** — for `userID` (authenticated users)
+> - **visitor_id** — for `stableID` (anonymous visitors; auto-generated
+>   by Confidence client SDKs)
+> - **company_id** — for a custom company/org/tenant unit
+>
+> Your client's existing entity fields:
+> 1. <entity-field-1>
+> 2. <entity-field-2>
+> ...
+> N. Create a new field
+>
+> Which Confidence field represents the same identifier as `<idType>`?
+
+Same wait-for-explicit-pick rule as Step 2 above. Silence is not
+consent. Map each distinct `idType` to one Confidence entity.
+
+- If user picks existing → use it as `targetingKey`
+- If user wants new → ASK for name + type → `mcp__confidence__addContextField`
+  (always provide an explicit `entityReference` — see Confidence Naming
+  Rules above)
+
+**Statsig unit targeting (`user_id` / `unit_id` conditions).** Statsig
+lets a rule target the unit directly via a `user_id` or `unit_id`
+condition (an allowlist/blocklist of IDs). Map the condition's `field`
+to the chosen entity field name in Confidence. Record this substitution
+in Section 2 of the plan.
+
+### Step 4: Generate MCP commands
+
+**Confirmation gate (MUST pass before generating).** Before writing the
+Flags to Migrate section, summarize the choices made in earlier steps
+(client, unit-ID → entity mapping) and ask:
+
+> Plan will assume client `<client>` with unit `<idType>` → entity
+> `<entity>`. All flags will be defaulted to `[ ] Migrate  [ ] Skip`
+> (neither pre-checked) — you'll opt each one in during review. Confirm
+> or change?
+
+Set the step to `⏸ awaiting user` and stop. Only proceed on an explicit
+`yes` / `confirm` / equivalent. A re-run or ambiguous reply is **not**
+confirmation.
+
+For each item, generate the MCP command payloads (`createFlag`,
+`addFlagToClient`, `addTargetingRule`, `resolveFlag`) using the Operator
+Mapping table together with the Confidence Targeting Payload Format
+(below). Write them into each flag's section in the plan.
+
+**After all commands generated:** Update Generation Status step 4 to
+`✓ complete`, set the overall status to `complete`, and tell the user:
+
+> Plan generated! Review it at `.claude/plans/statsig-flag-migration-<date>.md`
+>
+> Migration is **opt-in**: every flag starts with both checkboxes empty.
+> Tick `[x] Migrate` or `[x] Skip` for each flag — `execute` will refuse
+> any flag with neither box set. When ready, run:
+> `/migrate-statsig execute <plan-file>`
+
+**Rule → targeting-rule order.** Statsig rules form a waterfall — the
+first matching rule wins. Confidence evaluates targeting rules in
+declared order, so emit one `addTargetingRule` call per Statsig rule, in
+the same order.
+
+---
+
+## Confidence Targeting Payload Format
+
+This is how Confidence targeting rules are structured. Use this when
+generating `addTargetingRule` payloads.
+
+**CRITICAL:** The payload uses a `criteria` + `expression` pattern.
+Criteria are named references (`ref-0`, `ref-1`, ...) that define
+individual conditions. The `expression` combines them with boolean
+logic (`and`, `or`, `not`, `ref`).
+
+```json
+{
+  "criteria": {
+    "ref-0": {
+      "attribute": {
+        "attributeName": "<field>",
+        "<rule>": { ... }
+      }
+    }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+**DO NOT use nested rule objects like `{"or": {"operands": [{"eqRule": ...}]}}`
+at the top level.** That format is silently parsed as empty targeting
+(matching ALL contexts) due to `ignoringUnknownFields()` in the proto
+parser.
+
+### Criterion rules
+
+These mirror the canonical `Targeting` proto in the open-source
+resolver (`spotify/confidence-resolver`,
+`protos/confidence/flags/types/v1/target.proto`). The JSON wire form is
+proto3 → JSON (camelCase keys).
+
+| Match | Form |
+|---|---|
+| String eq | `"eqRule": { "value": { "stringValue": "X" } }` |
+| Number eq | `"eqRule": { "value": { "numberValue": N } }` |
+| Bool eq | `"eqRule": { "value": { "boolValue": true } }` |
+| Version eq | `"eqRule": { "value": { "versionValue": { "version": "1.2.3" } } }` |
+| String set (in) | `"setRule": { "values": [{ "stringValue": "A" }, { "stringValue": "B" }] }` |
+| `>=` | `"rangeRule": { "startInclusive": { "numberValue": N } }` |
+| `>` | `"rangeRule": { "startExclusive": { "numberValue": N } }` |
+| `<` | `"rangeRule": { "endExclusive": { "numberValue": N } }` |
+| `<=` | `"rangeRule": { "endInclusive": { "numberValue": N } }` |
+| Version `>=` | `"rangeRule": { "startInclusive": { "versionValue": { "version": "2.0.0" } } }` |
+| Version `<` | `"rangeRule": { "endExclusive": { "versionValue": { "version": "3.0.0" } } }` |
+| Timestamp `>=` | `"rangeRule": { "startInclusive": { "timestampValue": "2022-11-17T15:16:17Z" } }` |
+| starts with | `"startsWithRule": { "value": "prefix" }` |
+| ends with | `"endsWithRule": { "value": "suffix" }` |
+| attribute is set (exists) | `{ "attribute": { "attributeName": "X" } }` (attribute criterion with **no** inner rule) |
+
+**Value types.** A `Value` is a oneof: `boolValue`, `numberValue`,
+`stringValue`, `timestampValue` (RFC-3339 string), `versionValue`
+(`{ "version": "X.Y.Z" }`), or `listValue`. Equality (`==`, `!=`, set
+membership) is defined for all types; comparison (`<`, `<=`, `>`, `>=`
+via `rangeRule`) is defined for **number, timestamp, and version**.
+
+**Version semantics.** The resolver parses version strings with 2–4
+numeric segments (`1.2`, `1.2.3`, `1.2.3.4`), strips any pre-release
+suffix after `-` (`1.2.3-beta` compares as `1.2.3`), and rejects
+non-numeric or `v`-prefixed strings (`v1.0.0` → does not parse).
+Send the version in the evaluation context as a plain string; the
+`versionValue` criterion makes Confidence compare it as a version
+rather than lexically.
+
+**Set rule vs OR-of-eq.** `setRule` with multiple values is the native
+"is one of" and is preferred over an `or` of `eqRule`s when realizing
+list membership. Both resolve identically.
+
+**Existence / null checks.** An attribute criterion with **no inner
+rule** — just `{ "attribute": { "attributeName": "X" } }` — is a
+presence check: it matches when attribute `X` is set. To express
+**"attribute is null/absent"**, reference that criterion under `not`:
+
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "country" } }
+  },
+  "expression": { "not": { "ref": "ref-0" } }
+}
+```
+
+Because it composes like any other criterion, "X is null AND Y = foo"
+is expressible: `and(not(ref-x), ref-y)`. Note: the web segment editor
+may not render a control for a ruleless criterion, so a null rule can
+look empty in the UI even though it resolves correctly — call this out
+in the plan when you emit one.
+
+### Default value (no server-side default → emit a catch-all rule)
+
+Confidence has **no server-side flag default**. The `Flag` resource
+carries variants and an ordered list of rules but no default-value
+field. The resolver's contract is explicit: *"each rule is tried in
+order; the first match assigns a variant; if no rule matches, no variant
+is assigned."* When no rule matches, the SDK returns **the default the
+caller passed at the call site** (e.g. `checkGate` defaults to `false`).
+
+So a Statsig default — a gate's implicit `false`, or a dynamic config's
+`defaultValue` — does **not** map to any flag-level field. To preserve
+it faithfully, emit it as an explicit **catch-all final rule**:
+
+- `addTargetingRule` with `variantAllocations` = `{ "<defaultVariant>": 100 }`
+  and **no `payload`** (an omitted/empty payload targets all contexts).
+- Add it **last**, after every specific rule, so it only catches
+  subjects that matched nothing above it.
+
+For a **gate**, the catch-all variant is `disabled` (`false`). For a
+**dynamic config**, it's the variant carrying `defaultValue`. For an
+**experiment** whose `allocation` < 100, the unallocated users fall
+through — emit a catch-all serving the control group's value.
+
+### Expression combinators
+
+| Pattern | Expression |
+|---------|-----------|
+| Single condition | `{ "ref": "ref-0" }` |
+| AND | `{ "and": { "operands": [{ "ref": "ref-0" }, { "ref": "ref-1" }] } }` |
+| OR | `{ "or": { "operands": [{ "ref": "ref-0" }, { "ref": "ref-1" }] } }` |
+| NOT | `{ "not": { "ref": "ref-0" } }` |
+| NOT IN (list) | Prefer one `setRule` criterion wrapped in `not`: `{ "not": { "ref": "ref-0" } }`. |
+| attribute IS null | `not`-wrap a ruleless presence criterion: `{ "not": { "ref": "ref-0" } }` where `ref-0` is `{ "attribute": { "attributeName": "X" } }` |
+
+### Worked examples
+
+**Single equality (country = "US"):**
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "country", "eqRule": { "value": { "stringValue": "US" } } } }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+**Version range (appVersion >= 2.0.0):**
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "appVersion", "rangeRule": { "startInclusive": { "versionValue": { "version": "2.0.0" } } } } }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+**Set membership (country in [US, UK, SE]):**
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "country", "setRule": { "values": [{ "stringValue": "US" }, { "stringValue": "UK" }, { "stringValue": "SE" }] } } }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+**Suffix alternation (email ends with @test.com OR @qa.com):**
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "email", "endsWithRule": { "value": "@test.com" } } },
+    "ref-1": { "attribute": { "attributeName": "email", "endsWithRule": { "value": "@qa.com" } } }
+  },
+  "expression": { "or": { "operands": [{ "ref": "ref-0" }, { "ref": "ref-1" }] } }
+}
+```
+
+## Segments
+
+The Confidence MCP in this plugin does **not** expose a `createSegment`
+tool, so Statsig segments are **inlined** into each referencing flag's
+targeting rather than turned into reusable Confidence segments:
+
+- **`rule_based` segment** (`passes_segment` / `fails_segment`): fetch
+  its definition, translate its `conditions[]` with the operator table,
+  and inline them into the flag's `criteria` + `expression`. For
+  `passes_segment` reference the segment's combined expression directly;
+  for `fails_segment` wrap it in `not`. If the same segment is referenced
+  by many flags, repeat the inlined criteria in each (de-dup is not
+  available without a segment primitive — note this in the plan).
+- **`id_list` segment** (`in_segment_list` / `not_in_segment_list`): if
+  the list is small (≤ ~50 ids), inline as a `setRule` on the entity
+  field (wrapped in `not` for the `not_in` case). If large, mark the
+  condition BLOCKED.
+
+## Multivariant / Group Split Handling
+
+**CRITICAL:** A single Confidence targeting rule CAN assign multiple
+variants at different split percentages. Use ONE rule per Statsig rule
+(gate/config) or per experiment, listing all variants and their shares
+in that rule.
+
+- **Gate rule** (boolean): ONE rule. `rolloutPercentage` = the rule's
+  `passPercentage`; `variantAllocations` = `{ "enabled": 100 }`. Users
+  who match but fall outside `passPercentage` fall through the waterfall
+  toward the catch-all `disabled` rule — this reproduces the FAIL group.
+- **Dynamic config rule**: ONE rule per config rule. `rolloutPercentage`
+  = `passPercentage`; `variantAllocations` = `{ "<variant-for-this-returnValue>": 100 }`.
+- **Experiment**: ONE rule. `rolloutPercentage` = `allocation`;
+  `variantAllocations` = each group's `name` → its `size`
+  (e.g. `{ "control": 50, "treatment": 50 }`).
+
+**Do NOT create separate rules per variant.** One targeting rule = one
+set of targeting conditions, with the variant split defined inside that
+rule.
+
+## Operator Mapping (Statsig → Confidence)
+
+This is how Statsig conditions map to the Confidence targeting payloads
+defined above. Within a single Statsig rule, all `conditions` are ANDed.
+Across rules in a gate/config, the waterfall means each rule becomes a
+**separate Confidence targeting rule** in the same order.
+
+A Statsig condition is `{ type, operator, targetValue, field, customID }`.
+The **`type`** selects the attribute; the **`operator`** selects the
+rule shape. `targetValue` may be a scalar or array — normalize to an
+array.
+
+### Condition `type` → Confidence attribute
+
+| Statsig `type` | Confidence attribute name | Notes |
+|---|---|---|
+| `public` | (none) | "Everyone" — emit a catch-all rule (no payload) at the rule's `passPercentage` |
+| `user_id` | the chosen entity field | unit allowlist/blocklist; use entity field name |
+| `unit_id` (+ `customID`) | the entity field for that custom unit | |
+| `email` | `email` | |
+| `country` | `country` | 2-letter code (Statsig derives from IP if absent — Confidence needs it in context) |
+| `app_version` | `appVersion` | version-typed |
+| `os_name` | `os` | |
+| `os_version` | `osVersion` | version-typed |
+| `browser_name` | `browserName` | |
+| `browser_version` | `browserVersion` | version-typed |
+| `locale` | `locale` | |
+| `ip_address` | `ipAddress` | |
+| `device_model` | `deviceModel` | |
+| `user_agent` | `userAgent` | |
+| `url` | `url` | |
+| `time` | `time` | timestamp |
+| `environment_tier` | — | Confidence scopes environments via clients, not targeting; record as a note, usually drop or map to a `tier` attribute |
+| `custom_field` (+ `field`) | `field` value | the custom attribute name |
+| `passes_segment` / `fails_segment` | — | inline the segment (see "Segments") |
+| `passes_gate` / `fails_gate` | — | **BLOCKED** (no cross-flag dependency) |
+| `experiment_group` | — | **BLOCKED** (depends on experiment assignment) |
+| `javascript` | — | **BLOCKED** (arbitrary JS) |
+| `target_app` | — | record as a note; usually handled by client scoping |
+
+### Operator → Confidence rule shape
+
+Statsig operators: `any`, `none`, `any_case_sensitive`,
+`none_case_sensitive`, `gt`, `gte`, `lt`, `lte`, `version_gt`,
+`version_gte`, `version_lt`, `version_lte`, `version_eq`, `version_neq`,
+`str_starts_with_any`, `str_ends_with_any`, `str_contains_any`,
+`str_contains_none`, `str_matches`, `eq`, `neq`, `before`, `after`,
+`on`, `in_segment_list`, `not_in_segment_list`, plus null checks
+(`is null` / `is not null`).
+
+| Statsig operator | Confidence payload strategy |
+|---|---|
+| `any` / `any_case_sensitive` (single value) | one criterion `eqRule`, expression `ref` |
+| `any` / `any_case_sensitive` (multi value) | one criterion `setRule { values }`, expression `ref` |
+| `none` / `none_case_sensitive` | same as `any`, expression wraps `ref` in `not` |
+| `eq` | one criterion `eqRule`, expression `ref` |
+| `neq` | one criterion `eqRule`, expression `not` wrapping `ref` |
+| `gt` | `rangeRule.startExclusive: { numberValue: N }` |
+| `gte` | `rangeRule.startInclusive: { numberValue: N }` |
+| `lt` | `rangeRule.endExclusive: { numberValue: N }` |
+| `lte` | `rangeRule.endInclusive: { numberValue: N }` |
+| `version_gt` | `rangeRule.startExclusive: { versionValue: { version } }` |
+| `version_gte` | `rangeRule.startInclusive: { versionValue: { version } }` |
+| `version_lt` | `rangeRule.endExclusive: { versionValue: { version } }` |
+| `version_lte` | `rangeRule.endInclusive: { versionValue: { version } }` |
+| `version_eq` | `eqRule.value.versionValue: { version }` |
+| `version_neq` | `eqRule` version, expression `not` wrapping `ref` |
+| `str_starts_with_any` | one `startsWithRule` per value, expression `or` of `ref`s |
+| `str_ends_with_any` | one `endsWithRule` per value, expression `or` of `ref`s |
+| `before` (time) | `rangeRule.endExclusive: { timestampValue }` |
+| `after` (time) | `rangeRule.startExclusive: { timestampValue }` |
+| `on` (time) | `eqRule.value.timestampValue` |
+| `in_segment_list` | small list → `setRule` on entity; large → BLOCKED |
+| `not_in_segment_list` | small list → `setRule` on entity wrapped in `not`; large → BLOCKED |
+| `is null` | ruleless presence criterion under `not`: `{ "attribute": { "attributeName": "X" } }`, expression `not` wrapping `ref` |
+| `is not null` | ruleless presence criterion, expression `ref` |
+| `str_matches` (regex) | decompose like below; else BLOCKED |
+| `str_contains_any` / `str_contains_none` | **BLOCKED** (Confidence has no substring/contains rule) |
+
+**Case sensitivity caveat.** Statsig's `any`/`none` are
+case-INsensitive; `any_case_sensitive`/`none_case_sensitive` are
+case-sensitive. Confidence string equality is case-sensitive. For
+case-insensitive Statsig conditions, note in the plan that the
+evaluation context value must be normalized (e.g. lowercased) to match,
+or surface it for review if exact case parity matters.
+
+### Regex (`str_matches`)
+
+Confidence has no general regex rule, but `startsWithRule` /
+`endsWithRule` cover the anchored prefix/suffix patterns that make up
+the majority of real Statsig `str_matches` rules — including
+alternation, which decomposes into an `or` of literal prefixes/suffixes.
+
+| Statsig `str_matches` value | Confidence payload strategy |
+|---|---|
+| `^prefix.*` / `^prefix` | one `startsWithRule { value: "prefix" }`, expression `ref` |
+| `.*suffix$` / `suffix$` | one `endsWithRule { value: "suffix" }`, expression `ref` |
+| `^(a\|b\|c).*` (prefix alternation) | one `startsWithRule` per branch, expression `or` |
+| `.*@(test\|qa)\.com$` (suffix alternation) | one `endsWithRule` per branch (`@test.com`, `@qa.com`), expression `or` |
+
+**Decomposition rule.** A `str_matches` value is auto-migratable when,
+after stripping anchors (`^`/`$`) and any leading/trailing `.*`, the
+remainder is **literal text containing at most one alternation group**
+`(x|y|...)` and no other regex metacharacters (no `[]`, `+`, `?`, `{}`,
+`\d`, `\w`, `.` used as wildcard; escaped literals like `\.` count as
+the literal char). Anything else is BLOCKED.
+
+### Blocked (manual review)
+
+Only these genuinely have no clean Confidence translation:
+
+- **`str_contains_any` / `str_contains_none`** — Confidence has no
+  substring/contains rule. Reason: `Uses a 'contains' match on
+  '<attribute>'; Confidence has no substring rule.`
+- **Generic `str_matches` regex** — anything that fails the
+  decomposition rule above (character classes, quantifiers, wildcard
+  `.`, etc.). Reason: `Uses a regex on '<attribute>' that isn't a
+  prefix/suffix/alternation; Confidence has no general regex rule.`
+- **`passes_gate` / `fails_gate`** — depends on another gate's
+  evaluation. Confidence has no cross-flag dependency. Reason: `Depends
+  on gate '<gate>'; Confidence has no flag-to-flag dependency. Inline
+  that gate's conditions or migrate manually.`
+- **`experiment_group`** — depends on another experiment's assignment.
+  Reason: `Depends on experiment-group assignment; migrate manually.`
+- **`javascript`** — arbitrary JS expression. Reason: `Uses a custom
+  JavaScript condition; no Confidence equivalent.`
+- **Large `id_list` segments** — can't inline thousands of ids. Reason:
+  `References an id_list segment too large to inline.`
+- **Unnormalizable version strings** — `v`-prefixed or build-metadata
+  versions that can't be reduced to 2–4-segment form. Reason: `Version
+  comparison on '<attribute>' uses a format Confidence can't parse.`
+
+When a rule/condition is blocked, mark it in Section 4 (per the
+template). A flag is fully blocked only when *every* non-default rule is
+blocked.
+
+### Worked example (gate waterfall)
+
+A three-rule Statsig gate — internal users force-on at 100%, then a 50%
+rollout to US/CA, then "Everyone" at 0% — becomes THREE
+`addTargetingRule` calls plus a catch-all:
+
+1. Rule 1: `email str_ends_with_any ["@spotify.com"]` →
+   `endsWithRule "@spotify.com"`, `rolloutPercentage` 100,
+   `{ "enabled": 100 }`
+2. Rule 2: `country any ["US","CA"]` → `setRule`, `rolloutPercentage`
+   50, `{ "enabled": 100 }` (the other 50% fall through)
+3. Rule 3 (`public`, passPercentage 0) → since 0% pass, this contributes
+   nothing; omit it and rely on the catch-all
+4. Catch-all (default): no payload → `disabled` at 100%. Reproduces the
+   gate's implicit `false`; MUST come last.
+
+---
+
+## Plan Flag: Template
+
+```markdown
+# Statsig to Confidence Flag Migration Plan
+
+**Created:** <date>
+**Scope:** Flag definitions only
+
+---
+
+## Generation Status
+
+| Step | Status | Result |
+|------|--------|--------|
+| 1. Scan Statsig | ○ not started | |
+| 2. Choose client | ○ not started | |
+| 3. Map unit ID | ○ not started | |
+| 4. Generate rules | ○ not started | |
+
+**Overall:** in progress
+
+---
+
+## 1. Default Client
+
+A client represents the application that resolves flags (e.g. your
+website, backend service, or mobile app). Each client authenticates
+with its own secret and can be scoped to environments (dev, staging,
+prod). Flags are associated with clients so Confidence knows which
+application receives which flags.
+
+**Available Clients:** <list from MCP>
+
+**Selected:** `<client>`
+
+---
+
+## 2. Unit ID Mapping
+
+An entity is the "thing" being randomly assigned to a variant — usually
+a user. The entity field (like `user_id` or `visitor_id`) is the
+identifier Confidence uses for consistent assignment: the same subject
+always sees the same variant.
+
+Statsig's unit ID (`idType`) maps to one Confidence entity field.
+
+| Statsig `idType` | Confidence entity field |
+|------------------|-------------------------|
+| <userID / stableID / custom> | `<selected-entity>` |
+
+Any Statsig rules that targeted `user_id` / `unit_id` directly are
+rewritten to target `<selected-entity>`.
+
+---
+
+## 3. Context Schema
+
+The context schema defines what fields Confidence expects in the
+evaluation context when resolving flags — things like `country`,
+`plan`, or `appVersion` that targeting rules use.
+
+> Note: Statsig auto-derives some attributes server-side (country from
+> IP; browser/OS/version from the user agent). Confidence needs these
+> passed explicitly in the evaluation context — Phase 2 must supply them.
+
+### Already in Confidence
+
+| Field | Type | Entity | Statsig condition |
+|-------|------|--------|-------------------|
+<matching fields>
+
+### Need to Create
+
+| Field | Type | Entity | Statsig condition |
+|-------|------|--------|-------------------|
+<missing fields — execute will create these>
+
+### Confidence-only (not in Statsig)
+
+| Field | Type | Entity |
+|-------|------|--------|
+<reference only, no action needed>
+
+---
+
+## 4. Flags to Migrate
+
+**Migration is opt-in.** Each flag starts with both checkboxes empty.
+Tick `[x] Migrate` for every flag you want to bring across, or
+`[x] Skip` to drop it. Flags with neither box ticked will be refused
+by `execute` — no implicit defaults.
+
+### Flag: `<flag-key>`
+
+**Statsig type:** <Feature Gate / Dynamic Config / Experiment>
+**Description:** <from Statsig if available, otherwise empty>
+**Confidence schema:** <e.g. `{ enabled: boolean }` for a gate; the value shape for a config/experiment>
+**Variants:** <variant list — e.g. "enabled, disabled" for a gate; group names for an experiment>
+**Confidence resolve path:** `<flag-key>.<property>` (Phase 2 reads this; `.enabled` for gates, `.<param>` per config/experiment parameter)
+**Unit:** <idType> → entity `<entity>`
+**Enabled in Statsig:** <yes / no — if no, all rules added at 0% rollout and flag created OFF>
+**Rules (Statsig, in order):**
+  1. `<rule name>` — <plain-English condition>, pass <X>%, <variant split>
+  2. ...
+**Default:** <gate: disabled; config: defaultValue → variant; experiment: control fall-through>
+**Segments inlined:** <none, or list of segment ids whose conditions were inlined>
+**Null rules emitted:** <none, or "is null on '<attr>' → ruleless presence criterion under `not`; may render empty in the segment editor">
+**Confidence rules:** one targeting rule per Statsig rule, in the same order, plus a final catch-all rule for the default
+**Action:** [ ] Migrate  [ ] Skip
+
+If any rule or the whole flag is BLOCKED, replace the **Action** line
+with:
+
+**Status:** BLOCKED — <one-line reason from the BLOCKED rules above>
+**Action:** [ ] Skip (no migrate option available until the block is resolved)
+
+**MCP Commands:**
+<createFlag, addFlagToClient, addTargetingRule (ONE per Statsig rule, in order, with variant assignments and their split) THEN a final catch-all addTargetingRule (no payload, 100% → default variant), resolveFlag with full parameters — positive AND negative case (negative must land on the catch-all and return the default variant)>
+
+---
+
+## 5. Progress
+
+| # | Flag | Status |
+|---|------|--------|
+| 1 | <flag> | :white_circle: |
+```
+
+---
+
+## Execute: How It Works
+
+`execute <plan-file>` walks through the plan interactively, step by step.
+
+### For flag plans
+
+```
+1. READ the plan file
+   - Client is already in the plan — use it, do NOT re-ask
+   - Unit-ID → entity mapping is in the plan
+   - REFUSE TO PROCEED if any flag has neither `[x] Migrate` nor
+     `[x] Skip` ticked. List those flags back and ask the user to tick a
+     box for each. Migration is opt-in — never assume a default.
+   - REFUSE TO PROCEED if any flag is marked `BLOCKED` and the user
+     hasn't either resolved the block or ticked `[x] Skip`. Surface the
+     BLOCKED flags and the reason for each.
+2. FOR EACH FLAG marked [x] Migrate:
+   - Show flag name, type, description, and rules in plain English
+   - ASK: "Create this flag in Confidence? [Yes / Skip / Pause]"
+   - If Yes → run the Flag Setup Sequence (below)
+   - CHECKPOINT: "Flag done. [Continue / Pause]?"
+   - Wait for user response
+3. COMPLETION
+   - Show summary: created vs skipped
+```
+
+### For code plans
+
+**Each flag = one PR.** The code migration creates a separate pull
+request for each flag, keeping changes small and reviewable.
+
+```
+1. READ the plan file
+2. SDK SETUP (Section 1 of plan) — one-time, before any flag
+   - Show install command from plan
+   - ASK: "Install SDK now? [Yes / Skip / I already did]"
+   - Show wrapper file path + API surface from plan
+   - ASK: "Create the Confidence wrapper now? [Yes / Skip / I already did]"
+3. FOR EACH FLAG in the files list:
+   a. Create a branch: `migrate/<flag-key>-to-confidence`
+   b. Show flag name + all files using it
+   c. ASK: "Transform this flag's files? [Yes / Skip / Pause]"
+   d. If Yes → apply transform rules from plan to all files for this flag
+   e. Run lint + typecheck on changed files
+   f. Commit changes
+   g. Create PR titled: "feat: migrate <flag-key> from Statsig to Confidence"
+   h. CHECKPOINT: "PR created. [Continue to next flag / Pause]?"
+4. COMPLETION — show summary + list all PRs created
+```
+
+### Flag Setup Sequence (MUST complete all steps before resolving)
+
+Each flag MUST go through these steps in order. Do NOT call
+`resolveFlag` until ALL prior steps succeed.
+
+```
+STEP 1: createFlag
+  → If flag already exists, check the response for which clients
+    it's enabled on.
+
+STEP 2: Ensure flag is active and on the correct client
+  → If createFlag response does NOT list the target client:
+    a. Try addFlagToClient
+    b. If that fails with "Cannot update an archived flag":
+       → unarchiveFlag first, then retry addFlagToClient
+  → If createFlag response lists the target client: proceed
+
+STEP 3: addTargetingRule
+  → Add the targeting rule(s) from the plan. Emit one addTargetingRule
+    call per Statsig rule in the SAME ORDER (Confidence evaluates rules
+    top-down — order is semantically significant).
+  → Add the default LAST as a catch-all rule: addTargetingRule with
+    variantAllocations { <defaultVariant>: 100 } and NO payload (empty
+    payload = targets all contexts). Confidence has no flag-level default
+    (see "Default value" above), so this is the only way to reproduce a
+    gate's implicit false / a config's defaultValue. It MUST come after
+    every specific rule.
+  → IMPORTANT: targeting rules added while a flag is archived OR
+    immediately after unarchiving may become inactive. Always complete
+    steps 1-2 fully BEFORE calling addTargetingRule.
+
+STEP 4: resolveFlag (verification)
+  → MUST test BOTH positive AND negative cases:
+    a. Resolve with a context that SHOULD match → verify expected variant
+    b. Resolve with a context that SHOULD NOT match any specific rule →
+       verify it lands on the catch-all and returns the default variant
+  → For multi-rule flags, also resolve with a context that misses the
+    first rule but matches a later one — verifies waterfall order.
+  → For attribute-based targeting, the resolve call MUST include those
+    attributes in the evaluation context.
+  → Do NOT report a flag as successfully migrated until both positive and
+    negative resolve tests pass.
+```
+
+### Rules
+
+- **NEVER auto-continue** — always wait for user at each checkpoint
+- **Flag-by-flag** — each flag is one unit (its files + tests)
+- **Preserve source order** — one Confidence rule per Statsig rule, in
+  the same order
+- **Resumable** — update the Progress table in the plan file after each step
+
+## Execute: Statsig-Specific Notes
+
+**Inline segments first.** For any flag whose rules reference a
+`rule_based` segment, the inlined criteria are already part of that
+flag's targeting payload in the plan (this plugin's Confidence MCP has no
+`createSegment` tool). No separate segment-creation step is needed —
+just apply the flag's payload as written.
+
+**Disabled-in-Statsig handling.** If an item's `isEnabled` is false,
+surface that during execute:
+
+> This <gate/config/experiment> is DISABLED in Statsig. I'll create it in
+> Confidence but keep the rules at 0% rollout so it stays off until you
+> turn it on intentionally. Continue?
+
+**Type → Confidence schema (and the resolve-path handoff to Phase 2).**
+A Confidence flag is a struct, not a bare scalar, so each flag needs a
+named **property** that holds the migrated value. Pick the property by
+Statsig type so Phase 2 can reconstruct the resolve path:
+
+| Statsig type | Confidence schema (`schemaObject`) | Resolve path |
+|--------------|------------------------------------|--------------|
+| **Feature Gate** | `{ "enabled": "boolean" }` (the `createFlag` default) | `<flag>.enabled` |
+| **Dynamic Config** | the value object's shape (one property per key) | `<flag>.<key>` per parameter |
+| **Experiment** | the group `parameterValues` shape (one property per parameter) | `<flag>.<param>` per parameter |
+
+For gates, variants are `enabled` (`{ enabled: true }`) and `disabled`
+(`{ enabled: false }`). For configs, create one variant per distinct
+`returnValue` plus one for `defaultValue`. For experiments, create one
+variant per `group`, each carrying its `parameterValues`. Record the
+resolve path on the flag's plan entry — Phase 2's code transform reads
+it verbatim.
+
+**Waterfall verification.** Because Statsig items often have multiple
+rules, the Flag Setup Sequence Step 4 (above) requires you to also
+resolve with a context that misses the first rule but matches a later
+one — this verifies the waterfall order is preserved.
+
+---
+
+## Plan Code: Steps
+
+The code phase has 5 steps: Step 1 detect language/framework, Step 2
+fetch the Confidence SDK guide (and signal any resolve-mode change),
+Step 3 scan the codebase for Statsig usage, Step 4 generate transform
+rules, Step 5 generate the plan.
+
+### Step 1: Detect language & framework
+
+```
+Grep: pattern="<Statsig import/symbol patterns from Step 3>"  → Find Statsig usage
+Glob: pattern="package.json" or "build.gradle" or "go.mod" or "requirements.txt" etc
+Read: dependency file  → Determine language/framework
+```
+
+### Step 2: Fetch SDK guide from `confidence-docs` MCP
+
+**Step 2a — pick the target resolve mode.** Confidence has FOUR modes,
+not a local/remote binary. Pick from the language/framework detected in
+Step 1, honoring the "prefer local resolve" policy (see "SDK
+Preference"):
+
+| Target mode | Confidence SDKs | How evaluation works | Network profile |
+|-------------|-----------------|----------------------|-----------------|
+| **In-process** (local resolve) | backend **Java, Go, JS/Node, Rust** | Periodically fetch the resolver **state** (full ruleset); evaluate locally via WASM | No per-eval network call; network only for state refresh |
+| **Cached client** | **Android, iOS, web/browser JS, React, React Native** | Backend resolves; device **prefetches and caches resolved VALUES**. Reads are local + offline. Context change triggers a refetch | Network on init / context change / refresh — NOT per read |
+| **Server-precomputed** | server-rendered React/Next.js (RSC) | Server resolves for a bound subject; client reads resolved values offline | Resolution on the server; client reads are offline |
+| **Remote** (per-call) | backend **Python, Ruby, .NET** | Each resolve is a service call to Confidence | One call per resolve (with default-value fallback on failure) |
+
+Routing:
+
+- Backend **and** language ∈ {Java, Go, JS/Node, Rust} → **in-process**.
+  Fetch the local-resolve guide (server-only):
+
+  ```
+  mcp__confidence-docs__getLocalResolveIntegrationGuide
+    sdk: "JAVA" | "GO" | "JS" | "RUST"
+  ```
+
+- Client app (mobile / browser / React Native) → **cached client**.
+  Backend **Python / Ruby / .NET** → **remote**. Either way fetch:
+
+  ```
+  mcp__confidence-docs__getCodeSnippetAndSdkIntegrationTips
+    sdk: "<detected>"
+  ```
+
+**CRITICAL:** Include the ACTUAL MCP response in the plan, not a
+reference to fetch it. Plans are self-sufficient.
+
+**Step 2b — signal any resolve-mode CHANGE.** Compare the source mode
+(defined in "Source resolve mode (Statsig)" below) to the target mode
+from 2a and, if it shifts, tell the user precisely what changes. Record
+the decision and any change notice in the plan's SDK Setup section and
+re-surface it at execute time. If unchanged, state that explicitly.
+
+### Source resolve mode (Statsig) — feeds the Step 2b signal
+
+Map the Statsig SDK in use to a source mode by surface:
+
+- **Statsig server SDK** (`statsig-node` v3+, Server Core
+  `@statsig/statsig-node-core`, `statsig` Python/Ruby, Java/Go/.NET) →
+  source mode = **in-process eval** (the SDK downloads the project config
+  and evaluates locally, no per-check network call).
+- **Statsig client SDK** (`@statsig/js-client`, `@statsig/react-bindings`,
+  Android/iOS) → **precomputed/cached values**: the server precomputes
+  per-user values that the client reads locally (with `updateUser`
+  triggering a refetch).
+- **Statsig on-device evaluation client SDK**
+  (`@statsig/js-on-device-eval-client`) → **on-device eval** (the client
+  downloads the ruleset and evaluates locally).
+
+Then the Step 2b transitions apply:
+
+- Statsig server → Confidence **in-process** (Java/Go/JS/Rust):
+  unchanged.
+- Statsig server → Confidence **remote** (Python/Ruby/.NET): ⚠️
+  in-process → remote — each resolve becomes a service call.
+- Statsig client (precomputed) → Confidence **cached client**: ✅ similar
+  model — backend resolves, client reads cached values offline; reads
+  stay local/fast.
+- Statsig on-device eval → Confidence **cached client**: ⚠️ on-device →
+  cached client. Reads stay local/offline, but evaluation moves to the
+  backend; the device caches resolved values instead of the ruleset (a
+  payload/security win — the full ruleset is no longer shipped to the
+  client).
+
+### Plan-file path
+
+`.claude/plans/statsig-code-migration-<date>.md`
+
+### Step 3: Scan codebase for Statsig usage
+
+```
+Grep: pattern="statsig|Statsig|StatsigClient|StatsigUser" → Find Statsig imports
+Grep: pattern="checkGate|check_gate" → boolean gate checks
+Grep: pattern="getConfig|get_config|getDynamicConfig|get_dynamic_config" → dynamic configs
+Grep: pattern="getExperiment|get_experiment" → experiments
+Grep: pattern="getLayer|get_layer" → layers
+Grep: pattern="useGateValue|useFeatureGate|useExperiment|useLayer|useDynamicConfig|useStatsigClient" → React hooks
+```
+
+**Scan case-insensitively.** Method names vary by language and SDK
+generation (legacy vs Server Core). Map whatever you find to an
+evaluation TYPE, not a fixed spelling:
+
+| Statsig call | What it returns | Confidence accessor (by value type) |
+|--------------|-----------------|-------------------------------------|
+| `checkGate(user, "g")` / `client.checkGate("g")` | boolean | `getBooleanValue("g.enabled", false, ctx)` |
+| `getConfig(user, "c").get("p", d)` | typed param | `get<Type>Value("c.p", d, ctx)` |
+| `getDynamicConfig(user, "c").get("p", d)` | typed param | `get<Type>Value("c.p", d, ctx)` |
+| `getExperiment(user, "e").get("p", d)` | typed param | `get<Type>Value("e.p", d, ctx)` |
+| `getLayer(user, "l").get("p", d)` | typed param | `get<Type>Value("<exp>.p", d, ctx)` — the layer param resolves through its backing experiment flag |
+| `.getValue()` / `.value` (whole config object) | object | `getObjectValue("c", {}, ctx)` |
+
+**Classify the SDK as client-side or server-side** — this decides the
+evaluation-context model in Step 4:
+
+| Statsig package | Side |
+|-----------------|------|
+| `@statsig/js-client`, `@statsig/react-bindings`, `@statsig/react-native-bindings`, Android/iOS client SDK | **client** |
+| `@statsig/js-on-device-eval-client` | **client (on-device eval)** |
+| `statsig-node`, `@statsig/statsig-node-core`, `statsig` (Python/Ruby), Java/Go/.NET server SDK | **server** |
+
+Group files by the **gate/config/experiment name** they reference (the
+string argument). For each evaluation site, record:
+- The Statsig name and TYPE (gate / config / experiment / layer)
+- **Client vs server side** (from the table above)
+- The value type (boolean for gates; inferred from the `.get(param, default)`
+  call or `default` literal for configs/experiments)
+- The `StatsigUser` argument (so the transform can map `userID`/`custom`
+  to `targetingKey` + attributes)
+- The `default` argument (carried over to the Confidence call)
+- The **Confidence resolve path** (`<flag-key>.<property>`) from the
+  Phase 1 plan's "Confidence resolve path" line. For gates the property
+  is `enabled`. If the item is NOT in the Phase 1 plan, flag it — the
+  code references a flag that was never migrated; do not invent a path.
+
+### Step 4: Generate transform rules
+
+**Two things are NOT 1:1 line replacements — get them right first:**
+
+1. **Name → resolve path.** Confidence flags are structs; every read
+   uses a dot-path `<flag-key>.<property>`. Use the resolve path from the
+   Phase 1 plan everywhere the bare Statsig name appeared. A
+   `getConfig("c").get("p")` becomes `getXValue("c.p", default)` — the
+   parameter folds INTO the path.
+2. **Evaluation-context model depends on client vs server:**
+   - **Server SDKs** pass the `StatsigUser` **per call** — fold
+     `user.userID` → `targetingKey` and `user.custom` / top-level fields
+     → attributes into the evaluation-context argument of each resolve.
+   - **Client SDKs** use **ambient** context — no per-call user argument.
+     Hoist `userID` + attributes ONCE into a
+     `setEvaluationContext`/`setEvaluationContextAndWait` call (at init or
+     where the user becomes known, replacing Statsig's
+     `updateUser` / init user), and the per-call site becomes a bare
+     `get<Type>Value(path, default)`.
+
+**StatsigUser → evaluation context.** Statsig's user object
+(`{ userID, email, country, appVersion, custom: {...}, customIDs: {...} }`)
+maps to a Confidence evaluation context: `userID` → `targetingKey`;
+top-level reserved fields and `custom` entries → attributes of the same
+name; `customIDs` → the corresponding entity fields. Statsig auto-derives
+country/browser/OS/version server-side — in Confidence you MUST pass
+these explicitly, so add them to the context where targeting needs them.
+
+**Server-target mapping (per-call context), JS/TS example:**
+
+| Statsig call | OpenFeature call |
+|--------------|------------------|
+| `statsig.checkGate(user, "g")` | `client.getBooleanValue("g.enabled", false, { targetingKey: user.userID, ...attrs })` |
+| `statsig.getConfig(user, "c").get("p", d)` | `client.get<Type>Value("c.p", d, { targetingKey: user.userID, ...attrs })` |
+| `statsig.getExperiment(user, "e").get("p", d)` | `client.get<Type>Value("e.p", d, { targetingKey: user.userID, ...attrs })` |
+
+The accessor name and signature are language-specific (use the Step 2
+SDK guide):
+- **Go**: PascalCase, context-LAST, `ctx` first:
+  `client.BooleanValue(ctx, "g.enabled", false, evalCtx)` where
+  `evalCtx := openfeature.NewEvaluationContext(user.UserID, attrsMap)`.
+- **Java**: build a `MutableContext(userID)` + `ctx.add(...)`:
+  `client.getBooleanValue("g.enabled", false, ctx)`.
+- **Python (REMOTE target)**: snake_case `get_<type>_value`, context
+  last: `client.get_boolean_value("g.enabled", False, EvaluationContext(targeting_key=user_id, attributes=attrs))`.
+  Use `api.set_provider(ConfidenceOpenFeatureProvider(Confidence(client_secret=...)))`
+  (NOT `set_provider_and_wait`) and delete Statsig's `initialize()` wait.
+
+**Client-target mapping (ambient context):** the per-call site drops its
+user argument; emit a one-time context setup instead.
+
+| Statsig call | Confidence client call | Plus, once |
+|--------------|------------------------|------------|
+| `client.checkGate("g")` | `getBooleanValue("g.enabled", false)` | `setEvaluationContext({ targetingKey: userID, ...attrs })` |
+| `client.getExperiment("e").get("p", d)` | `get<Type>Value("e.p", d)` | (same — set once) |
+
+**React mapping.** Statsig `@statsig/react-bindings` hooks map to
+Confidence's React provider + `useFlag`:
+
+| Statsig (React) | Confidence (React) |
+|-----------------|--------------------|
+| `<StatsigProvider sdkKey user>` | `<ConfidenceProvider>` with evaluation context `{ targetingKey: userID, ...attrs }` |
+| `useGateValue("g")` / `useFeatureGate("g").value` | `useFlag("g.enabled", false)` |
+| `useExperiment("e").get("p", d)` / `.value.p` | `useFlag("e.p", d)` |
+| `useLayer("l").get("p", d)` | `useFlag("<exp>.p", d)` |
+| `useStatsigClient().checkGate("g")` | `useFlag("g.enabled", false)` (or imperative client read) |
+
+**Remove Statsig readiness scaffolding.** Statsig examples gate the
+first check behind `await statsig.initialize(...)` /
+`await client.initializeAsync()` / `StatsigProvider`'s loading state.
+Confidence's `setProviderAndWait` / `setEvaluationContextAndWait` already
+block until flags are ready — delete the hand-rolled wait rather than
+porting it. Drop Statsig's `disableExposureLog` plumbing and manual
+exposure logging (`logEvent` for exposures) — Confidence logs exposure
+automatically.
+
+**Layers caveat.** A Statsig `getLayer("l").get("p", d)` reads a
+parameter that, in Statsig, is owned by whichever experiment is
+currently allocated in that layer. Confidence has no layer; resolve the
+param through the specific experiment flag the Phase 1 plan created for
+it. If a layer parameter is shared across multiple experiments, surface
+it for review rather than guessing which flag owns it.
+
+### Step 5: Generate plan
+
+Save the plan to `.claude/plans/statsig-code-migration-<date>.md` using
+the template below.
+
+**Two Confidence-wide truths every code transform must honor:**
+
+- **Flags are structs — read a property, not the bare name.** Always use
+  `<flag>.<property>` (gates → `.enabled`; configs/experiments →
+  `.<param>`).
+- **Client SDKs use ambient context; server SDKs pass it per call.**
+
+## Plan Code: Template
+
+```markdown
+# Statsig to Confidence Code Migration Plan
+
+**Created:** <date>
+**Scope:** Code transformation only
+**Language:** <detected>
+**Framework:** <detected>
+
+---
+
+## Generation Status
+
+| Step | Status | Result |
+|------|--------|--------|
+| 1. Detect language | ○ not started | |
+| 2. Fetch SDK guide | ○ not started | |
+| 3. Scan codebase | ○ not started | |
+| 4. Transform rules | ○ not started | |
+| 5. Group by flag | ○ not started | |
+
+**Overall:** in progress
+
+---
+
+## 1. SDK Setup
+
+### Resolve mode
+
+| | |
+|---|---|
+| **Source mode** | <in-process eval / precomputed-cached / on-device eval — per surface> |
+| **Target mode** | <in-process / cached client / server-precomputed / remote — from Step 2a> |
+| **Change** | <unchanged / ⚠️ in-process → remote / ⚠️ on-device → cached client / … — see notice> |
+
+<If changed: one-paragraph notice of what actually shifts. If unchanged: "Resolve mode is preserved.">
+
+### Install
+
+<install commands from MCP response>
+
+### API Reference (from MCP: confidence-docs)
+
+<code examples from MCP response>
+
+### Create Confidence Wrapper
+
+**File:** <appropriate path for detected framework>
+
+**Must match source API surface:**
+
+| Method | Signature |
+|--------|-----------|
+<detected from source SDK usage>
+
+---
+
+## 2. Transform Rules
+
+### Source Files
+
+| Find | Replace |
+|------|---------|
+| <Statsig import> | <Confidence import> |
+| <Statsig usage> | <Confidence usage> |
+
+### Test Files
+
+| Find | Replace |
+|------|---------|
+| <Statsig mock> | <Confidence mock> |
+
+---
+
+## 3. Files to Transform
+
+<list from codebase scan, grouped by gate/config/experiment name>
+
+---
+
+## 4. Progress
+
+| # | Item | Status |
+|---|------|--------|
+| 0 | SDK Setup | :white_circle: |
+```
+
+---
+
+## Required Prerequisites
+
+This skill needs the Confidence-side MCPs listed in "Prerequisites:
+Confidence Side" above (`confidence` for `plan flags`/`execute`,
+`confidence-docs` for `plan code`), plus the Statsig Console API — no
+MCP, just `curl` with `STATSIG-API-KEY: $STATSIG_API_KEY` and
+`STATSIG-API-VERSION: 20240601`.
+
+| Source | What's used |
+|--------|-------------|
+| Confidence MCP | `listClients`, `createClient`, `getContextSchema`, `addContextField`, `createFlag`, `addFlagToClient`, `unarchiveFlag`, `addTargetingRule`, `resolveFlag` |
+| Confidence Docs MCP (`plan code`) | `getLocalResolveIntegrationGuide`, `getCodeSnippetAndSdkIntegrationTips`, `searchDocumentation`, `getFullSource` |
+| Statsig Console API (`STATSIG-API-KEY`) | `GET /console/v1/gates`, `GET /console/v1/gates/{id}`, `GET /console/v1/dynamic_configs[/{id}]`, `GET /console/v1/experiments[/{id}]`, `GET /console/v1/segments/{id}` |

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -248,7 +248,7 @@ flags, but they map differently:
 |--------------|-----------|----------------------|
 | **Feature Gate** | Boolean on/off with a rule waterfall | Boolean flag (`{ enabled }`); each rule → one targeting rule |
 | **Dynamic Config** | Returns a JSON value object; rules pick which value | Struct flag; each rule's `returnValue` → a variant; `defaultValue` → catch-all |
-| **Experiment** | A/B/n test with weighted groups | Struct flag; each `group` → a variant, split by `size`; `allocation` → rolloutPercentage |
+| **Experiment** | A/B/n test with weighted groups | Struct flag; each `group` → a variant, split by `size` in `variantAllocations` (see allocation<100 note) |
 
 > **Layers.** A Statsig **layer** groups several experiments that share a
 > parameter namespace and an allocation budget. Confidence has no layer
@@ -297,7 +297,9 @@ matched rule's `passPercentage` doesn't pass), the gate returns `false`.
   allocated users in this group), `parameterValues` (the value object for
   the group). Group sizes sum to 100 across the experiment.
 - `allocation` (0–100) — percent of eligible users entering the
-  experiment at all. Maps to the rule's `rolloutPercentage`.
+  experiment at all. There is no rollout knob in Confidence's
+  `addTargetingRule`, so `allocation` < 100 can't be encoded exactly —
+  see "Experiment `allocation` < 100 (limitation)".
 - `controlGroupID` — which group is control (informational)
 - `targetingGateID` — restrict the experiment to users who pass this
   gate. Confidence has no cross-flag gate dependency — see "Blocked".
@@ -780,10 +782,14 @@ it faithfully, emit it as an explicit **catch-all final rule**:
 - Add it **last**, after every specific rule, so it only catches
   subjects that matched nothing above it.
 
-For a **gate**, the catch-all variant is `disabled` (`false`). For a
-**dynamic config**, it's the variant carrying `defaultValue`. For an
-**experiment** whose `allocation` < 100, the unallocated users fall
-through — emit a catch-all serving the control group's value.
+For a **gate**, the catch-all variant is `disabled` (`false`) — reached
+only by users who matched **no** rule (remember each gate rule already
+captures its own fail share as `disabled` inside `variantAllocations`,
+per "Multivariant / Group Split Handling"). For a **dynamic config**,
+the catch-all variant carries `defaultValue`. For an **experiment**,
+emit a catch-all serving the **control** group's value (users outside
+the targeting, or — when approximating `allocation` < 100 — the
+non-entrants).
 
 ### Expression combinators
 
@@ -859,24 +865,54 @@ targeting rather than turned into reusable Confidence segments:
 
 ## Multivariant / Group Split Handling
 
-**CRITICAL:** A single Confidence targeting rule CAN assign multiple
-variants at different split percentages. Use ONE rule per Statsig rule
-(gate/config) or per experiment, listing all variants and their shares
-in that rule.
+**CRITICAL — there is no separate `rolloutPercentage` knob.** The
+Confidence `addTargetingRule` tool takes only `variantAllocations` (a
+map of variant → percent that **must sum to exactly 100**), `payload`,
+and `targetingKey`. Encode the entire pass/fail or group split *inside*
+`variantAllocations` — do NOT expect a rule-level rollout field.
 
-- **Gate rule** (boolean): ONE rule. `rolloutPercentage` = the rule's
-  `passPercentage`; `variantAllocations` = `{ "enabled": 100 }`. Users
-  who match but fall outside `passPercentage` fall through the waterfall
-  toward the catch-all `disabled` rule — this reproduces the FAIL group.
-- **Dynamic config rule**: ONE rule per config rule. `rolloutPercentage`
-  = `passPercentage`; `variantAllocations` = `{ "<variant-for-this-returnValue>": 100 }`.
-- **Experiment**: ONE rule. `rolloutPercentage` = `allocation`;
-  `variantAllocations` = each group's `name` → its `size`
-  (e.g. `{ "control": 50, "treatment": 50 }`).
+**CRITICAL — Statsig captures matched users; there is no fall-through.**
+In Statsig, *"as soon as a user qualifies based on the condition in a
+given rule, Statsig doesn't evaluate subsequent rules for this user"* —
+the matched user is then placed in the rule's Pass or Fail group right
+there. So a matched-but-failed user does **not** continue down the
+waterfall. Fold the fail share into the same Confidence rule:
+
+- **Gate rule** (boolean): ONE rule with the rule's conditions as
+  `payload` and `variantAllocations` =
+  `{ "enabled": <passPercentage>, "disabled": <100 − passPercentage> }`.
+  A pure feature gate (passPercentage 100) is `{ "enabled": 100 }`; a
+  25% rollout is `{ "enabled": 25, "disabled": 75 }`. A `public`
+  ("Everyone") rule is the same but with **no payload** (targets all).
+- **Dynamic config rule**: ONE rule per config rule, conditions as
+  `payload`, `variantAllocations` =
+  `{ "<variant-for-this-returnValue>": <passPercentage>, "<defaultVariant>": <100 − passPercentage> }`.
+  When `passPercentage` is 100 (the common case) it's just
+  `{ "<variant>": 100 }`.
+- **Experiment**: ONE rule (conditions from `inlineTargetingRules` as
+  `payload`, or no payload) with `variantAllocations` = each group's
+  `name` → its `size` (e.g. `{ "control": 50, "treatment": 50 }`).
 
 **Do NOT create separate rules per variant.** One targeting rule = one
 set of targeting conditions, with the variant split defined inside that
-rule.
+rule via `variantAllocations`.
+
+### Experiment `allocation` < 100 (limitation)
+
+`variantAllocations` must sum to 100 and there is no rollout knob, so an
+experiment with `allocation` < 100 (only part of eligible users enter,
+the rest get the control/default) **cannot be encoded exactly** with
+integer group shares. Handle it one of two ways and record the choice in
+the plan:
+
+- **Approximate** by scaling: each entering group gets
+  `round(size × allocation / 100)`, and the leftover (`100 − Σ`) goes to
+  the **control** variant (the not-entered users). Note that the split
+  is approximate and the control share is inflated by the non-entrants.
+- **Flag for review** if exact allocation fidelity matters.
+
+A fully-allocated experiment (`allocation` 100) is exact — just use the
+group sizes directly.
 
 ## Operator Mapping (Statsig → Confidence)
 
@@ -894,7 +930,7 @@ array.
 
 | Statsig `type` | Confidence attribute name | Notes |
 |---|---|---|
-| `public` | (none) | "Everyone" — emit a catch-all rule (no payload) at the rule's `passPercentage` |
+| `public` | (none) | "Everyone" — emit a rule with **no payload**; put the pass/fail split in `variantAllocations` (e.g. `{ enabled: 25, disabled: 75 }` for a 25% pass) |
 | `user_id` | the chosen entity field | unit allowlist/blocklist; use entity field name |
 | `unit_id` (+ `customID`) | the entity field for that custom unit | |
 | `email` | `email` | |
@@ -1017,16 +1053,19 @@ blocked.
 ### Worked example (gate waterfall)
 
 A three-rule Statsig gate — internal users force-on at 100%, then a 50%
-rollout to US/CA, then "Everyone" at 0% — becomes THREE
-`addTargetingRule` calls plus a catch-all:
+pass to US/CA, then "Everyone" at 0% — becomes `addTargetingRule` calls
+plus a catch-all (the split lives entirely in `variantAllocations`;
+there is no separate rollout field):
 
 1. Rule 1: `email str_ends_with_any ["@spotify.com"]` →
-   `endsWithRule "@spotify.com"`, `rolloutPercentage` 100,
-   `{ "enabled": 100 }`
-2. Rule 2: `country any ["US","CA"]` → `setRule`, `rolloutPercentage`
-   50, `{ "enabled": 100 }` (the other 50% fall through)
-3. Rule 3 (`public`, passPercentage 0) → since 0% pass, this contributes
-   nothing; omit it and rely on the catch-all
+   payload `endsWithRule "@spotify.com"`,
+   `variantAllocations { "enabled": 100 }`
+2. Rule 2: `country any ["US","CA"]` (passPercentage 50) → payload
+   `setRule [US, CA]`, `variantAllocations { "enabled": 50, "disabled": 50 }`
+   — the 50% fail share is captured **in this rule** as `disabled`, NOT
+   left to fall through (Statsig capture semantics)
+3. Rule 3 (`public`, passPercentage 0) → 0% pass contributes nothing;
+   omit it and rely on the catch-all
 4. Catch-all (default): no payload → `disabled` at 100%. Reproduces the
    gate's implicit `false`; MUST come last.
 
@@ -1132,11 +1171,12 @@ by `execute` — no implicit defaults.
 **Variants:** <variant list — e.g. "enabled, disabled" for a gate; group names for an experiment>
 **Confidence resolve path:** `<flag-key>.<property>` (Phase 2 reads this; `.enabled` for gates, `.<param>` per config/experiment parameter)
 **Unit:** <idType> → entity `<entity>`
-**Enabled in Statsig:** <yes / no — if no, all rules added at 0% rollout and flag created OFF>
+**Enabled in Statsig:** <yes / no — if no, set every rule's pass share to 0 (gate rules become `variantAllocations { disabled: 100 }`) so the flag stays OFF until intentionally enabled>
 **Rules (Statsig, in order):**
   1. `<rule name>` — <plain-English condition>, pass <X>%, <variant split>
   2. ...
-**Default:** <gate: disabled; config: defaultValue → variant; experiment: control fall-through>
+**Default:** <gate: disabled (no-match catch-all); config: defaultValue → variant; experiment: control catch-all>
+**Rollout/split:** <how passPercentage / group size / allocation are encoded in variantAllocations — note any allocation<100 approximation>
 **Segments inlined:** <none, or list of segment ids whose conditions were inlined>
 **Null rules emitted:** <none, or "is null on '<attr>' → ruleless presence criterion under `not`; may render empty in the segment editor">
 **Confidence rules:** one targeting rule per Statsig rule, in the same order, plus a final catch-all rule for the default
@@ -1276,8 +1316,9 @@ just apply the flag's payload as written.
 surface that during execute:
 
 > This <gate/config/experiment> is DISABLED in Statsig. I'll create it in
-> Confidence but keep the rules at 0% rollout so it stays off until you
-> turn it on intentionally. Continue?
+> Confidence but keep it OFF (every rule's pass share set to 0 — gate
+> rules become `variantAllocations { disabled: 100 }`) until you turn it
+> on intentionally. Continue?
 
 **Type → Confidence schema (and the resolve-path handoff to Phase 2).**
 A Confidence flag is a struct, not a bare scalar, so each flag needs a

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -1255,6 +1255,18 @@ curl -sS -X POST "https://flags.confidence.dev/v1/segments/<id>:allocate" \
 - **De-duplicate:** a Statsig `rule_based` segment referenced by N flags
   becomes ONE Confidence segment, referenced N times. Track the
   `statsig-segment-id → segments/<id>` map in the plan.
+- **Composing segments (e.g. `passes_segment` AND `fails_segment` in one
+  Statsig rule):** a REST flag rule references exactly ONE segment, but
+  segment targeting supports **segment criteria** — create a wrapper
+  segment whose expression combines the reusable ones (verified live):
+
+  ```json
+  "targeting": {
+    "criteria": { "s0": { "segment": { "segment": "segments/premium-users" } },
+                   "s1": { "segment": { "segment": "segments/internal-staff" } } },
+    "expression": { "and": { "operands": [ { "ref": "s0" }, { "not": { "ref": "s1" } } ] } }
+  }
+  ```
 - **`id_list` segments → materialized segments** (BigQuery only): export
   the id list to a BigQuery table, then
   `POST /v1/materializedSegments?materializationId=<id>` and a load job
@@ -1548,6 +1560,10 @@ STEP 3: addTargetingRule
     steps 1-2 fully BEFORE calling addTargetingRule.
 
 STEP 4: resolveFlag (verification)
+  → Resolver state propagates asynchronously: a resolveFlag immediately
+    after flag/rule creation can fail with "No active flags found for
+    the client" even though the flag is ACTIVE and wired (observed
+    live). Wait a few seconds and retry before treating it as an error.
   → MUST test BOTH positive AND negative cases:
     a. Resolve with a context that SHOULD match → verify expected variant
     b. Resolve with a context that SHOULD NOT match any specific rule →

--- a/skills/migrate-statsig/test-fixtures/.gitignore
+++ b/skills/migrate-statsig/test-fixtures/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/skills/migrate-statsig/test-fixtures/README.md
+++ b/skills/migrate-statsig/test-fixtures/README.md
@@ -29,7 +29,7 @@ Python 3.10+ stdlib, no dependencies.
 ```bash
 python3 server.py
 # Fake Statsig Console API listening on http://127.0.0.1:4000
-#   10 gates, 1 dynamic config, 2 experiments, 2 segments
+#   12 gates, 1 dynamic config, 2 experiments, 3 segments
 ```
 
 Override the port if 4000 is taken:
@@ -82,9 +82,10 @@ Pick a throwaway Confidence client and map the `userID` unit to a
 | `legacy_checkout` | `isEnabled: false` → flag created OFF, rules at 0% rollout | Migrate (with warning) |
 | `non_prod_email_gate` | `str_matches` suffix alternation `.*@(test\|qa\|staging)\.com$` → one `endsWithRule` per branch, OR'd | Migrate |
 | `contains_blocked_gate` | `str_contains_any` → no Confidence substring rule | BLOCKED |
-| `depends_on_gate` | `passes_gate` → no cross-flag dependency | BLOCKED |
-| `premium_segment_gate` | `passes_segment` + `fails_segment` (both `rule_based`) → inline each segment's conditions | Migrate |
+| `depends_on_gate` | `passes_gate` → inline the referenced gate's conditions (or a shared segment) | Migrate (inlined) |
+| `premium_segment_gate` | `passes_segment` + `fails_segment` (both `rule_based`) → reusable segments (REST) or inline (MCP) | Migrate |
 | `test_user_allowlist` | `user_id any` → `setRule` on the chosen entity field | Migrate |
+| `vip_gate` | `passes_segment` on an **`id_list`** segment (count 5000) → REST materialized segment (BigQuery), else BLOCKED | Migrate (REST) |
 | `old_onboarding_gate` | `status: Archived` → hidden from list unless opted in | Skipped (archived) |
 
 ## Fixture dynamic configs
@@ -97,25 +98,28 @@ Pick a throwaway Confidence client and map the `userID` unit to a
 
 | `id` | What it tests |
 |---|---|
-| `checkout_button_experiment` | 50/50 groups, `allocation: 100` → ONE rule, variant split 50/50 |
-| `onboarding_flow_experiment` | 3 groups (34/33/33), `allocation: 50` → rule at 50% rollout, control fall-through catch-all; `inlineTargetingRules` (country US/CA); `layerID` set → layer note |
+| `checkout_button_experiment` | 50/50 groups, `allocation: 100` → ONE rule, variant split 50/50 (MCP-OK) |
+| `onboarding_flow_experiment` | 3 groups (34/33/33), `allocation: 50` (→ REST segment `proportion` 0.5; control catch-all); `inlineTargetingRules` (country US/CA); `layerID` → REST exclusivity group; `holdoutIDs` → holdback surface step |
 
-## Fixture segments (rule_based → inlined)
+## Fixture segments
 
-| `id` | Targeting |
-|---|---|
-| `premium_users` | `custom_field plan any [premium, enterprise]` |
-| `internal_staff` | `email str_ends_with_any [@spotify.com]` |
+| `id` | Type | Targeting |
+|---|---|---|
+| `premium_users` | rule_based | `custom_field plan any [premium, enterprise]` |
+| `internal_staff` | rule_based | `email str_ends_with_any [@spotify.com]` |
+| `vip_user_list` | id_list (count 5000) | literal unit IDs → REST materialized segment (BigQuery) |
 
-These are inlined into `premium_segment_gate` because this plugin's
-Confidence MCP has no `createSegment` tool.
+The `rule_based` segments become reusable Confidence segments on the REST
+backend, or are inlined into `premium_segment_gate` on the MCP backend
+(this plugin's Confidence MCP has no `createSegment` tool). The `id_list`
+segment maps to a REST materialized segment.
 
 ## What a successful test looks like
 
 After running `plan flags`, the generated plan file at
 `.claude/plans/statsig-flag-migration-<date>.md` should:
 
-- Include the 10 non-archived gates, 1 dynamic config, and 2 experiments
+- Include the 11 non-archived gates, 1 dynamic config, and 2 experiments
   in Section 4 (`old_onboarding_gate` is archived and excluded by default)
 - For `new_search_rollout`, render the rule as something like "country is
   not DE and not FR AND appBuildNumber >= 28"
@@ -126,17 +130,23 @@ After running `plan flags`, the generated plan file at
 - For `gradual_rollout`, emit a catch-all rule at 25% rollout to `enabled`
 - For `legacy_checkout`, note "Enabled in Statsig: no" and warn rules go
   in at 0% rollout
-- For `premium_segment_gate`, inline the `premium_users` conditions and
-  inline `internal_staff` wrapped in `not`
+- For `premium_segment_gate`, create reusable `premium_users` /
+  `internal_staff` segments (REST) or inline their conditions (MCP), with
+  `internal_staff` wrapped in `not`
 - For `test_user_allowlist`, rewrite the `user_id` condition to a
   `setRule` on the chosen entity field
+- For `depends_on_gate`, inline the referenced `internal_tools_gate`
+  conditions (email ends with `@spotify.com`) — not BLOCKED
+- For `vip_gate`, mark `Backend: REST` and map the `vip_user_list`
+  id_list segment to a materialized segment (or BLOCKED if no BigQuery)
 - For `homepage_config`, create one variant per `returnValue` plus a
   default variant for `defaultValue`, and emit a final catch-all rule
-- For `onboarding_flow_experiment`, emit ONE rule at 50% rollout with the
-  three-way group split, restricted to US/CA, plus a layer note
-- Mark `contains_blocked_gate` and `depends_on_gate` as **BLOCKED** with
-  clear reasons. `execute` should refuse to proceed on these unless
-  they're `[x] Skip`'d
+- For `onboarding_flow_experiment`, mark `Backend: REST`, use a segment
+  with `proportion` 0.5 + the three-way group split restricted to US/CA,
+  map `layerID` to an exclusivity group, and record the `q1_holdout` →
+  holdback surface step
+- Mark only `contains_blocked_gate` as **BLOCKED** (`str_contains_any`).
+  `execute` should refuse to proceed on it unless it's `[x] Skip`'d
 
 ## Verifying the translation logic (`verify_migration.py`)
 

--- a/skills/migrate-statsig/test-fixtures/README.md
+++ b/skills/migrate-statsig/test-fixtures/README.md
@@ -38,7 +38,7 @@ Python 3.10+ stdlib, no dependencies.
 ```bash
 python3 server.py
 # Fake Statsig Console API listening on http://127.0.0.1:4000
-#   12 gates, 1 dynamic config, 2 experiments, 3 segments
+#   13 gates, 1 dynamic config, 2 experiments, 3 segments
 ```
 
 Override the port if 4000 is taken:
@@ -95,6 +95,7 @@ Pick a throwaway Confidence client and map the `userID` unit to a
 | `premium_segment_gate` | `passes_segment` + `fails_segment` (both `rule_based`) → reusable segments (REST) or inline (MCP) | Migrate |
 | `test_user_allowlist` | `user_id any` → `setRule` on the chosen entity field | Migrate |
 | `vip_gate` | `passes_segment` on an **`id_list`** segment (count 5000) → REST materialized segment (BigQuery), else BLOCKED | Migrate (REST) |
+| `onboarding_na_targeting` | plain `country any [US, CA]` gate; also referenced by `onboarding_flow_experiment.targetingGateID` (conditions inlined there) | Migrate |
 | `old_onboarding_gate` | `status: Archived` → hidden from list unless opted in | Skipped (archived) |
 
 ## Fixture dynamic configs
@@ -108,7 +109,7 @@ Pick a throwaway Confidence client and map the `userID` unit to a
 | `id` | What it tests |
 |---|---|
 | `checkout_button_experiment` | 50/50 groups, `allocation: 100` → ONE rule, variant split 50/50 (MCP-OK) |
-| `onboarding_flow_experiment` | 3 groups (34/33/33), `allocation: 50` (→ REST segment `proportion` 0.5; control catch-all); `inlineTargetingRules` (country US/CA); `layerID` → REST exclusivity group; `holdoutIDs` → holdback surface step |
+| `onboarding_flow_experiment` | 3 groups (34/33/33), `allocation: 50` (→ REST segment `proportion` 0.5; control catch-all); `targetingGateID: onboarding_na_targeting` (gate conditions inlined — how the modern console targets experiments); `layerID` → REST exclusivity group; duplicated `holdoutIDs` (live-API quirk — dedupe) → holdback surface step |
 
 ## Fixture segments
 
@@ -128,7 +129,7 @@ segment maps to a REST materialized segment.
 After running `plan flags`, the generated plan file at
 `.claude/plans/statsig-flag-migration-<date>.md` should:
 
-- Include the 11 non-archived gates, 1 dynamic config, and 2 experiments
+- Include the 12 non-archived gates, 1 dynamic config, and 2 experiments
   in Section 4 (`old_onboarding_gate` is archived and excluded by default)
 - For `new_search_rollout`, render the rule as something like "country is
   not DE and not FR AND appBuildNumber >= 28"
@@ -151,9 +152,10 @@ After running `plan flags`, the generated plan file at
 - For `homepage_config`, create one variant per `returnValue` plus a
   default variant for `defaultValue`, and emit a final catch-all rule
 - For `onboarding_flow_experiment`, mark `Backend: REST`, use a segment
-  with `proportion` 0.5 + the three-way group split restricted to US/CA,
-  map `layerID` to an exclusivity group, and record the `q1_holdout` →
-  holdback surface step
+  with `proportion` 0.5 + the three-way group split restricted to US/CA
+  (inlined from the `onboarding_na_targeting` targeting gate), map
+  `layerID` to an exclusivity group, and record the `q1_holdout` →
+  holdback surface step (deduped — the live API returns the id twice)
 - Mark only `contains_blocked_gate` as **BLOCKED** (`str_contains_any`).
   `execute` should refuse to proceed on it unless it's `[x] Skip`'d
 

--- a/skills/migrate-statsig/test-fixtures/README.md
+++ b/skills/migrate-statsig/test-fixtures/README.md
@@ -138,6 +138,25 @@ After running `plan flags`, the generated plan file at
   clear reasons. `execute` should refuse to proceed on these unless
   they're `[x] Skip`'d
 
+## Verifying the translation logic (`verify_migration.py`)
+
+`verify_migration.py` models Statsig's deterministic evaluation (condition
+matching + the waterfall) over the fixtures and prints a context × flag
+matrix of expected results — including which gates are BLOCKED and which
+experiments have an un-representable `allocation` < 100. Run it
+before/after `execute` to spot-check that Confidence resolves match
+Statsig for the same context:
+
+```bash
+python3 verify_migration.py
+```
+
+It imports the fixtures directly from `server.py`, so no network or
+running server is needed. The random percentage dimension
+(`passPercentage` / group `size` / `allocation`) is reported as metadata
+rather than simulated, since bucketing is a property of the hashing, not
+the config translation.
+
 ## What this does NOT test
 
 - **Real Statsig evaluation.** This server is config-only; it never

--- a/skills/migrate-statsig/test-fixtures/README.md
+++ b/skills/migrate-statsig/test-fixtures/README.md
@@ -22,6 +22,15 @@ enum values, required fields, and pagination semantics
 If you suspect the fixtures have drifted from real Statsig, fetch that
 file fresh and diff against `server.py`.
 
+One thing the spec does NOT capture (verified against the live Console
+API): operators are validated **per condition type**. Notably,
+`str_starts_with_any` / `str_ends_with_any` are rejected for `email`,
+`custom_field`, `url`, `locale`, `user_agent`, and `browser_name` —
+suffix matching arrives as an anchored `str_matches` regex instead, and
+`custom_field` additionally accepts array operators
+(`array_contains_any/none/all`, `not_array_contains_all`). The fixtures
+only use type/operator combinations the live API accepts.
+
 ## Run
 
 Python 3.10+ stdlib, no dependencies.
@@ -75,7 +84,7 @@ Pick a throwaway Confidence client and map the `userID` unit to a
 
 | `id` | What it tests | Expected status |
 |---|---|---|
-| `internal_tools_gate` | `str_ends_with_any` → `endsWithRule` | Migrate |
+| `internal_tools_gate` | `str_matches` suffix regex (`.*@spotify\.com$`) → `endsWithRule` | Migrate |
 | `new_search_rollout` | `none` (NOT IN) → `setRule` + `not`, numeric `gte` → `rangeRule`, AND in one rule | Migrate |
 | `mobile_only_feature` | `os_name any` → `setRule`, `app_version version_gte` → `rangeRule` with `versionValue` | Migrate |
 | `gradual_rollout` | `public` "Everyone" at 25% → catch-all rule at 25% rollout | Migrate |
@@ -106,7 +115,7 @@ Pick a throwaway Confidence client and map the `userID` unit to a
 | `id` | Type | Targeting |
 |---|---|---|
 | `premium_users` | rule_based | `custom_field plan any [premium, enterprise]` |
-| `internal_staff` | rule_based | `email str_ends_with_any [@spotify.com]` |
+| `internal_staff` | rule_based | `email str_matches [.*@spotify\.com$]` |
 | `vip_user_list` | id_list (count 5000) | literal unit IDs → REST materialized segment (BigQuery) |
 
 The `rule_based` segments become reusable Confidence segments on the REST
@@ -136,7 +145,7 @@ After running `plan flags`, the generated plan file at
 - For `test_user_allowlist`, rewrite the `user_id` condition to a
   `setRule` on the chosen entity field
 - For `depends_on_gate`, inline the referenced `internal_tools_gate`
-  conditions (email ends with `@spotify.com`) — not BLOCKED
+  conditions (email matches `.*@spotify\.com$` → `endsWithRule`) — not BLOCKED
 - For `vip_gate`, mark `Backend: REST` and map the `vip_user_list`
   id_list segment to a materialized segment (or BLOCKED if no BigQuery)
 - For `homepage_config`, create one variant per `returnValue` plus a

--- a/skills/migrate-statsig/test-fixtures/README.md
+++ b/skills/migrate-statsig/test-fixtures/README.md
@@ -1,0 +1,150 @@
+# Fake Statsig Console API Server
+
+A local HTTP server that mimics Statsig's Console API for testing the
+`migrate-statsig` skill end-to-end without needing a Statsig account.
+
+The server is read-only and serves the read endpoints the skill calls
+(gates, dynamic configs, experiments, and segments). Fixtures are inline
+in `server.py` and chosen to exercise every branch of the skill's
+operator-mapping table — both the auto-migratable translations
+(SemVer, regex alternation, set membership, segment inlining) and the
+genuinely BLOCKED paths.
+
+## Schema source of truth
+
+JSON shapes are derived from Statsig's public OpenAPI 3.0 spec at
+<https://api.statsig.com/openapi/20240601.json> (publicly served, no
+auth, no account). It is the authoritative reference for field names,
+enum values, required fields, and pagination semantics
+(`ExternalGateDto`, `DynamicConfigDto`, `ExternalExperimentDto`,
+`SegmentDto`).
+
+If you suspect the fixtures have drifted from real Statsig, fetch that
+file fresh and diff against `server.py`.
+
+## Run
+
+Python 3.10+ stdlib, no dependencies.
+
+```bash
+python3 server.py
+# Fake Statsig Console API listening on http://127.0.0.1:4000
+#   10 gates, 1 dynamic config, 2 experiments, 2 segments
+```
+
+Override the port if 4000 is taken:
+
+```bash
+python3 server.py --port 4055
+```
+
+## Smoke test
+
+In another terminal:
+
+```bash
+export STATSIG_API_KEY=fake-key-for-testing
+curl -sS -H "STATSIG-API-KEY: $STATSIG_API_KEY" \
+  -H "STATSIG-API-VERSION: 20240601" \
+  "http://127.0.0.1:4000/console/v1/gates?limit=3&page=1" | jq
+```
+
+You should see three gate summaries plus a `pagination` block. If you
+forget the header, the server returns
+`401 {"message": "Missing STATSIG-API-KEY header"}`.
+
+## Drive the skill against this server
+
+In Claude Code / Cursor, with the server running:
+
+```
+export STATSIG_API_KEY=fake-key-for-testing
+```
+
+Then run `/migrate-statsig plan flags`. When the skill prompts you for
+the Statsig Console API base URL, answer:
+
+```
+http://127.0.0.1:4000
+```
+
+Pick a throwaway Confidence client and map the `userID` unit to a
+`user_id` entity field, confirm, and review the generated plan file.
+
+## Fixture gates and what each one tests
+
+| `id` | What it tests | Expected status |
+|---|---|---|
+| `internal_tools_gate` | `str_ends_with_any` → `endsWithRule` | Migrate |
+| `new_search_rollout` | `none` (NOT IN) → `setRule` + `not`, numeric `gte` → `rangeRule`, AND in one rule | Migrate |
+| `mobile_only_feature` | `os_name any` → `setRule`, `app_version version_gte` → `rangeRule` with `versionValue` | Migrate |
+| `gradual_rollout` | `public` "Everyone" at 25% → catch-all rule at 25% rollout | Migrate |
+| `legacy_checkout` | `isEnabled: false` → flag created OFF, rules at 0% rollout | Migrate (with warning) |
+| `non_prod_email_gate` | `str_matches` suffix alternation `.*@(test\|qa\|staging)\.com$` → one `endsWithRule` per branch, OR'd | Migrate |
+| `contains_blocked_gate` | `str_contains_any` → no Confidence substring rule | BLOCKED |
+| `depends_on_gate` | `passes_gate` → no cross-flag dependency | BLOCKED |
+| `premium_segment_gate` | `passes_segment` + `fails_segment` (both `rule_based`) → inline each segment's conditions | Migrate |
+| `test_user_allowlist` | `user_id any` → `setRule` on the chosen entity field | Migrate |
+| `old_onboarding_gate` | `status: Archived` → hidden from list unless opted in | Skipped (archived) |
+
+## Fixture dynamic configs
+
+| `id` | What it tests |
+|---|---|
+| `homepage_config` | Server-side `defaultValue` → catch-all variant; two country rules each with a distinct `returnValue` → one variant per return value |
+
+## Fixture experiments
+
+| `id` | What it tests |
+|---|---|
+| `checkout_button_experiment` | 50/50 groups, `allocation: 100` → ONE rule, variant split 50/50 |
+| `onboarding_flow_experiment` | 3 groups (34/33/33), `allocation: 50` → rule at 50% rollout, control fall-through catch-all; `inlineTargetingRules` (country US/CA); `layerID` set → layer note |
+
+## Fixture segments (rule_based → inlined)
+
+| `id` | Targeting |
+|---|---|
+| `premium_users` | `custom_field plan any [premium, enterprise]` |
+| `internal_staff` | `email str_ends_with_any [@spotify.com]` |
+
+These are inlined into `premium_segment_gate` because this plugin's
+Confidence MCP has no `createSegment` tool.
+
+## What a successful test looks like
+
+After running `plan flags`, the generated plan file at
+`.claude/plans/statsig-flag-migration-<date>.md` should:
+
+- Include the 10 non-archived gates, 1 dynamic config, and 2 experiments
+  in Section 4 (`old_onboarding_gate` is archived and excluded by default)
+- For `new_search_rollout`, render the rule as something like "country is
+  not DE and not FR AND appBuildNumber >= 28"
+- For `mobile_only_feature`, translate `app_version >= 1.2.0` as a
+  version range (not numeric)
+- For `non_prod_email_gate`, decompose the alternation into three
+  `endsWithRule`s (`@test.com`, `@qa.com`, `@staging.com`) OR'd together
+- For `gradual_rollout`, emit a catch-all rule at 25% rollout to `enabled`
+- For `legacy_checkout`, note "Enabled in Statsig: no" and warn rules go
+  in at 0% rollout
+- For `premium_segment_gate`, inline the `premium_users` conditions and
+  inline `internal_staff` wrapped in `not`
+- For `test_user_allowlist`, rewrite the `user_id` condition to a
+  `setRule` on the chosen entity field
+- For `homepage_config`, create one variant per `returnValue` plus a
+  default variant for `defaultValue`, and emit a final catch-all rule
+- For `onboarding_flow_experiment`, emit ONE rule at 50% rollout with the
+  three-way group split, restricted to US/CA, plus a layer note
+- Mark `contains_blocked_gate` and `depends_on_gate` as **BLOCKED** with
+  clear reasons. `execute` should refuse to proceed on these unless
+  they're `[x] Skip`'d
+
+## What this does NOT test
+
+- **Real Statsig evaluation.** This server is config-only; it never
+  decides "given user X, what value?". The migration translates
+  *configs*; post-migration evaluation happens on Confidence's side.
+- **Authentication semantics.** The server validates the header is
+  present but doesn't check the value, scope, or rate limits.
+- **Mutations.** All write methods (POST/PATCH/PUT/DELETE) return 405.
+  Migration is read-only on the Statsig side; writes happen against
+  Confidence.

--- a/skills/migrate-statsig/test-fixtures/README.md
+++ b/skills/migrate-statsig/test-fixtures/README.md
@@ -167,6 +167,36 @@ running server is needed. The random percentage dimension
 rather than simulated, since bucketing is a property of the hashing, not
 the config translation.
 
+## Seeding a real Statsig project (`seed_statsig.py`)
+
+To test end-to-end against **real** Statsig instead of this fake server,
+`seed_statsig.py` pushes the same fixtures into an actual Statsig project
+via the Console API (free tier is enough):
+
+1. Sign up at <https://statsig.com> and create a project (manual — the
+   signup flow can't be automated).
+2. Create a **Console API key with write access** under Project Settings
+   > API Keys (starts with `console-`).
+3. Seed:
+
+   ```bash
+   export STATSIG_API_KEY=console-...
+   python3 seed_statsig.py            # --dry-run to preview, --teardown to clean up
+   ```
+
+4. One manual step: the Console API cannot write `inlineTargetingRules`
+   (read-only as of API version 20240601), so add the inline rule to
+   `onboarding_flow_experiment` in the console UI: country is any of
+   [US, CA].
+
+Then run `/confidence:migrate-statsig plan flags` against
+`https://statsigapi.net` and compare the plan with
+`python3 verify_migration.py` — same expectations as the fake-server
+table above. Differences from the fake fixtures: experiment group IDs
+and `controlGroupID` are assigned by Statsig (Control is kept as the
+first group), and `status` values reflect the real lifecycle
+(experiments are started by the script).
+
 ## What this does NOT test
 
 - **Real Statsig evaluation.** This server is config-only; it never

--- a/skills/migrate-statsig/test-fixtures/seed_statsig.py
+++ b/skills/migrate-statsig/test-fixtures/seed_statsig.py
@@ -30,9 +30,12 @@ What gets seeded (mirrors server.py):
 
 KNOWN API LIMITATION — one manual step. The Console API cannot write
 `inlineTargetingRules` (read-only on ExternalExperimentDto; absent from
-the create/update DTOs as of API version 20240601). After seeding, add
-the inline targeting rule to `onboarding_flow_experiment` by hand in the
-console UI: country is any of [US, CA]. The script prints a reminder.
+the create/update DTOs as of API version 20240601). Experiments whose
+fixture carries inline targeting are therefore left UNSTARTED (targeting
+locks at start): add the rule in the console UI (for
+`onboarding_flow_experiment`: country is any of [US, CA]), then re-run
+this script to start them. If an experiment was already started, unlock
+it with `PUT /console/v1/experiments/{id}/reset`.
 """
 
 import argparse
@@ -191,6 +194,15 @@ def seed(api: Api, vip_count: int) -> int:
         ]
         if not step(api, f"experiment {exp['id']}", "POST", "/console/v1/experiments", body):
             failures += 1
+            continue
+        if exp.get("inlineTargetingRules"):
+            # Targeting locks once an experiment starts, and the API can't
+            # write inlineTargetingRules — leave it in `setup` so the rule
+            # can be added in the console UI first, then re-run this script
+            # (or PUT /{id}/start) to start it. A started experiment can be
+            # unlocked again with PUT /{id}/reset.
+            print(f"  ⏸ start {exp['id']} — SKIPPED: add the inline targeting "
+                  "rule in the console UI first, then re-run to start")
             continue
         if not step(api, f"  start {exp['id']}", "PUT",
                     f"/console/v1/experiments/{exp['id']}/start", {}):

--- a/skills/migrate-statsig/test-fixtures/seed_statsig.py
+++ b/skills/migrate-statsig/test-fixtures/seed_statsig.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Seed a real Statsig project with the migrate-statsig test fixtures.
+
+Pushes the fixtures defined in `server.py` into an actual Statsig project
+through the Console API, so the migration skill can be tested end-to-end
+against real Statsig (wire format, pagination, auth) instead of the fake
+server. Statsig's free tier is sufficient.
+
+Prerequisites:
+  * A Statsig account + project (console.statsig.com — manual signup).
+  * A Console API key with WRITE access (Project Settings > API Keys,
+    starts with `console-`), exported as STATSIG_API_KEY.
+
+Run:
+    export STATSIG_API_KEY=console-...
+    python3 seed_statsig.py             # create everything
+    python3 seed_statsig.py --dry-run   # print what would be created
+    python3 seed_statsig.py --teardown  # best-effort delete of seeded items
+
+What gets seeded (mirrors server.py):
+  * 3 segments  — premium_users / internal_staff (rule_based, with rules),
+                  vip_user_list (id_list, --vip-count generated ids)
+  * 1 layer     — onboarding_layer
+  * 12 gates    — including the disabled one (isEnabled false) and the
+                  archived one (created, then archived via /archive)
+  * 1 dynamic config — homepage_config (defaultValue + 2 rules)
+  * 2 experiments — created, then started (PUT /{id}/start → active);
+                  onboarding_flow_experiment is attached to the layer
+  * 1 holdout   — q1_holdout, attached to onboarding_flow_experiment
+
+KNOWN API LIMITATION — one manual step. The Console API cannot write
+`inlineTargetingRules` (read-only on ExternalExperimentDto; absent from
+the create/update DTOs as of API version 20240601). After seeding, add
+the inline targeting rule to `onboarding_flow_experiment` by hand in the
+console UI: country is any of [US, CA]. The script prints a reminder.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+from server import DYNAMIC_CONFIGS, EXPERIMENTS, GATES, SEGMENTS
+
+API_VERSION = "20240601"
+
+# Fields that exist on the read DTOs (and our fixtures) but are not
+# accepted (or not safe to send) on the create DTOs.
+GATE_CREATE_FIELDS = {"id", "name", "description", "idType", "isEnabled", "rules", "type", "tags"}
+CONFIG_CREATE_FIELDS = {"id", "name", "description", "idType", "isEnabled", "rules", "defaultValue"}
+EXPERIMENT_CREATE_FIELDS = {"id", "name", "description", "idType", "allocation", "layerID"}
+SEGMENT_CREATE_FIELDS = {"id", "name", "description", "idType", "type", "rules"}
+
+HOLDOUT = {
+    "id": "q1_holdout",
+    "name": "Q1 holdout",
+    "description": "Fixture holdout covering the onboarding experiment.",
+    "idType": "userID",
+    "passPercentage": 5,
+    "experimentIDs": ["onboarding_flow_experiment"],
+}
+
+LAYER = {
+    "id": "onboarding_layer",
+    "name": "Onboarding layer",
+    "description": "Fixture layer for onboarding experiments.",
+    "idType": "userID",
+}
+
+
+class Api:
+    def __init__(self, base: str, key: str, dry_run: bool):
+        self.base = base.rstrip("/")
+        self.key = key
+        self.dry_run = dry_run
+
+    def call(self, method: str, path: str, body: dict | None = None) -> tuple[int, Any]:
+        url = f"{self.base}{path}"
+        if self.dry_run:
+            print(f"  DRY-RUN {method} {path}"
+                  + (f" {json.dumps(body)[:120]}..." if body else ""))
+            return 200, {}
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("STATSIG-API-KEY", self.key)
+        req.add_header("STATSIG-API-VERSION", API_VERSION)
+        if data:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.status, json.loads(resp.read() or b"{}")
+        except urllib.error.HTTPError as e:
+            try:
+                payload = json.loads(e.read() or b"{}")
+            except json.JSONDecodeError:
+                payload = {}
+            return e.code, payload
+
+
+def step(api: Api, label: str, method: str, path: str, body: dict | None = None) -> bool:
+    """Run one API call; treat 'already exists' conflicts as a skip."""
+    code, payload = api.call(method, path, body)
+    if 200 <= code < 300:
+        print(f"  ✓ {label}")
+        return True
+    msg = str(payload.get("message", payload))[:160]
+    if code in (400, 409) and ("exist" in msg.lower() or "duplicate" in msg.lower()):
+        print(f"  ⊘ {label} — already exists, skipping")
+        return True
+    print(f"  ✗ {label} — HTTP {code}: {msg}")
+    return False
+
+
+def pick(d: dict, allowed: set) -> dict:
+    return {k: v for k, v in d.items() if k in allowed and v is not None}
+
+
+def seed(api: Api, vip_count: int) -> int:
+    failures = 0
+
+    print("\n## Segments")
+    for seg in SEGMENTS:
+        body = pick(seg, SEGMENT_CREATE_FIELDS)
+        if not step(api, f"segment {seg['id']} ({seg['type']})", "POST", "/console/v1/segments", body):
+            failures += 1
+            continue
+        if seg["type"] == "id_list":
+            ids = [f"vip-user-{i:05d}" for i in range(vip_count)]
+            for start in range(0, len(ids), 1000):  # add_ids caps at 1000/call
+                batch = ids[start : start + 1000]
+                if not step(api, f"  add_ids {seg['id']} [{start}..{start + len(batch)})",
+                            "PATCH", f"/console/v1/segments/{seg['id']}/add_ids", {"ids": batch}):
+                    failures += 1
+                    break
+
+    print("\n## Layer")
+    if not step(api, f"layer {LAYER['id']}", "POST", "/console/v1/layers",
+                {k: v for k, v in LAYER.items() if k != "id"} | {"id": LAYER["id"]}):
+        failures += 1
+
+    print("\n## Gates")
+    for gate in GATES:
+        body = pick(gate, GATE_CREATE_FIELDS)
+        if not step(api, f"gate {gate['id']}", "POST", "/console/v1/gates", body):
+            failures += 1
+            continue
+        if gate.get("status") in ("Archived", "archived"):
+            if not step(api, f"  archive {gate['id']}", "POST",
+                        f"/console/v1/gates/{gate['id']}/archive"):
+                failures += 1
+
+    print("\n## Dynamic configs")
+    for cfg in DYNAMIC_CONFIGS:
+        body = pick(cfg, CONFIG_CREATE_FIELDS)
+        if not step(api, f"dynamic config {cfg['id']}", "POST", "/console/v1/dynamic_configs", body):
+            failures += 1
+
+    print("\n## Experiments")
+    for exp in EXPERIMENTS:
+        body = pick(exp, EXPERIMENT_CREATE_FIELDS)
+        # Group ids are assigned by Statsig; send name/size/parameterValues
+        # only and keep Control first (Statsig defaults control to the
+        # first group, replacing the fixtures' controlGroupID).
+        body["groups"] = [
+            {"name": g["name"], "size": g["size"], "parameterValues": g["parameterValues"]}
+            for g in exp["groups"]
+        ]
+        if not step(api, f"experiment {exp['id']}", "POST", "/console/v1/experiments", body):
+            failures += 1
+            continue
+        if not step(api, f"  start {exp['id']}", "PUT",
+                    f"/console/v1/experiments/{exp['id']}/start", {}):
+            failures += 1
+
+    print("\n## Holdout")
+    if step(api, f"holdout {HOLDOUT['id']}", "POST", "/console/v1/holdouts",
+            {"id": HOLDOUT["id"], "name": HOLDOUT["name"],
+             "description": HOLDOUT["description"], "idType": HOLDOUT["idType"]}):
+        if not step(api, f"  attach {HOLDOUT['id']} → {HOLDOUT['experimentIDs']}", "PATCH",
+                    f"/console/v1/holdouts/{HOLDOUT['id']}",
+                    {"isEnabled": True, "passPercentage": HOLDOUT["passPercentage"],
+                     "experimentIDs": HOLDOUT["experimentIDs"]}):
+            failures += 1
+    else:
+        failures += 1
+
+    return failures
+
+
+def teardown(api: Api) -> None:
+    print("\n## Teardown (best-effort)")
+    for exp in EXPERIMENTS:
+        step(api, f"delete experiment {exp['id']}", "DELETE", f"/console/v1/experiments/{exp['id']}")
+    for cfg in DYNAMIC_CONFIGS:
+        step(api, f"delete dynamic config {cfg['id']}", "DELETE", f"/console/v1/dynamic_configs/{cfg['id']}")
+    for gate in GATES:
+        step(api, f"delete gate {gate['id']}", "DELETE", f"/console/v1/gates/{gate['id']}")
+    for seg in SEGMENTS:
+        step(api, f"delete segment {seg['id']}", "DELETE", f"/console/v1/segments/{seg['id']}")
+    step(api, f"delete holdout {HOLDOUT['id']}", "DELETE", f"/console/v1/holdouts/{HOLDOUT['id']}")
+    step(api, f"delete layer {LAYER['id']}", "DELETE", f"/console/v1/layers/{LAYER['id']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base", default="https://statsigapi.net",
+                        help="Console API base URL (default: %(default)s)")
+    parser.add_argument("--vip-count", type=int, default=5000,
+                        help="ids to upload into the vip_user_list id_list segment")
+    parser.add_argument("--dry-run", action="store_true", help="print calls without sending")
+    parser.add_argument("--teardown", action="store_true", help="delete the seeded items")
+    args = parser.parse_args()
+
+    key = os.environ.get("STATSIG_API_KEY", "")
+    if not key and not args.dry_run:
+        sys.exit("Set STATSIG_API_KEY to a Console API key with write access "
+                 "(Project Settings > API Keys; starts with 'console-').")
+    if key and not key.startswith("console-") and not args.dry_run:
+        print("WARNING: key does not start with 'console-' — this must be a "
+              "CONSOLE API key, not a server/client SDK key.\n")
+
+    api = Api(args.base, key, args.dry_run)
+
+    if args.teardown:
+        teardown(api)
+        return
+
+    failures = seed(api, args.vip_count)
+
+    print("\n" + "=" * 64)
+    if failures:
+        print(f"Done with {failures} failure(s) — see ✗ lines above.")
+    else:
+        print("All fixtures seeded.")
+    print("""
+MANUAL STEP (Console API can't write inlineTargetingRules):
+  In the Statsig console, open experiment `onboarding_flow_experiment`
+  and add an inline targeting rule: country is any of [US, CA].
+
+Then run the migration against real Statsig:
+  /confidence:migrate-statsig plan flags     (base URL: https://statsigapi.net)
+and diff the plan against `python3 verify_migration.py`.""")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/migrate-statsig/test-fixtures/seed_statsig.py
+++ b/skills/migrate-statsig/test-fixtures/seed_statsig.py
@@ -21,7 +21,7 @@ What gets seeded (mirrors server.py):
   * 3 segments  — premium_users / internal_staff (rule_based, with rules),
                   vip_user_list (id_list, --vip-count generated ids)
   * 1 layer     — onboarding_layer
-  * 12 gates    — including the disabled one (isEnabled false) and the
+  * 13 gates    — including the disabled one (isEnabled false) and the
                   archived one (created, then archived via /archive)
   * 1 dynamic config — homepage_config (defaultValue + 2 rules)
   * 2 experiments — created, then started (PUT /{id}/start → active);
@@ -54,7 +54,7 @@ API_VERSION = "20240601"
 # accepted (or not safe to send) on the create DTOs.
 GATE_CREATE_FIELDS = {"id", "name", "description", "idType", "isEnabled", "rules", "type", "tags"}
 CONFIG_CREATE_FIELDS = {"id", "name", "description", "idType", "isEnabled", "rules", "defaultValue"}
-EXPERIMENT_CREATE_FIELDS = {"id", "name", "description", "idType", "allocation", "layerID"}
+EXPERIMENT_CREATE_FIELDS = {"id", "name", "description", "idType", "allocation", "layerID", "targetingGateID"}
 SEGMENT_CREATE_FIELDS = {"id", "name", "description", "idType", "type", "rules"}
 
 HOLDOUT = {

--- a/skills/migrate-statsig/test-fixtures/seed_statsig.py
+++ b/skills/migrate-statsig/test-fixtures/seed_statsig.py
@@ -68,6 +68,9 @@ LAYER = {
     "name": "Onboarding layer",
     "description": "Fixture layer for onboarding experiments.",
     "idType": "userID",
+    # Experiments in a layer may only use parameters the layer defines;
+    # set via PATCH after create (LayerCreateContractDto has no params).
+    "parameters": [{"name": "flow", "type": "string", "defaultValue": "classic"}],
 }
 
 
@@ -106,16 +109,28 @@ def step(api: Api, label: str, method: str, path: str, body: dict | None = None)
     if 200 <= code < 300:
         print(f"  ✓ {label}")
         return True
-    msg = str(payload.get("message", payload))[:160]
-    if code in (400, 409) and ("exist" in msg.lower() or "duplicate" in msg.lower()):
+    detail = payload.get("errors") or payload.get("message") or payload
+    msg = json.dumps(detail) if not isinstance(detail, str) else detail
+    lower = msg.lower()
+    if code in (400, 409) and any(s in lower for s in ("already exists", "already in use", "already started", "duplicate")):
         print(f"  ⊘ {label} — already exists, skipping")
         return True
-    print(f"  ✗ {label} — HTTP {code}: {msg}")
+    print(f"  ✗ {label} — HTTP {code}: {msg[:300]}")
     return False
 
 
+def strip_nones(value: Any) -> Any:
+    """Drop None-valued keys recursively — the API rejects explicit nulls
+    (e.g. a public condition must omit operator/targetValue entirely)."""
+    if isinstance(value, dict):
+        return {k: strip_nones(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [strip_nones(v) for v in value]
+    return value
+
+
 def pick(d: dict, allowed: set) -> dict:
-    return {k: v for k, v in d.items() if k in allowed and v is not None}
+    return strip_nones({k: v for k, v in d.items() if k in allowed and v is not None})
 
 
 def seed(api: Api, vip_count: int) -> int:
@@ -124,21 +139,27 @@ def seed(api: Api, vip_count: int) -> int:
     print("\n## Segments")
     for seg in SEGMENTS:
         body = pick(seg, SEGMENT_CREATE_FIELDS)
+        if not body.get("rules"):
+            body.pop("rules", None)  # only rule_based segments may carry rules
         if not step(api, f"segment {seg['id']} ({seg['type']})", "POST", "/console/v1/segments", body):
             failures += 1
             continue
         if seg["type"] == "id_list":
+            # id_list segments upload via /id_list (max 100k ids per call);
+            # /add_ids is only for user_store_id_list segments.
             ids = [f"vip-user-{i:05d}" for i in range(vip_count)]
-            for start in range(0, len(ids), 1000):  # add_ids caps at 1000/call
-                batch = ids[start : start + 1000]
-                if not step(api, f"  add_ids {seg['id']} [{start}..{start + len(batch)})",
-                            "PATCH", f"/console/v1/segments/{seg['id']}/add_ids", {"ids": batch}):
-                    failures += 1
-                    break
+            if not step(api, f"  id_list upload {seg['id']} ({len(ids)} ids)",
+                        "PATCH", f"/console/v1/segments/{seg['id']}/id_list", {"ids": ids}):
+                failures += 1
 
     print("\n## Layer")
-    if not step(api, f"layer {LAYER['id']}", "POST", "/console/v1/layers",
-                {k: v for k, v in LAYER.items() if k != "id"} | {"id": LAYER["id"]}):
+    create = {k: v for k, v in LAYER.items() if k != "parameters"}
+    if step(api, f"layer {LAYER['id']}", "POST", "/console/v1/layers", create):
+        if not step(api, f"  parameters {LAYER['id']}", "PATCH",
+                    f"/console/v1/layers/{LAYER['id']}",
+                    {"parameters": LAYER["parameters"]}):
+            failures += 1
+    else:
         failures += 1
 
     print("\n## Gates")
@@ -148,8 +169,8 @@ def seed(api: Api, vip_count: int) -> int:
             failures += 1
             continue
         if gate.get("status") in ("Archived", "archived"):
-            if not step(api, f"  archive {gate['id']}", "POST",
-                        f"/console/v1/gates/{gate['id']}/archive"):
+            if not step(api, f"  archive {gate['id']}", "PUT",
+                        f"/console/v1/gates/{gate['id']}/archive", {}):
                 failures += 1
 
     print("\n## Dynamic configs")
@@ -179,10 +200,14 @@ def seed(api: Api, vip_count: int) -> int:
     if step(api, f"holdout {HOLDOUT['id']}", "POST", "/console/v1/holdouts",
             {"id": HOLDOUT["id"], "name": HOLDOUT["name"],
              "description": HOLDOUT["description"], "idType": HOLDOUT["idType"]}):
-        if not step(api, f"  attach {HOLDOUT['id']} → {HOLDOUT['experimentIDs']}", "PATCH",
+        # Full update (POST) replaces experimentIDs; PATCH appends and
+        # duplicates entries on re-runs.
+        if not step(api, f"  attach {HOLDOUT['id']} → {HOLDOUT['experimentIDs']}", "POST",
                     f"/console/v1/holdouts/{HOLDOUT['id']}",
                     {"isEnabled": True, "passPercentage": HOLDOUT["passPercentage"],
-                     "experimentIDs": HOLDOUT["experimentIDs"]}):
+                     "experimentIDs": HOLDOUT["experimentIDs"], "gateIDs": [],
+                     "layerIDs": [], "isGlobal": False, "targetingGateID": None,
+                     "description": HOLDOUT["description"]}):
             failures += 1
     else:
         failures += 1

--- a/skills/migrate-statsig/test-fixtures/server.py
+++ b/skills/migrate-statsig/test-fixtures/server.py
@@ -626,7 +626,7 @@ class Handler(BaseHTTPRequestHandler):
         m = ROUTE_LIST.match(path)
         if m:
             coll, kind = COLLECTIONS[m["coll"]]
-            include_archived = self._bool_param(query, "include_archived")
+            include_archived = self._bool_param(query, "includeArchived")
             limit = int(query.get("limit", [str(self.limit_default)])[0])
             page = int(query.get("page", ["1"])[0])
 

--- a/skills/migrate-statsig/test-fixtures/server.py
+++ b/skills/migrate-statsig/test-fixtures/server.py
@@ -344,7 +344,28 @@ GATES: list[dict[str, Any]] = [
             }
         ],
     },
-    # 12. Archived gate — hidden from list unless include archived opt-in.
+    # 12. Targeting gate referenced by onboarding_flow_experiment's
+    #     targetingGateID — its conditions get inlined into the experiment.
+    {
+        "id": "onboarding_na_targeting",
+        "name": "Onboarding NA targeting",
+        "description": "Targeting gate for the onboarding experiment: North America only.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "North America",
+                "id": "rule_na_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {"type": "country", "operator": "any", "targetValue": ["US", "CA"]}
+                ],
+            }
+        ],
+    },
+    # 13. Archived gate — hidden from list unless include archived opt-in.
     {
         "id": "old_onboarding_gate",
         "name": "Old onboarding gate",
@@ -422,7 +443,7 @@ EXPERIMENTS: list[dict[str, Any]] = [
         "status": "active",
         "allocation": 100,
         "controlGroupID": "grp_control",
-        "targetingGateID": None,
+        "targetingGateID": "",  # unset reads back as empty string, not null
         "layerID": None,
         # NB: unset inlineTargetingRules is ABSENT from the real payload
         "groups": [
@@ -450,21 +471,15 @@ EXPERIMENTS: list[dict[str, Any]] = [
         "status": "active",
         "allocation": 50,
         "controlGroupID": "grp_ob_control",
-        "targetingGateID": None,
+        # The modern Statsig console creates experiment targeting as a
+        # targeting GATE (inline rules are legacy and the Console API
+        # can't write them) — fetch the gate and inline its conditions.
+        "targetingGateID": "onboarding_na_targeting",
         "layerID": "onboarding_layer",
         # Observed live: the Console API returns duplicated holdoutIDs
         # entries (one attach → two list items). Readers must dedupe.
         "holdoutIDs": ["q1_holdout", "q1_holdout"],
-        "inlineTargetingRules": [
-            {
-                "name": "North America",
-                "id": "rule_ob_na",
-                "passPercentage": 100,
-                "conditions": [
-                    {"type": "country", "operator": "any", "targetValue": ["US", "CA"]}
-                ],
-            }
-        ],
+        # NB: unset inlineTargetingRules is ABSENT from the real payload
         "groups": [
             {
                 "name": "Control",

--- a/skills/migrate-statsig/test-fixtures/server.py
+++ b/skills/migrate-statsig/test-fixtures/server.py
@@ -18,8 +18,11 @@ fetch). Field names match `ExternalGateDto`, `DynamicConfigDto`,
 Notable conventions:
   * camelCase everywhere (`idType`, `passPercentage`, `isEnabled`, ...)
   * IDs are strings (e.g. "internal_tools_gate")
-  * A condition is { type, operator, targetValue, field?, customID? };
-    targetValue may be a scalar or an array
+  * A condition is { type, operator?, targetValue, field?, customID? };
+    a single targetValue is a SCALAR (string/number), multiple values an
+    array; numeric comparisons carry numbers, not numeric strings; and
+    passes_gate / passes_segment / fails_segment conditions have NO
+    operator key (all verified against the live Console API)
   * Gates are boolean (no explicit default — implicit false on no match)
   * Dynamic configs carry a server-side `defaultValue`
   * Experiments carry weighted `groups[]` + an `allocation` percent
@@ -71,7 +74,9 @@ def _meta(entity_id: str, kind: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 GATES: list[dict[str, Any]] = [
-    # 1. email ends-with → endsWithRule. Single rule, 100% pass.
+    # 1. email suffix via str_matches → endsWithRule. Single rule, 100% pass.
+    #    (The Console API rejects str_ends_with_any for `email` — suffix
+    #    matching arrives as an anchored str_matches regex in practice.)
     {
         "id": "internal_tools_gate",
         "name": "Internal tools gate",
@@ -88,8 +93,8 @@ GATES: list[dict[str, Any]] = [
                 "conditions": [
                     {
                         "type": "email",
-                        "operator": "str_ends_with_any",
-                        "targetValue": ["@spotify.com"],
+                        "operator": "str_matches",
+                        "targetValue": ".*@spotify\\.com$",  # single targetValue → scalar on the wire
                     }
                 ],
             }
@@ -119,7 +124,7 @@ GATES: list[dict[str, Any]] = [
                         "type": "custom_field",
                         "field": "appBuildNumber",
                         "operator": "gte",
-                        "targetValue": ["28"],
+                        "targetValue": 28,  # numerics come back as numbers, not strings
                     },
                 ],
             }
@@ -148,7 +153,7 @@ GATES: list[dict[str, Any]] = [
                     {
                         "type": "app_version",
                         "operator": "version_gte",
-                        "targetValue": ["1.2.0"],
+                        "targetValue": "1.2.0",
                     },
                 ],
             }
@@ -168,7 +173,7 @@ GATES: list[dict[str, Any]] = [
                 "name": "Everyone",
                 "id": "rule_gradual_1",
                 "passPercentage": 25,
-                "conditions": [{"type": "public", "operator": None, "targetValue": None}],
+                "conditions": [{"type": "public"}],  # real wire shape: no operator/targetValue keys
             }
         ],
     },
@@ -180,7 +185,7 @@ GATES: list[dict[str, Any]] = [
         "idType": "userID",
         "isEnabled": False,
         "status": "Disabled",
-        "type": "STALE",
+        "type": "TEMPORARY",
         "rules": [
             {
                 "name": "US cohort",
@@ -210,7 +215,7 @@ GATES: list[dict[str, Any]] = [
                     {
                         "type": "email",
                         "operator": "str_matches",
-                        "targetValue": [".*@(test|qa|staging)\\.com$"],
+                        "targetValue": ".*@(test|qa|staging)\\.com$",
                     }
                 ],
             }
@@ -256,9 +261,8 @@ GATES: list[dict[str, Any]] = [
                 "passPercentage": 100,
                 "conditions": [
                     {
-                        "type": "passes_gate",
-                        "operator": "any",
-                        "targetValue": ["internal_tools_gate"],
+                        "type": "passes_gate",  # no operator key on the wire
+                        "targetValue": "internal_tools_gate",
                     }
                 ],
             }
@@ -280,14 +284,12 @@ GATES: list[dict[str, Any]] = [
                 "passPercentage": 100,
                 "conditions": [
                     {
-                        "type": "passes_segment",
-                        "operator": "any",
-                        "targetValue": ["premium_users"],
+                        "type": "passes_segment",  # no operator key on the wire
+                        "targetValue": "premium_users",
                     },
                     {
                         "type": "fails_segment",
-                        "operator": "any",
-                        "targetValue": ["internal_staff"],
+                        "targetValue": "internal_staff",
                     },
                 ],
             }
@@ -336,8 +338,7 @@ GATES: list[dict[str, Any]] = [
                 "conditions": [
                     {
                         "type": "passes_segment",
-                        "operator": "any",
-                        "targetValue": ["vip_user_list"],
+                        "targetValue": "vip_user_list",
                     }
                 ],
             }
@@ -351,7 +352,7 @@ GATES: list[dict[str, Any]] = [
         "idType": "userID",
         "isEnabled": False,
         "status": "Archived",
-        "type": "STALE",
+        "type": "TEMPORARY",
         "rules": [
             {
                 "name": "US cohort",
@@ -423,7 +424,7 @@ EXPERIMENTS: list[dict[str, Any]] = [
         "controlGroupID": "grp_control",
         "targetingGateID": None,
         "layerID": None,
-        "inlineTargetingRules": [],
+        # NB: unset inlineTargetingRules is ABSENT from the real payload
         "groups": [
             {
                 "name": "Control",
@@ -451,7 +452,9 @@ EXPERIMENTS: list[dict[str, Any]] = [
         "controlGroupID": "grp_ob_control",
         "targetingGateID": None,
         "layerID": "onboarding_layer",
-        "holdoutIDs": ["q1_holdout"],
+        # Observed live: the Console API returns duplicated holdoutIDs
+        # entries (one attach → two list items). Readers must dedupe.
+        "holdoutIDs": ["q1_holdout", "q1_holdout"],
         "inlineTargetingRules": [
             {
                 "name": "North America",
@@ -529,8 +532,8 @@ SEGMENTS: list[dict[str, Any]] = [
                 "conditions": [
                     {
                         "type": "email",
-                        "operator": "str_ends_with_any",
-                        "targetValue": ["@spotify.com"],
+                        "operator": "str_matches",
+                        "targetValue": ".*@spotify\\.com$",
                     }
                 ],
             }

--- a/skills/migrate-statsig/test-fixtures/server.py
+++ b/skills/migrate-statsig/test-fixtures/server.py
@@ -317,7 +317,33 @@ GATES: list[dict[str, Any]] = [
             }
         ],
     },
-    # 11. Archived gate — hidden from list unless include archived opt-in.
+    # 11. References an id_list segment (`vip_user_list`, count 5000) →
+    #     REST materialized segment (BigQuery), or BLOCKED if REST/BQ
+    #     unavailable. Exercises the id_list path + REST backend selection.
+    {
+        "id": "vip_gate",
+        "name": "VIP gate",
+        "description": "Enable for users on the curated VIP id list.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "VIPs",
+                "id": "rule_vip_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "passes_segment",
+                        "operator": "any",
+                        "targetValue": ["vip_user_list"],
+                    }
+                ],
+            }
+        ],
+    },
+    # 12. Archived gate — hidden from list unless include archived opt-in.
     {
         "id": "old_onboarding_gate",
         "name": "Old onboarding gate",
@@ -425,6 +451,7 @@ EXPERIMENTS: list[dict[str, Any]] = [
         "controlGroupID": "grp_ob_control",
         "targetingGateID": None,
         "layerID": "onboarding_layer",
+        "holdoutIDs": ["q1_holdout"],
         "inlineTargetingRules": [
             {
                 "name": "North America",
@@ -509,6 +536,19 @@ SEGMENTS: list[dict[str, Any]] = [
             }
         ],
     },
+    # id_list segment — a literal list of unit IDs (no rules). Large lists
+    # map to a Confidence materialized segment (REST/BigQuery); small ones
+    # can inline as a setRule. `count` is the list length.
+    {
+        "id": "vip_user_list",
+        "name": "VIP user list",
+        "description": "Hand-curated VIP user IDs uploaded as an id list.",
+        "idType": "userID",
+        "isEnabled": True,
+        "type": "id_list",
+        "count": 5000,
+        "rules": [],
+    },
 ]
 
 
@@ -532,9 +572,8 @@ ROUTE_BY_ID = re.compile(
 
 
 def _full(item: dict[str, Any], kind: str) -> dict[str, Any]:
-    out = copy.deepcopy(item)
-    out.update(_meta(item["id"], kind))
-    return out
+    # Meta provides boilerplate defaults; fixture fields take precedence.
+    return {**_meta(item["id"], kind), **copy.deepcopy(item)}
 
 
 def _is_archived(item: dict[str, Any]) -> bool:

--- a/skills/migrate-statsig/test-fixtures/server.py
+++ b/skills/migrate-statsig/test-fixtures/server.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+"""Fake Statsig Console API server for testing the migrate-statsig skill.
+
+Implements the read endpoints the skill calls:
+  GET /console/v1/gates?limit=N&page=N
+  GET /console/v1/gates/{id}
+  GET /console/v1/dynamic_configs?limit=N&page=N
+  GET /console/v1/dynamic_configs/{id}
+  GET /console/v1/experiments?limit=N&page=N
+  GET /console/v1/experiments/{id}
+  GET /console/v1/segments/{id}
+
+JSON shapes are derived from Statsig's public OpenAPI 3.0 spec
+(<https://api.statsig.com/openapi/20240601.json>; no auth required to
+fetch). Field names match `ExternalGateDto`, `DynamicConfigDto`,
+`ExternalExperimentDto`, and `SegmentDto` as of API version 20240601.
+
+Notable conventions:
+  * camelCase everywhere (`idType`, `passPercentage`, `isEnabled`, ...)
+  * IDs are strings (e.g. "internal_tools_gate")
+  * A condition is { type, operator, targetValue, field?, customID? };
+    targetValue may be a scalar or an array
+  * Gates are boolean (no explicit default — implicit false on no match)
+  * Dynamic configs carry a server-side `defaultValue`
+  * Experiments carry weighted `groups[]` + an `allocation` percent
+  * List endpoints wrap results under `data` with a `pagination` object;
+    paginated via `page` (1-based) + `limit`
+
+Fixtures are curated to exercise every branch of the skill's
+operator-mapping table and BLOCKED markers — see README.md.
+
+Run:
+    python3 server.py [--port 4000] [--limit-default 50]
+"""
+
+import argparse
+import copy
+import json
+import re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+CREATED = 1705439406615
+MODIFIED = 1715439406750
+
+
+def _meta(entity_id: str, kind: str) -> dict[str, Any]:
+    """Common metadata fields shared by every entity type."""
+    return {
+        "lastModifierID": "4R5PV7mvYdW6NLCwK8ocoz",
+        "lastModifiedTime": MODIFIED,
+        "lastModifierName": "CONSOLE API",
+        "lastModifierEmail": None,
+        "creatorID": "4R5PV7mvYdW6NLCwK8ocoz",
+        "createdTime": CREATED,
+        "creatorName": "CONSOLE API",
+        "creatorEmail": None,
+        "targetApps": [],
+        "holdoutIDs": [],
+        "tags": [],
+        "team": None,
+        "teamID": None,
+        "version": 1,
+        "permalink": f"https://console.statsig.com/company/{kind}/{entity_id}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Feature gates (boolean)
+# ---------------------------------------------------------------------------
+
+GATES: list[dict[str, Any]] = [
+    # 1. email ends-with → endsWithRule. Single rule, 100% pass.
+    {
+        "id": "internal_tools_gate",
+        "name": "Internal tools gate",
+        "description": "Show internal tooling to Spotify employees only.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "Spotify employees",
+                "id": "rule_internal_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "email",
+                        "operator": "str_ends_with_any",
+                        "targetValue": ["@spotify.com"],
+                    }
+                ],
+            }
+        ],
+    },
+    # 2. country `none` (NOT IN) + custom_field numeric gte, ANDed in one rule.
+    {
+        "id": "new_search_rollout",
+        "name": "New search rollout",
+        "description": "Roll out new search outside DE/FR for app build 28+.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "TEMPORARY",
+        "rules": [
+            {
+                "name": "Eligible users",
+                "id": "rule_search_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "country",
+                        "operator": "none",
+                        "targetValue": ["DE", "FR"],
+                    },
+                    {
+                        "type": "custom_field",
+                        "field": "appBuildNumber",
+                        "operator": "gte",
+                        "targetValue": ["28"],
+                    },
+                ],
+            }
+        ],
+    },
+    # 3. os_name set membership + app_version version range, ANDed.
+    {
+        "id": "mobile_only_feature",
+        "name": "Mobile only feature",
+        "description": "iOS/Android users on app v1.2.0+.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "TEMPORARY",
+        "rules": [
+            {
+                "name": "Modern mobile clients",
+                "id": "rule_mobile_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "os_name",
+                        "operator": "any",
+                        "targetValue": ["iOS", "Android"],
+                    },
+                    {
+                        "type": "app_version",
+                        "operator": "version_gte",
+                        "targetValue": ["1.2.0"],
+                    },
+                ],
+            }
+        ],
+    },
+    # 4. Plain percentage rollout to "Everyone" (public), 25%.
+    {
+        "id": "gradual_rollout",
+        "name": "Gradual rollout",
+        "description": "25% rollout to all users.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "TEMPORARY",
+        "rules": [
+            {
+                "name": "Everyone",
+                "id": "rule_gradual_1",
+                "passPercentage": 25,
+                "conditions": [{"type": "public", "operator": None, "targetValue": None}],
+            }
+        ],
+    },
+    # 5. Disabled gate (isEnabled false) → migrate at 0% rollout.
+    {
+        "id": "legacy_checkout",
+        "name": "Legacy checkout",
+        "description": "Old experiment that's been turned off.",
+        "idType": "userID",
+        "isEnabled": False,
+        "status": "Disabled",
+        "type": "STALE",
+        "rules": [
+            {
+                "name": "US cohort",
+                "id": "rule_legacy_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {"type": "country", "operator": "any", "targetValue": ["US"]}
+                ],
+            }
+        ],
+    },
+    # 6. str_matches suffix alternation → one endsWithRule per branch, OR'd.
+    {
+        "id": "non_prod_email_gate",
+        "name": "Non-prod email gate",
+        "description": "Match test/qa/staging email domains.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "Non-prod emails",
+                "id": "rule_nonprod_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "email",
+                        "operator": "str_matches",
+                        "targetValue": [".*@(test|qa|staging)\\.com$"],
+                    }
+                ],
+            }
+        ],
+    },
+    # 7. str_contains_any → BLOCKED (Confidence has no substring rule).
+    {
+        "id": "contains_blocked_gate",
+        "name": "Contains blocked gate",
+        "description": "Email contains a substring — not migratable.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "Substring match",
+                "id": "rule_contains_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "email",
+                        "operator": "str_contains_any",
+                        "targetValue": ["statsig"],
+                    }
+                ],
+            }
+        ],
+    },
+    # 8. passes_gate → BLOCKED (no cross-flag dependency).
+    {
+        "id": "depends_on_gate",
+        "name": "Depends on another gate",
+        "description": "Only passes if another gate passes.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "Gated by ranking",
+                "id": "rule_depends_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "passes_gate",
+                        "operator": "any",
+                        "targetValue": ["internal_tools_gate"],
+                    }
+                ],
+            }
+        ],
+    },
+    # 9. passes_segment (rule_based) + fails_segment → inline both segments.
+    {
+        "id": "premium_segment_gate",
+        "name": "Premium segment gate",
+        "description": "In the Premium segment, excluding internal staff.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "Premium minus internal",
+                "id": "rule_premium_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "passes_segment",
+                        "operator": "any",
+                        "targetValue": ["premium_users"],
+                    },
+                    {
+                        "type": "fails_segment",
+                        "operator": "any",
+                        "targetValue": ["internal_staff"],
+                    },
+                ],
+            }
+        ],
+    },
+    # 10. user_id allowlist → setRule on the chosen entity field.
+    {
+        "id": "test_user_allowlist",
+        "name": "Test user allowlist",
+        "description": "Explicit list of test user IDs.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "type": "PERMANENT",
+        "rules": [
+            {
+                "name": "Test users",
+                "id": "rule_allowlist_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "user_id",
+                        "operator": "any",
+                        "targetValue": ["test-user-1", "test-user-2"],
+                    }
+                ],
+            }
+        ],
+    },
+    # 11. Archived gate — hidden from list unless include archived opt-in.
+    {
+        "id": "old_onboarding_gate",
+        "name": "Old onboarding gate",
+        "description": "Archived experiment from Q1.",
+        "idType": "userID",
+        "isEnabled": False,
+        "status": "Archived",
+        "type": "STALE",
+        "rules": [
+            {
+                "name": "US cohort",
+                "id": "rule_old_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {"type": "country", "operator": "any", "targetValue": ["US"]}
+                ],
+            }
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Dynamic configs (value objects with a server-side defaultValue)
+# ---------------------------------------------------------------------------
+
+DYNAMIC_CONFIGS: list[dict[str, Any]] = [
+    {
+        "id": "homepage_config",
+        "name": "Homepage config",
+        "description": "Homepage title and item count by country.",
+        "idType": "userID",
+        "isEnabled": True,
+        "status": "In Progress",
+        "defaultValue": {"title": "Welcome", "maxItems": 10},
+        "rules": [
+            {
+                "name": "US users",
+                "id": "rule_home_us",
+                "passPercentage": 100,
+                "conditions": [
+                    {"type": "country", "operator": "any", "targetValue": ["US"]}
+                ],
+                "returnValue": {"title": "Hi USA", "maxItems": 20},
+            },
+            {
+                "name": "EU users",
+                "id": "rule_home_eu",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "country",
+                        "operator": "any",
+                        "targetValue": ["DE", "FR", "SE"],
+                    }
+                ],
+                "returnValue": {"title": "Hallo EU", "maxItems": 15},
+            },
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Experiments (weighted groups + allocation)
+# ---------------------------------------------------------------------------
+
+EXPERIMENTS: list[dict[str, Any]] = [
+    # Simple 50/50 experiment, fully allocated.
+    {
+        "id": "checkout_button_experiment",
+        "name": "Checkout button experiment",
+        "description": "Test button color on checkout.",
+        "idType": "userID",
+        "status": "active",
+        "allocation": 100,
+        "controlGroupID": "grp_control",
+        "targetingGateID": None,
+        "layerID": None,
+        "inlineTargetingRules": [],
+        "groups": [
+            {
+                "name": "Control",
+                "id": "grp_control",
+                "size": 50,
+                "parameterValues": {"buttonColor": "blue"},
+            },
+            {
+                "name": "Treatment",
+                "id": "grp_treatment",
+                "size": 50,
+                "parameterValues": {"buttonColor": "green"},
+            },
+        ],
+    },
+    # 3-group experiment, allocation 50% (rest fall through to control value),
+    # with an inline targeting rule (country US/CA).
+    {
+        "id": "onboarding_flow_experiment",
+        "name": "Onboarding flow experiment",
+        "description": "Three onboarding variants, 50% allocated, NA only.",
+        "idType": "userID",
+        "status": "active",
+        "allocation": 50,
+        "controlGroupID": "grp_ob_control",
+        "targetingGateID": None,
+        "layerID": "onboarding_layer",
+        "inlineTargetingRules": [
+            {
+                "name": "North America",
+                "id": "rule_ob_na",
+                "passPercentage": 100,
+                "conditions": [
+                    {"type": "country", "operator": "any", "targetValue": ["US", "CA"]}
+                ],
+            }
+        ],
+        "groups": [
+            {
+                "name": "Control",
+                "id": "grp_ob_control",
+                "size": 34,
+                "parameterValues": {"flow": "classic"},
+            },
+            {
+                "name": "Variant A",
+                "id": "grp_ob_a",
+                "size": 33,
+                "parameterValues": {"flow": "guided"},
+            },
+            {
+                "name": "Variant B",
+                "id": "grp_ob_b",
+                "size": 33,
+                "parameterValues": {"flow": "minimal"},
+            },
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Segments (rule_based → inline; id_list → setRule or BLOCKED)
+# ---------------------------------------------------------------------------
+
+SEGMENTS: list[dict[str, Any]] = [
+    {
+        "id": "premium_users",
+        "name": "Premium users",
+        "description": "Subjects on a paid plan.",
+        "idType": "userID",
+        "isEnabled": True,
+        "type": "rule_based",
+        "rules": [
+            {
+                "name": "Paid plans",
+                "id": "seg_premium_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "custom_field",
+                        "field": "plan",
+                        "operator": "any",
+                        "targetValue": ["premium", "enterprise"],
+                    }
+                ],
+            }
+        ],
+    },
+    {
+        "id": "internal_staff",
+        "name": "Internal staff",
+        "description": "Spotify employees by email domain.",
+        "idType": "userID",
+        "isEnabled": True,
+        "type": "rule_based",
+        "rules": [
+            {
+                "name": "Spotify emails",
+                "id": "seg_internal_1",
+                "passPercentage": 100,
+                "conditions": [
+                    {
+                        "type": "email",
+                        "operator": "str_ends_with_any",
+                        "targetValue": ["@spotify.com"],
+                    }
+                ],
+            }
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer
+# ---------------------------------------------------------------------------
+
+COLLECTIONS: dict[str, tuple[list[dict[str, Any]], str]] = {
+    "gates": (GATES, "gate"),
+    "dynamic_configs": (DYNAMIC_CONFIGS, "dynamic_config"),
+    "experiments": (EXPERIMENTS, "experiment"),
+    "segments": (SEGMENTS, "segment"),
+}
+
+ARCHIVED_STATUSES = {"Archived", "archived"}
+
+ROUTE_LIST = re.compile(r"^/console/v1/(?P<coll>gates|dynamic_configs|experiments|segments)/?$")
+ROUTE_BY_ID = re.compile(
+    r"^/console/v1/(?P<coll>gates|dynamic_configs|experiments|segments)/(?P<id>[^/]+)/?$"
+)
+
+
+def _full(item: dict[str, Any], kind: str) -> dict[str, Any]:
+    out = copy.deepcopy(item)
+    out.update(_meta(item["id"], kind))
+    return out
+
+
+def _is_archived(item: dict[str, Any]) -> bool:
+    return item.get("status") in ARCHIVED_STATUSES
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "FakeStatsig/0.1"
+    limit_default = 50
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"  {self.address_string()} → {fmt % args}")
+
+    def _send(self, code: int, body: Any) -> None:
+        payload = json.dumps(body).encode() if body is not None else b""
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if payload:
+            self.wfile.write(payload)
+
+    def _check_auth(self) -> bool:
+        if not self.headers.get("STATSIG-API-KEY", ""):
+            self._send(401, {"message": "Missing STATSIG-API-KEY header", "data": None})
+            return False
+        return True
+
+    def _bool_param(self, query: dict[str, list[str]], name: str) -> bool:
+        return name in query and query[name][0].lower() in ("true", "1", "yes")
+
+    def do_GET(self) -> None:  # noqa: N802
+        if not self._check_auth():
+            return
+
+        parsed = urlparse(self.path)
+        path = parsed.path
+        query = parse_qs(parsed.query)
+
+        m = ROUTE_BY_ID.match(path)
+        if m:
+            coll, kind = COLLECTIONS[m["coll"]]
+            item = next((x for x in coll if x["id"] == m["id"]), None)
+            if item is None:
+                self._send(404, {"message": f"{m['coll']} {m['id']} not found", "data": None})
+                return
+            self._send(200, {"message": f"{m['coll']} read successfully.", "data": _full(item, kind)})
+            return
+
+        m = ROUTE_LIST.match(path)
+        if m:
+            coll, kind = COLLECTIONS[m["coll"]]
+            include_archived = self._bool_param(query, "include_archived")
+            limit = int(query.get("limit", [str(self.limit_default)])[0])
+            page = int(query.get("page", ["1"])[0])
+
+            visible = [x for x in coll if include_archived or not _is_archived(x)]
+            total = len(visible)
+            start = (page - 1) * limit
+            window = visible[start : start + limit]
+            next_page = str(page + 1) if start + limit < total else None
+            prev_page = str(page - 1) if page > 1 else None
+
+            self._send(
+                200,
+                {
+                    "message": f"{m['coll']} listed successfully.",
+                    "data": [_full(x, kind) for x in window],
+                    "pagination": {
+                        "itemsPerPage": limit,
+                        "pageNumber": page,
+                        "totalItems": total,
+                        "nextPage": next_page,
+                        "previousPage": prev_page,
+                    },
+                },
+            )
+            return
+
+        self._send(404, {"message": f"No route for {path}", "data": None})
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._send(405, {"message": "This fake server is read-only", "data": None})
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._send(405, {"message": "This fake server is read-only", "data": None})
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        self._send(405, {"message": "This fake server is read-only", "data": None})
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._send(405, {"message": "This fake server is read-only", "data": None})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=4000)
+    parser.add_argument("--limit-default", type=int, default=50)
+    args = parser.parse_args()
+
+    Handler.limit_default = args.limit_default
+    server = HTTPServer(("127.0.0.1", args.port), Handler)
+    base = f"http://127.0.0.1:{args.port}"
+    print(f"Fake Statsig Console API listening on {base}")
+    print(
+        f"  {len(GATES)} gates, {len(DYNAMIC_CONFIGS)} dynamic configs, "
+        f"{len(EXPERIMENTS)} experiments, {len(SEGMENTS)} segments"
+    )
+    print("  Point the migrate-statsig skill at this base URL when prompted.")
+    print("  Set STATSIG_API_KEY to anything (any non-empty value passes).")
+    print("  Press Ctrl+C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/migrate-statsig/test-fixtures/verify_migration.py
+++ b/skills/migrate-statsig/test-fixtures/verify_migration.py
@@ -267,7 +267,9 @@ def main() -> None:
     for exp in EXPERIMENTS:
         groups = ", ".join(f"{g['name']}={g['size']}%" for g in exp["groups"])
         itr = exp.get("inlineTargetingRules") or []  # key is absent when unset
-        targ = "all" if not itr else "inline-targeted"
+        tgate = GATES_BY_ID.get(exp["targetingGateID"]) if exp.get("targetingGateID") else None
+        targ = ("inline-targeted" if itr else
+                f"gate:{tgate['id']}" if tgate else "all")
         print(f"  {exp['id']}")
         print(f"      allocation={exp['allocation']}%  groups=[{groups}]  targeting={targ}")
         if exp["allocation"] < 100:
@@ -282,6 +284,8 @@ def main() -> None:
                   "(surface step)")
         for cname, ctx in CONTEXTS.items():
             eligible = eval_rules(itr, ctx, ENTITY) is not None if itr else True
+            if eligible and tgate:  # targetingGateID restricts entry like passes_gate
+                eligible = eval_rules(tgate["rules"], ctx, ENTITY) is not None
             print(f"      {cname:<16} -> {'in-experiment' if eligible else 'control (untargeted)'}")
 
     print("\nDone. Compare these against Confidence resolveFlag output.")

--- a/skills/migrate-statsig/test-fixtures/verify_migration.py
+++ b/skills/migrate-statsig/test-fixtures/verify_migration.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Model Statsig's evaluation over the fixtures to produce a ground-truth matrix.
+
+This computes, locally and with no network, what each fixture
+gate/dynamic-config/experiment is expected to return for a set of test
+contexts. Use it to spot-check that Confidence resolves (after running
+`/migrate-statsig execute`) match Statsig for the same context.
+
+It deliberately models the **deterministic** part of evaluation:
+condition matching and the waterfall. The random percentage dimension
+(passPercentage / group size / allocation) is reported as metadata, not
+simulated — bucketing is stable per unit ID but its exact split is a
+property of the hashing, not the translation, so the matrix reports the
+pass-eligible variant(s) and their configured split.
+
+Run:
+    python3 verify_migration.py
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from server import DYNAMIC_CONFIGS, EXPERIMENTS, GATES, SEGMENTS
+
+SEGMENTS_BY_ID = {s["id"]: s for s in SEGMENTS}
+
+
+# ---------------------------------------------------------------------------
+# Condition / operator evaluation (the same surface the skill translates)
+# ---------------------------------------------------------------------------
+
+# Operators that have no clean Confidence translation. A condition using
+# one of these makes the whole rule (and usually the flag) BLOCKED.
+BLOCKED_OPERATORS = {"str_contains_any", "str_contains_none"}
+BLOCKED_TYPES = {"passes_gate", "fails_gate", "experiment_group", "javascript"}
+
+
+class Blocked(Exception):
+    """Raised when a condition cannot be migrated/evaluated."""
+
+
+def _as_list(v: Any) -> list[Any]:
+    if v is None:
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+def _ver_tuple(s: str) -> tuple[int, ...]:
+    s = s.split("-", 1)[0]
+    return tuple(int(p) for p in s.split("."))
+
+
+def _regex_alternation_ok(pattern: str) -> bool:
+    """True if a str_matches value is a prefix/suffix/alternation we can map."""
+    body = pattern
+    anchored_end = body.endswith("$")
+    anchored_start = body.startswith("^")
+    body = body.lstrip("^").rstrip("$")
+    body = re.sub(r"^\.\*", "", body)
+    body = re.sub(r"\.\*$", "", body)
+    # Allow one (a|b|c) group plus literal text (escaped dots ok).
+    stripped = re.sub(r"\([^()]*\)", "", body).replace("\\.", "")
+    return (anchored_start or anchored_end) and not re.search(r"[\[\]+?{}\\]", stripped)
+
+
+def eval_condition(cond: dict[str, Any], ctx: dict[str, Any], entity_value: str) -> bool:
+    ctype = cond.get("type")
+    op = cond.get("operator")
+    targets = _as_list(cond.get("targetValue"))
+
+    if ctype in BLOCKED_TYPES or op in BLOCKED_OPERATORS:
+        raise Blocked(f"{ctype}/{op}")
+
+    if ctype == "public":
+        return True
+
+    if ctype in ("passes_segment", "fails_segment"):
+        seg = SEGMENTS_BY_ID.get(targets[0])
+        if seg is None:
+            raise Blocked(f"unknown segment {targets[0]}")
+        in_seg = eval_rules(seg["rules"], ctx, entity_value) is not None
+        return in_seg if ctype == "passes_segment" else not in_seg
+
+    # Pick the value from context. user_id/unit_id read the entity value.
+    if ctype in ("user_id", "unit_id"):
+        value = entity_value
+    elif ctype == "custom_field":
+        value = ctx.get(cond.get("field"))
+    elif ctype == "os_name":
+        value = ctx.get("os")
+    elif ctype == "app_version":
+        value = ctx.get("appVersion")
+    else:
+        value = ctx.get(ctype)
+
+    if op in ("any", "any_case_sensitive"):
+        return value in targets
+    if op in ("none", "none_case_sensitive"):
+        return value not in targets
+    if op == "eq":
+        return value == targets[0]
+    if op == "neq":
+        return value != targets[0]
+    if op in ("gt", "gte", "lt", "lte"):
+        if value is None:
+            return False
+        v, t = float(value), float(targets[0])
+        return {"gt": v > t, "gte": v >= t, "lt": v < t, "lte": v <= t}[op]
+    if op in ("version_gt", "version_gte", "version_lt", "version_lte", "version_eq", "version_neq"):
+        if value is None:
+            return False
+        v, t = _ver_tuple(str(value)), _ver_tuple(targets[0])
+        return {
+            "version_gt": v > t,
+            "version_gte": v >= t,
+            "version_lt": v < t,
+            "version_lte": v <= t,
+            "version_eq": v == t,
+            "version_neq": v != t,
+        }[op]
+    if op == "str_starts_with_any":
+        return any(str(value).startswith(t) for t in targets) if value is not None else False
+    if op == "str_ends_with_any":
+        return any(str(value).endswith(t) for t in targets) if value is not None else False
+    if op == "str_matches":
+        if not _regex_alternation_ok(targets[0]):
+            raise Blocked(f"generic regex {targets[0]}")
+        return re.search(targets[0], str(value)) is not None if value is not None else False
+
+    raise Blocked(f"unhandled operator {op}")
+
+
+def eval_rules(rules: list[dict[str, Any]], ctx: dict[str, Any], entity_value: str) -> dict | None:
+    """Return the first matching rule (waterfall), or None if no rule matches."""
+    for rule in rules:
+        try:
+            if all(eval_condition(c, ctx, entity_value) for c in rule["conditions"]):
+                return rule
+        except Blocked:
+            continue
+    return None
+
+
+def flag_is_blocked(rules: list[dict[str, Any]]) -> str | None:
+    """Return a reason if every non-trivial rule is blocked, else None."""
+    reasons = []
+    any_ok = False
+    for rule in rules:
+        try:
+            for c in rule["conditions"]:
+                # Probe each condition for migratability with a dummy ctx.
+                eval_condition(c, {}, "")
+            any_ok = True
+        except Blocked as b:
+            reasons.append(str(b))
+    return None if any_ok else (reasons[0] if reasons else "all rules blocked")
+
+
+# ---------------------------------------------------------------------------
+# Test contexts
+# ---------------------------------------------------------------------------
+
+CONTEXTS: dict[str, dict[str, Any]] = {
+    "spotify-emp": {"email": "emp@spotify.com", "country": "US", "appBuildNumber": 30},
+    "us-newbuild": {"country": "US", "appBuildNumber": 30},
+    "de-newbuild": {"country": "DE", "appBuildNumber": 30},
+    "us-oldbuild": {"country": "US", "appBuildNumber": 20},
+    "ios-1.3": {"os": "iOS", "appVersion": "1.3.0"},
+    "ios-1.1": {"os": "iOS", "appVersion": "1.1.0"},
+    "qa-email": {"email": "x@qa.com"},
+    "premium-gmail": {"plan": "premium", "email": "u@gmail.com"},
+    "premium-spotify": {"plan": "premium", "email": "u@spotify.com"},
+    "free-jp": {"plan": "free", "country": "JP"},
+}
+
+ENTITY = "test-user-1"  # exercises the user_id allowlist gate
+
+
+def main() -> None:
+    print("=" * 72)
+    print("Statsig fixture evaluation — ground-truth matrix")
+    print("=" * 72)
+
+    print("\n## Feature gates (boolean) — first matching rule, or default false\n")
+    for gate in GATES:
+        if gate.get("status") in ("Archived", "archived"):
+            print(f"  {gate['id']:<26} ARCHIVED (excluded from default scan)")
+            continue
+        blocked = flag_is_blocked(gate["rules"])
+        if blocked:
+            print(f"  {gate['id']:<26} BLOCKED ({blocked})")
+            continue
+        cells = []
+        for cname, ctx in CONTEXTS.items():
+            rule = eval_rules(gate["rules"], ctx, ENTITY)
+            if rule is None:
+                cells.append(f"{cname}=off")
+            else:
+                pp = rule["passPercentage"]
+                cells.append(f"{cname}={'on' if pp else 'off'}@{pp}%")
+        print(f"  {gate['id']:<26}")
+        for c in cells:
+            if "=on" in c or "off@" in c:
+                print(f"      {c}")
+
+    print("\n## Dynamic configs — returned variant value (or defaultValue)\n")
+    for cfg in DYNAMIC_CONFIGS:
+        print(f"  {cfg['id']}  (default={cfg['defaultValue']})")
+        for cname, ctx in CONTEXTS.items():
+            rule = eval_rules(cfg["rules"], ctx, ENTITY)
+            val = rule["returnValue"] if rule else cfg["defaultValue"]
+            print(f"      {cname:<16} -> {val}")
+
+    print("\n## Experiments — group split + allocation + targeting\n")
+    for exp in EXPERIMENTS:
+        groups = ", ".join(f"{g['name']}={g['size']}%" for g in exp["groups"])
+        targ = "all" if not exp["inlineTargetingRules"] else "inline-targeted"
+        print(f"  {exp['id']}")
+        print(f"      allocation={exp['allocation']}%  groups=[{groups}]  targeting={targ}")
+        if exp["allocation"] < 100:
+            print("      NOTE: allocation < 100 — not exactly representable; "
+                  "approximate or flag for review")
+        if exp["layerID"]:
+            print(f"      NOTE: belongs to layer '{exp['layerID']}' (no Confidence layer primitive)")
+        for cname, ctx in CONTEXTS.items():
+            rule = eval_rules(exp["inlineTargetingRules"], ctx, ENTITY) if exp["inlineTargetingRules"] else True
+            eligible = rule is not None if exp["inlineTargetingRules"] else True
+            print(f"      {cname:<16} -> {'in-experiment' if eligible else 'control (untargeted)'}")
+
+    print("\nDone. Compare these against Confidence resolveFlag output.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/migrate-statsig/test-fixtures/verify_migration.py
+++ b/skills/migrate-statsig/test-fixtures/verify_migration.py
@@ -266,7 +266,8 @@ def main() -> None:
     print("\n## Experiments — group split + allocation + targeting\n")
     for exp in EXPERIMENTS:
         groups = ", ".join(f"{g['name']}={g['size']}%" for g in exp["groups"])
-        targ = "all" if not exp["inlineTargetingRules"] else "inline-targeted"
+        itr = exp.get("inlineTargetingRules") or []  # key is absent when unset
+        targ = "all" if not itr else "inline-targeted"
         print(f"  {exp['id']}")
         print(f"      allocation={exp['allocation']}%  groups=[{groups}]  targeting={targ}")
         if exp["allocation"] < 100:
@@ -275,12 +276,12 @@ def main() -> None:
         if exp["layerID"]:
             print(f"      NOTE: layer '{exp['layerID']}' → REST exclusivity group "
                   "(exclusivityTags)")
-        if exp.get("holdoutIDs"):
-            print(f"      NOTE: holdouts {exp['holdoutIDs']} → Confidence holdback "
+        holdouts = list(dict.fromkeys(exp.get("holdoutIDs") or []))  # live API duplicates entries
+        if holdouts:
+            print(f"      NOTE: holdouts {holdouts} → Confidence holdback "
                   "(surface step)")
         for cname, ctx in CONTEXTS.items():
-            rule = eval_rules(exp["inlineTargetingRules"], ctx, ENTITY) if exp["inlineTargetingRules"] else True
-            eligible = rule is not None if exp["inlineTargetingRules"] else True
+            eligible = eval_rules(itr, ctx, ENTITY) is not None if itr else True
             print(f"      {cname:<16} -> {'in-experiment' if eligible else 'control (untargeted)'}")
 
     print("\nDone. Compare these against Confidence resolveFlag output.")

--- a/skills/migrate-statsig/test-fixtures/verify_migration.py
+++ b/skills/migrate-statsig/test-fixtures/verify_migration.py
@@ -56,16 +56,27 @@ def _ver_tuple(s: str) -> tuple[int, ...]:
 
 
 def _regex_alternation_ok(pattern: str) -> bool:
-    """True if a str_matches value is a prefix/suffix/alternation we can map."""
+    """True if a str_matches value is a prefix/suffix/alternation we can map.
+
+    Mirrors the skill's decomposition rule: after stripping anchors and
+    leading/trailing `.*`, the remainder must be literal text (escaped
+    dots ok) with at most ONE alternation group of literals — no other
+    regex metacharacters (`.` as wildcard, quantifiers, classes, ...).
+    """
+    metachars = r"[\[\]+?{}\\.*]"  # checked after removing `\.` escapes
     body = pattern
     anchored_end = body.endswith("$")
     anchored_start = body.startswith("^")
     body = body.lstrip("^").rstrip("$")
     body = re.sub(r"^\.\*", "", body)
     body = re.sub(r"\.\*$", "", body)
-    # Allow one (a|b|c) group plus literal text (escaped dots ok).
+    groups = re.findall(r"\(([^()]*)\)", body)
+    if len(groups) > 1:
+        return False
+    if any(re.search(metachars, g.replace("\\.", "")) for g in groups):
+        return False
     stripped = re.sub(r"\([^()]*\)", "", body).replace("\\.", "")
-    return (anchored_start or anchored_end) and not re.search(r"[\[\]+?{}\\]", stripped)
+    return (anchored_start or anchored_end) and not re.search(metachars, stripped)
 
 
 def eval_condition(cond: dict[str, Any], ctx: dict[str, Any], entity_value: str) -> bool:
@@ -85,6 +96,9 @@ def eval_condition(cond: dict[str, Any], ctx: dict[str, Any], entity_value: str)
             raise Blocked(f"unknown segment {targets[0]}")
         if seg.get("type") in ("id_list", "user_store_id_list"):
             raise Blocked(f"id_list segment {seg['id']} (REST materialized)")
+        if seg.get("type") != "rule_based":
+            # e.g. analysis_list — analysis-only audience, no Confidence equivalent
+            raise Blocked(f"{seg.get('type')} segment {seg['id']}")
         in_seg = eval_rules(seg["rules"], ctx, entity_value) is not None
         return in_seg if ctype == "passes_segment" else not in_seg
 
@@ -211,6 +225,10 @@ def main() -> None:
         if gate.get("status") in ("Archived", "archived"):
             print(f"  {gate['id']:<26} ARCHIVED (excluded from default scan)")
             continue
+        if not gate.get("isEnabled", True):
+            print(f"  {gate['id']:<26} DISABLED in Statsig (false for every "
+                  "context; migrates OFF — rules at 0%)")
+            continue
         id_list = references_id_list(gate["rules"])
         if id_list:
             print(f"  {gate['id']:<26} REST backend (id_list segment "
@@ -236,6 +254,10 @@ def main() -> None:
     print("\n## Dynamic configs — returned variant value (or defaultValue)\n")
     for cfg in DYNAMIC_CONFIGS:
         print(f"  {cfg['id']}  (default={cfg['defaultValue']})")
+        if not cfg.get("isEnabled", True):
+            print("      DISABLED in Statsig (defaultValue for every context; "
+                  "migrates OFF — rules at 0%)")
+            continue
         for cname, ctx in CONTEXTS.items():
             rule = eval_rules(cfg["rules"], ctx, ENTITY)
             val = rule["returnValue"] if rule else cfg["defaultValue"]

--- a/skills/migrate-statsig/test-fixtures/verify_migration.py
+++ b/skills/migrate-statsig/test-fixtures/verify_migration.py
@@ -25,6 +25,7 @@ from typing import Any
 from server import DYNAMIC_CONFIGS, EXPERIMENTS, GATES, SEGMENTS
 
 SEGMENTS_BY_ID = {s["id"]: s for s in SEGMENTS}
+GATES_BY_ID = {g["id"]: g for g in GATES}
 
 
 # ---------------------------------------------------------------------------
@@ -33,8 +34,10 @@ SEGMENTS_BY_ID = {s["id"]: s for s in SEGMENTS}
 
 # Operators that have no clean Confidence translation. A condition using
 # one of these makes the whole rule (and usually the flag) BLOCKED.
+# passes_gate/fails_gate are NOT blocked — the referenced gate's
+# conditions can be inlined (modeled below).
 BLOCKED_OPERATORS = {"str_contains_any", "str_contains_none"}
-BLOCKED_TYPES = {"passes_gate", "fails_gate", "experiment_group", "javascript"}
+BLOCKED_TYPES = {"experiment_group", "javascript"}
 
 
 class Blocked(Exception):
@@ -80,8 +83,17 @@ def eval_condition(cond: dict[str, Any], ctx: dict[str, Any], entity_value: str)
         seg = SEGMENTS_BY_ID.get(targets[0])
         if seg is None:
             raise Blocked(f"unknown segment {targets[0]}")
+        if seg.get("type") in ("id_list", "user_store_id_list"):
+            raise Blocked(f"id_list segment {seg['id']} (REST materialized)")
         in_seg = eval_rules(seg["rules"], ctx, entity_value) is not None
         return in_seg if ctype == "passes_segment" else not in_seg
+
+    if ctype in ("passes_gate", "fails_gate"):
+        gate = GATES_BY_ID.get(targets[0])
+        if gate is None:
+            raise Blocked(f"unknown gate {targets[0]}")
+        passes = eval_rules(gate["rules"], ctx, entity_value) is not None
+        return passes if ctype == "passes_gate" else not passes
 
     # Pick the value from context. user_id/unit_id read the entity value.
     if ctype in ("user_id", "unit_id"):
@@ -143,6 +155,17 @@ def eval_rules(rules: list[dict[str, Any]], ctx: dict[str, Any], entity_value: s
     return None
 
 
+def references_id_list(rules: list[dict[str, Any]]) -> str | None:
+    """Return the id_list segment id a rule references (REST/materialized), else None."""
+    for rule in rules:
+        for c in rule.get("conditions", []):
+            if c.get("type") in ("passes_segment", "fails_segment"):
+                seg = SEGMENTS_BY_ID.get(_as_list(c.get("targetValue"))[0])
+                if seg and seg.get("type") in ("id_list", "user_store_id_list"):
+                    return seg["id"]
+    return None
+
+
 def flag_is_blocked(rules: list[dict[str, Any]]) -> str | None:
     """Return a reason if every non-trivial rule is blocked, else None."""
     reasons = []
@@ -188,6 +211,11 @@ def main() -> None:
         if gate.get("status") in ("Archived", "archived"):
             print(f"  {gate['id']:<26} ARCHIVED (excluded from default scan)")
             continue
+        id_list = references_id_list(gate["rules"])
+        if id_list:
+            print(f"  {gate['id']:<26} REST backend (id_list segment "
+                  f"'{id_list}' → materialized segment / BigQuery)")
+            continue
         blocked = flag_is_blocked(gate["rules"])
         if blocked:
             print(f"  {gate['id']:<26} BLOCKED ({blocked})")
@@ -220,10 +248,14 @@ def main() -> None:
         print(f"  {exp['id']}")
         print(f"      allocation={exp['allocation']}%  groups=[{groups}]  targeting={targ}")
         if exp["allocation"] < 100:
-            print("      NOTE: allocation < 100 — not exactly representable; "
-                  "approximate or flag for review")
+            print("      NOTE: allocation < 100 — exact via REST segment proportion "
+                  f"({exp['allocation'] / 100}); MCP can only approximate")
         if exp["layerID"]:
-            print(f"      NOTE: belongs to layer '{exp['layerID']}' (no Confidence layer primitive)")
+            print(f"      NOTE: layer '{exp['layerID']}' → REST exclusivity group "
+                  "(exclusivityTags)")
+        if exp.get("holdoutIDs"):
+            print(f"      NOTE: holdouts {exp['holdoutIDs']} → Confidence holdback "
+                  "(surface step)")
         for cname, ctx in CONTEXTS.items():
             rule = eval_rules(exp["inlineTargetingRules"], ctx, ENTITY) if exp["inlineTargetingRules"] else True
             eligible = rule is not None if exp["inlineTargetingRules"] else True


### PR DESCRIPTION
## Summary

Adds a self-contained **Statsig → Confidence** migration skill for **Phase 1 — flag definitions** (Phase 2 — code transformation — follows in a separate PR next week, preserved on the `statsig-phase2` branch).

- Reads Statsig's Console API (`statsigapi.net`) and maps the three Statsig types to Confidence: feature gates → boolean flags, dynamic configs → struct flags with a server `defaultValue`, experiments → flags with weighted groups + allocation.
- Two Confidence-side execution backends, **both live-tested**:
  - **MCP** (default) — gates, configs, and fully-allocated experiments.
  - **REST API** (`flags.confidence.dev/v1`) — partial allocation, reusable/composed/materialized segments, layer exclusivity.

## Testing — full end-to-end against real infrastructure

1. **Fake-server fixtures** (`test-fixtures/server.py`): wire format verified field-by-field against Statsig's published OpenAPI spec AND against a live Statsig project (free tier, seeded via `test-fixtures/seed_statsig.py`). Live probing corrected several spec-invisible behaviors now encoded in the fixtures: per-type operator validation (no `str_ends_with_any` on email — suffix targeting arrives as `str_matches`), scalar vs array `targetValue`, no `operator` key on gate/segment conditions, duplicated `holdoutIDs` entries, `targetingGateID` as the modern console's experiment-targeting path.
2. **Phase 1 executed end-to-end**: real Statsig project → real Confidence project. **13/13 migratable flags created; 24/24 deterministic resolve checks match the `verify_migration.py` ground truth** (positive, negative, and waterfall cases). Both BLOCKED fixtures correctly refused.
3. **REST recipes validated live** (previously doc-grounded only): segment `allocation.proportion` 0.5, `exclusivityTags`, `:allocate`, bucket-range rules, rule `priority` + enable PATCH, and segment composition (`and(segment, not(segment))` via segment criteria).

## Known limitations

- **Substring matching** (`str_contains_any/none`) — no Confidence equivalent on any backend; BLOCKED with a documented context-tokenization workaround.
- **General regex** beyond prefix/suffix/single-alternation — BLOCKED.
- **`javascript` / `experiment_group`** conditions — BLOCKED.
- **Large `id_list` segments** → materialized segments, which require a **BigQuery dataset** connected to the Confidence project; BLOCKED without one (small lists inline as set rules).
- **Statsig holdouts → Confidence holdbacks** — holdbacks are a surface-level Admin-UI setting with no flag-API surface; recorded in the plan as a one-time manual step.
- **Version ranges on non-numeric schemes** — BLOCKED (numeric 2–4-segment versions, `v`-prefix, `-prerelease`, `+build` all handled).
- `resolveFlag` immediately after creation can transiently report "No active flags found" (async resolver propagation) — retry guidance documented.

## Test plan

- [x] Fixtures vs published OpenAPI spec
- [x] Fixtures vs live Statsig Console API (seeded project)
- [x] `plan flags` against the live Statsig Console API
- [x] Execute into a real Confidence project (MCP backend, 11 flags)
- [x] Execute REST backend against a real Confidence project (2 flags: reusable/composed segments, partial allocation + exclusivity)
- [x] Resolve verification vs `verify_migration.py` ground truth (24/24)
- [ ] Phase 2 (`plan code`) — follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
