### PR TITLE
fix: Fix MCP Servers table — use the working mcp.confidence.dev host

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ This plugin provides access to Confidence tools across these categories:
 
 | Server | Endpoint | Description |
 |--------|----------|-------------|
-| `confidence-flags` | `https://mcp.confidence.spotify.com/mcp/flags` | Feature flag management |
-| `confidence-docs` | `https://mcp.confidence.spotify.com/mcp/docs` | Confidence documentation |
+| `confidence-flags` | `https://mcp.confidence.dev/mcp/flags` | Feature flag management |
+| `confidence-docs` | `https://mcp.confidence.dev/mcp/docs` | Confidence documentation |
 
 ## Supported Clients
 


### PR DESCRIPTION
The "MCP Servers" table lists `mcp.confidence.spotify.com`, which doesn't resolve. The `.cursor/mcp.json` example just above (and the bundled `.mcp.json`) use `mcp.confidence.dev` — the live endpoint. This aligns the table with the working host so the manual setup steps don't point at a dead host.