### PR TITLE
feat(migrate-optimizely): Optimizely→Confidence migration kit (flags + code)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Confidence",
     "shortDescription": "Feature flags, experiments, and migration tools",
-    "longDescription": "Access Confidence feature flags, experiments, and migration tools directly from Codex. Create, list, resolve, and target feature flags. Migrate from PostHog, Eppo, or Statsig to Confidence SDK.",
+    "longDescription": "Access Confidence feature flags, experiments, and migration tools directly from Codex. Create, list, resolve, and target feature flags. Migrate from PostHog, Eppo, Statsig, or Optimizely to Confidence SDK.",
     "developerName": "Spotify Confidence",
     "category": "Productivity",
     "capabilities": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This plugin integrates Confidence with Claude Code, providing tools for feature 
 - `/confidence:migrate-posthog <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from PostHog to Confidence SDK
 - `/confidence:migrate-eppo <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Eppo to Confidence SDK
 - `/confidence:migrate-statsig <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Statsig to Confidence SDK
-- `/confidence:migrate-optimizely <plan flags | execute <plan-file>>` — Migrate feature flag definitions from Optimizely Feature Experimentation to Confidence (Phase 1; code transformation ships separately)
+- `/confidence:migrate-optimizely <plan flags | plan code | execute <plan-file>>` — Migrate feature flags from Optimizely Feature Experimentation to Confidence SDK (flags + code)
 - `/confidence:onboard-confidence <create-account | invite-user | create-client | setup-wizard | setup-warehouse | learn | status>` — Create accounts, onboard users, set up SDK clients, configure warehouses, and learn experimentation concepts
 
 ## Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This plugin integrates Confidence with Claude Code, providing tools for feature 
 - `/confidence:migrate-posthog <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from PostHog to Confidence SDK
 - `/confidence:migrate-eppo <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Eppo to Confidence SDK
 - `/confidence:migrate-statsig <plan flag | plan code | execute <plan-file>>` — Migrate feature flags from Statsig to Confidence SDK
+- `/confidence:migrate-optimizely <plan flags | execute <plan-file>>` — Migrate feature flag definitions from Optimizely Feature Experimentation to Confidence (Phase 1; code transformation ships separately)
 - `/confidence:onboard-confidence <create-account | invite-user | create-client | setup-wizard | setup-warehouse | learn | status>` — Create accounts, onboard users, set up SDK clients, configure warehouses, and learn experimentation concepts
 
 ## Skills
@@ -14,6 +15,7 @@ This plugin integrates Confidence with Claude Code, providing tools for feature 
 - **migrate-posthog** — Auto-triggers when the user asks to migrate PostHog flags or transform SDK code to Confidence
 - **migrate-eppo** — Auto-triggers when the user asks to migrate Eppo flags or transform SDK code to Confidence
 - **migrate-statsig** — Auto-triggers when the user asks to migrate Statsig gates/configs/experiments or transform SDK code to Confidence
+- **migrate-optimizely** — Auto-triggers when the user asks to migrate Optimizely flags/rollouts/experiments to Confidence
 - **onboard-confidence** — Auto-triggers when the user asks to create a Confidence account, invite users, set up SDK clients, configure warehouses, run the setup wizard, or learn about experimentation
 
 ## MCP Servers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,4 +12,4 @@ You are a helpful assistant that can manage Confidence feature flags and experim
 - Always check that the user is authenticated before performing flag operations.
 - Use the confidence-docs tools to answer questions about SDK integration, OpenFeature setup, and best practices.
 - When creating flags, confirm the flag name and schema with the user before proceeding.
-- For migrations from PostHog, Eppo, or Statsig, guide the user through the migration plan before executing changes.
+- For migrations from PostHog, Eppo, Statsig, or Optimizely, guide the user through the migration plan before executing changes.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This plugin provides access to Confidence tools across these categories:
 > /confidence:migrate-statsig plan flag
 > /confidence:migrate-statsig plan code
 > /confidence:migrate-optimizely plan flags
+> /confidence:migrate-optimizely plan code
 ```
 
 ## MCP Servers

--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ This plugin provides access to Confidence tools across these categories:
 
 - **Feature flags** — Create, list, update, archive, resolve, and target feature flags
 - **Documentation** — Search Confidence docs and SDK integration guides
-- **Migration** — Migrate feature flags from PostHog, Eppo, or Statsig to Confidence
+- **Migration** — Migrate feature flags from PostHog, Eppo, Statsig, or Optimizely to Confidence
 
 ## Slash Commands
 
 - `/confidence:migrate-posthog` — Migrate feature flags from PostHog to Confidence SDK
 - `/confidence:migrate-eppo` — Migrate feature flags from Eppo to Confidence SDK
 - `/confidence:migrate-statsig` — Migrate feature flags from Statsig to Confidence SDK
+- `/confidence:migrate-optimizely` — Migrate feature flags from Optimizely Feature Experimentation to Confidence SDK
 
 ## Example Usage
 
@@ -102,6 +103,7 @@ This plugin provides access to Confidence tools across these categories:
 > /confidence:migrate-eppo plan code
 > /confidence:migrate-statsig plan flag
 > /confidence:migrate-statsig plan code
+> /confidence:migrate-optimizely plan flags
 ```
 
 ## MCP Servers

--- a/commands/migrate-optimizely.md
+++ b/commands/migrate-optimizely.md
@@ -1,7 +1,7 @@
 ---
 name: migrate-optimizely
 description: Migrate feature flags from Optimizely to Confidence
-argument-hint: [plan flags | execute <plan-file>]
+argument-hint: [plan flags | plan code | execute <plan-file>]
 ---
 
 All migration instructions are maintained in `skills/migrate-optimizely/SKILL.md` to prevent divergence.

--- a/commands/migrate-optimizely.md
+++ b/commands/migrate-optimizely.md
@@ -1,0 +1,9 @@
+---
+name: migrate-optimizely
+description: Migrate feature flags from Optimizely to Confidence
+argument-hint: [plan flags | execute <plan-file>]
+---
+
+All migration instructions are maintained in `skills/migrate-optimizely/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/migrate-optimizely/SKILL.md` and follow those instructions to handle this command.

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1417,6 +1417,13 @@ with:
 **Each flag = one PR.** The code migration creates a separate pull
 request for each flag, keeping changes small and reviewable.
 
+**If the plan's Migration style is `provider swap` (already on
+OpenFeature) or `facade re-point`,** there is no per-flag call-site work.
+Do a single PR that swaps the registered provider (or repoints the
+facade's internal provider) to Confidence per "Already on OpenFeature →
+provider swap", leaving call sites unchanged, then verify. The per-flag
+loop below applies only to the `call-site rewrite` style.
+
 ```
 1. READ the plan file
 2. SDK SETUP (Section 1 of plan) — one-time, before any flag
@@ -1566,10 +1573,10 @@ verifies the waterfall (`rule_priorities`) order is preserved.
 
 ## Plan Code: Steps
 
-The code phase has 5 steps: Step 1 detect language/framework, Step 2
-fetch the Confidence SDK guide (and signal any resolve-mode change),
-Step 3 scan the codebase for Optimizely usage, Step 4 generate transform
-rules, Step 5 generate the plan.
+The code phase has 5 steps: Step 1 detect language/framework **and the
+migration style**, Step 2 fetch the Confidence SDK guide (and signal any
+resolve-mode change), Step 3 scan the codebase for Optimizely usage, Step
+4 generate transform rules, Step 5 generate the plan.
 
 ### Step 1: Detect language & framework
 
@@ -1578,6 +1585,44 @@ Grep: pattern="<Optimizely import/symbol patterns from Step 3>"  → Find Optimi
 Glob: pattern="package.json" or "build.gradle" or "*.csproj" or "go.mod" or "pyproject.toml"/"requirements.txt" or "Gemfile" etc
 Read: dependency file  → Determine language/framework AND which Optimizely SDK package
 ```
+
+### Step 1b: Detect the migration style (provider swap vs call-site rewrite)
+
+**This is the FIRST branch in the code phase — it changes everything
+below.** Before scanning for Optimizely calls, determine whether the app
+talks to Optimizely **directly** or **already through OpenFeature**.
+
+```
+Grep -i: pattern="@openfeature/|dev\.openfeature|open-feature/go-sdk|openfeature" → already on OpenFeature?
+Grep -i: pattern="OpenFeature\.(setProvider|setProviderAndWait)|SetProviderAndWait|getClient\(|useFlag\(" → OpenFeature wiring
+Grep -i: pattern="implements (Feature)?Provider|: Provider|class \w+Provider" → a custom OpenFeature provider class
+```
+
+Two styles result:
+
+| Style | When | Phase 2 work |
+|-------|------|--------------|
+| **Provider swap** | App **already uses OpenFeature** (standard `useFlag` / `get*Value` call sites; Optimizely is hidden behind a registered OpenFeature provider, official or custom) | Swap the **registered provider** to Confidence; **call sites do NOT change**. See "Already on OpenFeature → provider swap". |
+| **Call-site rewrite** | App calls the **Optimizely SDK directly** (`decide`, `isFeatureEnabled`, `getFeatureVariable*`, `activate`) | Rewrite call sites to OpenFeature + Confidence (Steps 2–5 below). |
+
+> **Why this matters.** A team already on OpenFeature did the hard part —
+> their call sites are vendor-neutral. Migrating them to Confidence is a
+> one-file provider swap, not a codebase-wide rewrite. Detecting this
+> first avoids needlessly rewriting `useFlag('x', false)` into itself.
+>
+> **Facade caveat.** Some teams hide the SDK behind a **home-grown facade**
+> (not OpenFeature) — e.g. an `ExperimentManager` exposing
+> `isFeatureEnabled(...)`. That is NOT the provider-swap case: the facade
+> is vendor-specific. The migration there is to repoint the facade's
+> internal provider at Confidence (a localized change inside the facade),
+> while its public API and call sites stay put. Treat it like a provider
+> swap scoped to the facade's implementation, and record the facade entry
+> point in the plan.
+
+If the style is **provider swap**, skip the call-site transform tables in
+Step 4 and follow "Already on OpenFeature → provider swap" instead. Step 2
+(SDK guide + resolve mode) and Phase 1 (flags must exist in Confidence)
+still apply.
 
 ### Step 2: Fetch SDK guide from `confidence-docs` MCP
 
@@ -1902,6 +1947,137 @@ using the template below.
 - **Flags are structs — read a property, not the bare key** (`<flag>.<property>`).
 - **Client SDKs use ambient context; server SDKs pass it per call.**
 
+---
+
+## Already on OpenFeature → provider swap
+
+When Step 1b found the app **already uses OpenFeature**, do NOT run the
+call-site transform. The call sites (`useFlag`, `get<Type>Value`,
+`get<Type>Evaluation`) are vendor-neutral and stay exactly as they are.
+The migration is to replace the **registered provider** with Confidence's
+OpenFeature provider, plus Phase 1 (the flags must exist in Confidence).
+
+### The swap, step by step
+
+```
+1. LOCATE the provider wiring:
+   - the registration call: OpenFeature.setProvider / setProviderAndWait /
+     SetProviderAndWait (JS/Java/Go), api.set_provider[_and_wait] (Python),
+     OpenFeatureAPI.getInstance().setProviderAndWait (Java), the
+     <OpenFeatureProvider> boundary (React)
+   - any CUSTOM provider class the team wrote (e.g. `class FooProvider
+     implements Provider`) wrapping the old vendor SDK
+2. REPLACE the provider with Confidence's, picking the package/mode from
+   Step 2a's routing (server in-process / browser cached / React / remote):
+   - Official vendor provider package → swap the import + the constructor
+     line for the Confidence provider.
+   - Hand-written custom provider (a class wrapping a vendor SDK directly,
+     e.g. a custom `OptimizelyProvider` wrapping `@optimizely/optimizely-sdk`)
+     → replace the class with the Confidence provider. If that class encodes
+     BUSINESS SEMANTICS (e.g. on/off-string
+     modelling, anonymous-context suppression, per-flag special-casing),
+     re-home that logic into a thin wrapper or hooks layered ON TOP of the
+     Confidence provider — do not silently drop it. Flag each such behavior
+     in the plan.
+3. KEEP all call sites unchanged.
+4. CONTEXT: OpenFeature evaluation context is already standard. Only adjust
+   if attribute names differ from the Confidence flag's targeting (e.g. a
+   custom targetingKey or attribute rename). Usually nothing to do.
+5. DELETE vendor scaffolding the old provider carried: datafile polling,
+   vendor event/decision listeners, SDK-key plumbing — Confidence's
+   provider handles state refresh and exposure logging itself.
+6. Phase 1: re-create the flags + audiences in Confidence so the new
+   provider resolves them (this is the same Phase 1 as the rewrite path).
+```
+
+The result is typically a **one- or few-file change** at the bootstrap /
+provider module, plus the flag re-creation — independent of how many call
+sites read flags.
+
+### Re-homing custom-provider semantics (prefer the flag model over code)
+
+A hand-written provider (or facade) often **computes** a value at read
+time instead of passing the flag through — e.g. exposing a boolean
+feature as an on/off **string**, or reading a variable **only if** the
+feature is enabled. Don't port that logic verbatim into a new wrapper if
+you can avoid it: push it into the **Confidence flag model** so the
+swapped-in provider needs no special-casing.
+
+- **Boolean feature exposed as an on/off string** → model the Confidence
+  flag with a `string` property whose variants are the literal strings the
+  call site expects (e.g. `"on"` / `"off"`), plus a targeting rule
+  (in-audience → `on`, otherwise → `off`). The call site's
+  `useFlag` / `get<Type>Value` is unchanged.
+- **Conditional variable read** ("return variable X only if the feature is
+  enabled, else a default") → fold the condition into variant values: the
+  matched variant carries X's value, the default/off variant carries the
+  fallback. "Only if enabled" becomes "only the matched variant has the
+  value."
+
+Then **delete** the special-casing from the old provider rather than
+re-homing it as code.
+
+> **Confirm before folding.** This only works when the logic is **static /
+> enumerable** as variants + targeting. If the value is computed from
+> runtime inputs that can't be expressed as targeting (arbitrary
+> client-side math, values derived from non-context state), keep a **thin
+> wrapper** over the Confidence provider for that flag and note it in the
+> plan.
+
+### Live-update / change-observer APIs
+
+If the app or facade exposes a flag-change/observer API — an `onChange`
+callback that fires when a flag's state changes without a restart — wire
+it to OpenFeature's **provider events** instead of the old vendor's
+flag-update callback: register a handler for the
+`PROVIDER_CONFIGURATION_CHANGED` event on the OpenFeature client/provider
+(`addHandler(...)`) and re-fire the app's callback from there. The
+Confidence provider refreshes resolver state on its poll interval and
+surfaces that as a configuration-changed event.
+
+> **Confirm before relying on it.** Verify the target Confidence provider
+> for this platform actually emits a configuration-changed event, and at
+> what **granularity**. If it signals a whole-state refresh (not per-flag)
+> while the source callback fired only on a *specific* flag's change, the
+> wrapper must diff that flag's value across the event to preserve the
+> original granularity. Record the decision in the plan.
+
+### Source providers you may be swapping out
+
+The app's current OpenFeature provider can be an official vendor package or
+a hand-written class. Recognize it, then swap it for the Confidence
+provider regardless of which one it is. Common sources (package names are
+indicative — confirm against the repo's manifest):
+
+| Current provider | Typical package / shape | Swap to (Confidence) |
+|------------------|-------------------------|----------------------|
+| Optimizely (custom) | hand-written `class …Provider implements Provider` wrapping `@optimizely/optimizely-sdk` | Confidence provider for the platform/mode (Step 2a) |
+| LaunchDarkly | `@launchdarkly/openfeature-server-provider` / `…-client-provider`, `launchdarkly-openfeature-*` | ″ |
+| Flagsmith | `@flagsmith/openfeature-*`, `flagsmith-openfeature` | ″ |
+| Split | `@splitsoftware/openfeature-provider-*` | ″ |
+| Unleash | `@unleash/openfeature` / community provider | ″ |
+| ConfigCat | `@configcat/openfeature-*` | ″ |
+| DevCycle | `@devcycle/openfeature-*` | ″ |
+| GO Feature Flag | `@openfeature/go-feature-flag-provider` | ″ |
+| flagd (reference) | `@openfeature/flagd-provider` / `dev.openfeature.contrib…flagd` | ″ |
+| Statsig / PostHog | community OpenFeature providers | ″ |
+| In-house / custom | any `Provider` / `FeatureProvider` implementation | ″ |
+
+In every case the **call sites and the OpenFeature client API are
+identical** — only the registered provider changes. The
+language/mode-specific Confidence provider (and its `setProviderAndWait` /
+`set_provider` init) comes from the Step 2 SDK guide.
+
+### Verify
+
+- Confirm the flags referenced by call sites exist in Confidence (Phase 1)
+  with matching resolve paths (`<flag>.<property>`).
+- Re-run the app's existing flag tests/usages — because call sites are
+  unchanged, the existing assertions should hold once the provider resolves
+  the migrated flags.
+- Spot-check a positive and a negative context (same as the rewrite path's
+  resolve verification).
+
 ## Plan Code: Template
 
 ```markdown
@@ -1911,6 +2087,7 @@ using the template below.
 **Scope:** Code transformation only
 **Language:** <detected>
 **Framework:** <detected>
+**Migration style:** <provider swap (already on OpenFeature) | call-site rewrite (direct Optimizely SDK) | facade re-point (home-grown facade)>
 
 ---
 

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Migrate feature flag definitions from Optimizely to Confidence. Use when the user says /migrate-optimizely or asks to migrate Optimizely flags/rollouts/experiments to Confidence.
+description: Migrate feature flags from Optimizely to Confidence SDK. Use when the user says /migrate-optimizely, asks to migrate Optimizely flags/rollouts/experiments, or transform Optimizely SDK code to Confidence.
 ---
 
 # Optimizely to Confidence Migration
@@ -9,6 +9,16 @@ Experimentation to Confidence. This skill is fully self-contained: it
 defines both the Optimizely-specific migration logic AND all the
 Confidence-side conventions it relies on (payload formats, naming rules,
 the flag setup sequence, the execute flow, etc.).
+
+## SDK Preference
+
+**ALWAYS prefer OpenFeature with local resolve.**
+
+| Priority | Approach | When to use |
+|----------|----------|-------------|
+| 1st | Local resolve | Default for all new integrations |
+| 2nd | Remote resolve | Only if local resolve not supported for platform |
+| Avoid | Direct SDK | Being phased out |
 
 ## Plan Philosophy
 
@@ -26,14 +36,15 @@ the flag setup sequence, the execute flow, etc.).
 | Command | Description |
 |---------|-------------|
 | `/migrate-optimizely plan flags` | Phase 1: plan flag definitions migration |
+| `/migrate-optimizely plan code` | Phase 2: plan code transformation |
 | `/migrate-optimizely execute <plan-file>` | Execute a plan interactively |
 
 ---
 
-## Migration Overview (MUST display at start of `plan flags`)
+## Migration Overview (MUST display at start of `plan flags` or `plan code`)
 
-**Every time** the user runs `plan flags`, display this overview FIRST
-— before doing any work.
+**Every time** the user runs `plan flags` or `plan code`, display this
+overview FIRST — before doing any work.
 
 ```
 ═══════════════════════════════════════════════════════════════
@@ -59,11 +70,20 @@ the flag setup sequence, the execute flow, etc.).
   │                                                        │
   │  Result: All flags live in Confidence, ready to resolve│
   ├─────────────────────────────────────────────────────────┤
-  │  PHASE 2 — Code Transformation (ships separately)      │
+  │  PHASE 2 — Code Transformation                         │
   │                                                        │
-  │  Once flags exist in Confidence, the code that         │
-  │  evaluates them is migrated flag-by-flag, one PR each. │
-  │  Phase 2 is delivered as a follow-up to this skill.    │
+  │  Once flags exist in Confidence, migrate the code that │
+  │  evaluates them. Each flag = one PR.                   │
+  │                                                        │
+  │  Steps:                                                │
+  │    1. Detect language & framework                      │
+  │    2. Fetch Confidence SDK guide                       │
+  │    3. Scan codebase for Optimizely usage               │
+  │    4. Generate transform rules (Optimizely→Confidence) │
+  │    5. Generate plan grouped by flag                    │
+  │    6. Execute: transform code flag by flag, one PR each│
+  │                                                        │
+  │  Result: Code uses Confidence SDK, Optimizely removed  │
   └─────────────────────────────────────────────────────────┘
 
   Why flags first?
@@ -76,8 +96,15 @@ the flag setup sequence, the execute flow, etc.).
 ═══════════════════════════════════════════════════════════════
 ```
 
-After displaying the overview, say: "Starting **Phase 1** — Flag
-Definitions", then proceed with the normal workflow.
+After displaying the overview, indicate which phase the user is about
+to enter:
+
+- For `plan flags`: "Starting **Phase 1** — Flag Definitions"
+- For `plan code`: "Starting **Phase 2** — Code Transformation.
+  Make sure Phase 1 (flag definitions) is complete first — the flags
+  need to exist in Confidence before the code can resolve them."
+
+Then proceed with the normal workflow for that phase.
 
 ---
 
@@ -90,6 +117,17 @@ Test: `mcp__confidence__listClients`
 If not available, install it:
 ```
 claude mcp add confidence --transport http --url https://mcp.confidence.dev/mcp/flags
+```
+
+The user will be prompted to authenticate via OAuth in their browser.
+
+### Confidence Docs MCP (required for `plan code` only)
+
+Test: `mcp__confidence-docs__searchDocumentation`
+
+If not available, install it:
+```
+claude mcp add confidence-docs --transport http --url https://mcp.confidence.dev/mcp/docs
 ```
 
 The user will be prompted to authenticate via OAuth in their browser.
@@ -458,8 +496,8 @@ Example after Step 1 completes:
 
 ## Plan Files: Resume Check & Progressive Updates
 
-`plan flags` uses a progressive plan file. Created at Step 1, updated
-after each step, so a closed session can resume.
+Both `plan flags` and `plan code` use a progressive plan file. Created
+at Step 1, updated after each step, so a closed session can resume.
 
 ### Resume check (MUST do first)
 
@@ -467,6 +505,7 @@ Before starting any plan workflow, check for an existing in-progress
 plan:
 
 - `plan flags` → `.claude/plans/optimizely-flag-migration-*.md`
+- `plan code`  → `.claude/plans/optimizely-code-migration-*.md`
 
 If a plan file exists, read its `## Generation Status` section:
 
@@ -1354,6 +1393,32 @@ with:
    - Show summary: created vs skipped
 ```
 
+### For code plans
+
+**Each flag = one PR.** The code migration creates a separate pull
+request for each flag, keeping changes small and reviewable.
+
+```
+1. READ the plan file
+2. SDK SETUP (Section 1 of plan) — one-time, before any flag
+   - Show install command from plan
+   - ASK: "Install SDK now? [Yes / Skip / I already did]"
+   - Show wrapper file path + API surface from plan
+   - ASK: "Create the Confidence wrapper now? [Yes / Skip / I already did]"
+   - If the plan flags a resolve-mode CHANGE, re-surface it here and get
+     an explicit acknowledgement before touching code
+3. FOR EACH FLAG in the files list:
+   a. Create a branch: `migrate/<flag-key>-to-confidence`
+   b. Show flag name + all files using it
+   c. ASK: "Transform this flag's files? [Yes / Skip / Pause]"
+   d. If Yes → apply transform rules from plan to all files for this flag
+   e. Run lint + typecheck on changed files
+   f. Commit changes
+   g. Create PR titled: "feat: migrate <flag-key> from Optimizely to Confidence"
+   h. CHECKPOINT: "PR created. [Continue to next flag / Pause]?"
+4. COMPLETION — show summary + list all PRs created
+```
+
 ### Flag Setup Sequence (MUST complete all steps before resolving)
 
 **Pick the backend from the flag's `Backend` field first.** The sequence
@@ -1480,15 +1545,412 @@ verifies the waterfall (`rule_priorities`) order is preserved.
 
 ---
 
+## Plan Code: Steps
+
+The code phase has 5 steps: Step 1 detect language/framework, Step 2
+fetch the Confidence SDK guide (and signal any resolve-mode change),
+Step 3 scan the codebase for Optimizely usage, Step 4 generate transform
+rules, Step 5 generate the plan.
+
+### Step 1: Detect language & framework
+
+```
+Grep: pattern="<Optimizely import/symbol patterns from Step 3>"  → Find Optimizely usage
+Glob: pattern="package.json" or "build.gradle" or "*.csproj" or "go.mod" or "pyproject.toml"/"requirements.txt" or "Gemfile" etc
+Read: dependency file  → Determine language/framework AND which Optimizely SDK package
+```
+
+### Step 2: Fetch SDK guide from `confidence-docs` MCP
+
+**Step 2a — pick the target resolve mode.** Confidence has FOUR modes,
+not a local/remote binary. Pick from the language/framework detected in
+Step 1, honoring the "prefer local resolve" policy (see "SDK
+Preference"):
+
+| Target mode | Confidence SDKs | How evaluation works | Network profile |
+|-------------|-----------------|----------------------|-----------------|
+| **In-process** (local resolve) | backend **Java, Go, JS/Node, Rust** | Periodically fetch the resolver **state** (full ruleset); evaluate locally via WASM | No per-eval network call; network only for state refresh |
+| **Cached client** | **Android, iOS, web/browser JS, React, React Native** | Backend resolves; device **prefetches and caches resolved VALUES** (not the ruleset). Reads are local + offline. Context change triggers a refetch | Network on init / context change / refresh — NOT per read |
+| **Server-precomputed** | server-rendered React/Next.js (RSC) | Server resolves for a bound subject; client reads resolved values offline | Resolution on the server; client reads are offline |
+| **Remote** (per-call) | backend **Python, Ruby, .NET** | Each resolve is a service call to Confidence | One call per resolve (with default-value fallback on failure) |
+
+Routing:
+
+- Backend **and** language ∈ {Java, Go, JS/Node, Rust} → **in-process**.
+  Fetch the local-resolve guide (server-only; the JS WASM provider is
+  **not** for browsers):
+
+  ```
+  mcp__confidence-docs__getLocalResolveIntegrationGuide
+    sdk: "JAVA" | "GO" | "JS" | "RUST"
+  ```
+
+- Client app (mobile / browser / React Native) → **cached client**.
+  Backend **Python / Ruby / .NET** → **remote**. Either way fetch:
+
+  ```
+  mcp__confidence-docs__getCodeSnippetAndSdkIntegrationTips
+    sdk: "<detected>"
+  ```
+
+- **Server-rendered React / Next.js (RSC)** → **server-precomputed**.
+  Use Confidence's React local-resolve provider (`<ConfidenceProvider>`
+  + `useFlag`); fetch `getLocalResolveIntegrationGuide sdk: "JS"`.
+
+> **PHP / Flutter / edge.** Optimizely ships PHP, Flutter, and edge
+> (Edge Worker / Agent) SDKs that Confidence does not match 1:1. If the
+> detected stack has no Confidence SDK, STOP and surface it: the flags
+> still migrate (Phase 1), but the code transform must be done manually
+> or the app re-platformed onto a supported Confidence SDK. Record this
+> in the plan rather than inventing an API.
+
+**CRITICAL:** Include the ACTUAL MCP response in the plan, not a
+reference to fetch it. Plans are self-sufficient.
+
+**Step 2b — signal any resolve-mode CHANGE.** Compare the source mode
+(defined in "Source resolve mode (Optimizely)" below) to the target mode
+from 2a and, if it shifts, tell the user precisely what changes. Record
+the decision and any change notice in the plan's SDK Setup section and
+re-surface it at execute time before touching code. If unchanged, state
+that explicitly so the user knows it was considered.
+
+### Source resolve mode (Optimizely) — feeds the Step 2b signal
+
+**Optimizely SDKs evaluate locally off a downloaded datafile — but
+"local" means different things on server vs client; the Agent is the
+exception.** Map the source surface to a mode:
+
+- **Optimizely backend SDK** (Node/Python/Ruby/PHP/Java/Go/.NET, datafile
+  in-process) → source mode = **in-process eval**.
+- **Optimizely client SDK** (Swift/Android/JS browser/React/React Native,
+  datafile on device) → source mode = **on-device eval** (the device
+  holds the full datafile and evaluates locally).
+- **Optimizely Agent** (the REST microservice exposing `/v1/decide`) →
+  source mode = **remote** (per-call service eval).
+- **Optimizely Edge / Cloudflare Worker** → source mode = **in-process at
+  edge**.
+
+Then the Step 2b transitions apply:
+
+- Optimizely backend → Confidence **in-process** (Java/Go/JS/Rust): unchanged.
+- Optimizely backend → Confidence **remote** (Python/Ruby/.NET): ⚠️ in-process
+  → remote — each resolve becomes a service call.
+- Optimizely client → Confidence **cached client** (mobile/web): ⚠️ on-device
+  → cached client. Reads stay local/offline and fast (NOT per-call
+  network), but evaluation moves to the backend: the device caches
+  resolved values instead of the datafile, targeting changes apply on the
+  next fetch, a cold first run may return defaults, and the full ruleset
+  is no longer shipped to the client (a security/payload win over
+  Optimizely's on-device datafile).
+- Optimizely Agent (remote) → Confidence **in-process** or **remote**: note
+  whether per-call network goes away (Agent → in-process) or stays
+  (Agent → remote).
+- Optimizely server-rendered React/Next.js → Confidence React
+  **local-resolve** provider: ✅ architecture preserved (server-precomputed
+  → server-precomputed). Surface as "no resolve-mode change".
+
+### Plan-file path
+
+`.claude/plans/optimizely-code-migration-<date>.md`
+
+### Step 3: Scan codebase for Optimizely usage
+
+Optimizely has **two API generations** — the modern **Decide API** and
+the **legacy Full Stack API**. Scan for both:
+
+```
+Grep: pattern="optimizely|Optimizely|@optimizely" → Find Optimizely imports/packages
+Grep: pattern="createInstance|OptimizelyFactory|createUserContext" → Find SDK init + user context
+Grep: pattern="\.decide(All|ForKeys)?\(" → Find the DECIDE API (current FX)
+Grep: pattern="isFeatureEnabled|getFeatureVariable(Boolean|String|Integer|Double|JSON)?|getAllFeatureVariables" → Find LEGACY feature API
+Grep: pattern="\.activate\(|getVariation\(" → Find LEGACY experiment API (returns a variation key)
+Grep: pattern="useDecision|useFeature|withOptimizely|OptimizelyProvider|OptimizelyFeature|OptimizelyExperiment" → Find REACT SDK usage
+Grep: pattern="\.track\(|trackEvent\(|addNotificationListener|NotificationCenter" → Find event tracking + notification listeners
+```
+
+Run greps **case-insensitively** (`rg -i` / `Grep -i`); method casing
+varies by language (Go `Decide`, Python `decide`, Java `decide`).
+
+**The Decide API (current).** A decision is fetched per flag:
+
+```
+user = optimizely.createUserContext(userId, attributes)
+decision = user.decide("flag_key")
+decision.enabled            // boolean
+decision.variables["var"]   // typed variable value (map; older SDKs: decision.getVariableValue("var"))
+decision.variationKey       // which variation (string) — for experiments
+decision.ruleKey            // which rule matched (no Confidence equivalent)
+```
+
+**The legacy Full Stack API.** Pre-`decide`, evaluation is per call with
+`userId` + `attributes` passed each time:
+
+```
+optimizely.isFeatureEnabled("feature_key", userId, attributes)                       // boolean
+optimizely.getFeatureVariableString("feature_key", "var", userId, attributes)        // typed variable
+optimizely.activate("experiment_key", userId, attributes)                            // → variation key (logs impression)
+optimizely.getVariation("experiment_key", userId, attributes)                        // → variation key (no impression)
+```
+
+**Classify the SDK as client-side or server-side** — this decides the
+evaluation-context model in Step 4:
+
+| Optimizely package | Side |
+|--------------------|------|
+| `@optimizely/react-sdk`, `@optimizely/optimizely-sdk` (browser usage), `OptimizelySwiftSDK`/`Optimizely` (iOS), `com.optimizely.ab:android-sdk`, React Native, `optimizely_flutter_sdk` | **client** |
+| `@optimizely/optimizely-sdk` (Node), `optimizely-sdk` (Python/Ruby), `optimizely/optimizely-sdk` (PHP), `com.optimizely.ab:core-api` (Java), `github.com/optimizely/go-sdk`, `Optimizely.SDK` (.NET), Optimizely Agent (REST) | **server** |
+
+`@optimizely/optimizely-sdk` is dual-use — disambiguate by where it runs
+(Node entrypoint = server; bundled into a browser/React app = client).
+
+Group files by **flag key** they reference (the first arg to `decide`,
+the first arg to `isFeatureEnabled` / `getFeatureVariable*`; for
+`activate`/`getVariation` the arg is an **experiment key** — resolve it to
+its parent flag via the Phase 1 plan, since FX experiments live inside a
+flag's ruleset).
+
+For each evaluation site, record:
+- Flag key (and, for `activate`/`getVariation`, the experiment key →
+  parent flag from Phase 1)
+- **Client vs server side** (from the table above)
+- API generation (**decide** vs **legacy**) and the value TYPE read
+  (`enabled` → boolean; each variable by its declared type)
+- The `userId`/user-context argument (→ `targetingKey`)
+- The `attributes` argument (→ evaluation context)
+- The default value (carried over to the Confidence call)
+- The **Confidence resolve path** (`<confidence-flag>.<property>`) — take
+  the Confidence flag key (Phase 1 normalized underscores → hyphens) and
+  property from the Phase 1 plan's "Confidence resolve path" line.
+  `decision.enabled` → `<flag>.enabled`; `decision.variables["x"]` /
+  `getFeatureVariable*(.., "x", ..)` → `<flag>.x`. If the flag is NOT in
+  the Phase 1 plan, surface it — do not invent a path.
+
+### Step 4: Generate transform rules
+
+Based on the SDK guide from `confidence-docs` MCP: extract install
+commands, initialization, the flag-evaluation API, and generate
+find/replace rules.
+
+**Two things are NOT 1:1 line replacements — get them right first:**
+
+1. **Flag key → resolve path.** Confidence flags are structs; every read
+   uses `<confidence-flag>.<property>` (see Step 3). The Confidence flag
+   key may differ from the Optimizely flag key (underscore→hyphen
+   normalization in Phase 1) — use the Phase 1 mapping everywhere.
+2. **Evaluation-context model depends on client vs server** (from Step 3):
+   - **Server SDKs** pass context **per call** — fold the `userId` +
+     `attributes` into the evaluation-context argument of each resolve.
+   - **Client SDKs** use **ambient** context — hoist `userId` +
+     `attributes` ONCE into a
+     `setEvaluationContext`/`setEvaluationContextAndWait` (where the
+     Optimizely code called `createUserContext` / set attributes), and the
+     per-call site becomes a bare `get<Type>Value(path, default)`.
+
+**Decide API → OpenFeature (server target, per-call context):**
+
+| Optimizely | OpenFeature |
+|------------|-------------|
+| `user = optimizely.createUserContext(uid, attrs)` | (no user object — build an evaluation context `{ targetingKey: uid, ...attrs }` per call) |
+| `user.decide("k").enabled` | `client.getBooleanValue("k.enabled", default, { targetingKey: uid, ...attrs })` |
+| `user.decide("k").variables["v"]` (string) | `client.getStringValue("k.v", default, ctx)` |
+| `user.decide("k").variables["v"]` (int/double) | `client.getNumberValue("k.v", default, ctx)` |
+| `user.decide("k").variables["v"]` (json) | `client.getObjectValue("k.v", default, ctx)` |
+
+**Legacy Full Stack API → OpenFeature (server target):**
+
+| Optimizely | OpenFeature |
+|------------|-------------|
+| `optimizely.isFeatureEnabled("k", uid, attrs)` | `client.getBooleanValue("k.enabled", false, { targetingKey: uid, ...attrs })` |
+| `optimizely.getFeatureVariableBoolean("k", "v", uid, attrs)` | `client.getBooleanValue("k.v", default, ctx)` |
+| `optimizely.getFeatureVariableString("k", "v", uid, attrs)` | `client.getStringValue("k.v", default, ctx)` |
+| `optimizely.getFeatureVariableInteger/Double("k", "v", uid, attrs)` | `client.getNumberValue("k.v", default, ctx)` |
+| `optimizely.getFeatureVariableJSON("k", "v", uid, attrs)` | `client.getObjectValue("k.v", default, ctx)` |
+| `optimizely.getAllFeatureVariables("k", uid, attrs)` | one `get<Type>Value("k.<v>", …)` per variable (Confidence has no "all variables" call) |
+
+**Client target (ambient context):** the per-call site drops its
+`uid`/`attrs` arguments; emit a one-time
+`setEvaluationContext({ targetingKey: uid, ...attrs })` where the source
+called `createUserContext` / set attributes (or at login/init).
+
+The accessor name AND signature are language-specific — use the Step 2
+SDK guide for the exact form:
+- **Go**: PascalCase, no `get` prefix, `ctx` first, context last:
+  `client.BooleanValue(ctx, "k.enabled", default, evalCtx)`; numeric →
+  `FloatValue`, integer → `IntValue`, JSON → `ObjectValue`.
+- **Java**: build a `MutableContext(uid)` + `ctx.add(...)` and pass it
+  last: `client.getBooleanValue("k.enabled", default, ctx)`,
+  `client.getDoubleValue("k.v", default, ctx)`, `getObjectValue(...)`.
+- **Python (REMOTE target)**: snake_case `get_<type>_value`, numeric →
+  `get_float_value`, JSON → `get_object_value`, context last:
+  `client.get_boolean_value("k.enabled", False, EvaluationContext(targeting_key=uid, attributes=attrs))`.
+  Use `api.set_provider(ConfidenceOpenFeatureProvider(Confidence(client_secret=...)))`
+  (NOT `set_provider_and_wait`) and delete Optimizely's datafile-ready wait.
+
+**`activate` / `getVariation` (legacy experiment API).** These return a
+**variation key** (string) for an *experiment*, and the impression is
+logged automatically by Confidence (so `activate`'s logging side effect
+is implicit). Map by how the result is used:
+- If the code **branches on the variation key string** (e.g.
+  `if (v === "treatment")`), expose the decision via the flag the
+  experiment belongs to: read the variable(s) that drive behavior
+  (`get<Type>Value("<flag>.<var>", …)`) instead of switching on the key,
+  OR — if a raw variant label is genuinely needed — read a string
+  property carrying it. Surface these sites for human review in the plan;
+  a key-switch is rarely a clean 1:1.
+- `getVariation` (no impression) has no separate Confidence form —
+  Confidence logs exposure on resolve. Note the behavior change.
+
+**React SDK mapping.** `@optimizely/react-sdk` →
+`@spotify-confidence/react` (or the React local-resolve provider for
+RSC; fetch the JS guide in Step 2):
+
+| Optimizely React | Confidence React |
+|------------------|------------------|
+| `<OptimizelyProvider optimizely={client} user={{ id, attributes }}>` | `<ConfidenceProvider>` with evaluation context `{ targetingKey: id, ...attributes }` |
+| `const [decision] = useDecision("k")` → `decision.enabled` / `decision.variables.v` | `useFlag("k.enabled", default)` / `useFlag("k.v", default)` |
+| `<OptimizelyFeature feature="k">{(enabled, variables) => …}</OptimizelyFeature>` | read via `useFlag("k.enabled", default)` (and `useFlag("k.v", …)` per variable) inside the component |
+| `<OptimizelyExperiment experiment="k">{(variation) => …}</OptimizelyExperiment>` | resolve the underlying flag's variable(s) with `useFlag`; branching on a raw variation key needs review (see `activate` above) |
+
+**Event tracking has no OpenFeature equivalent.**
+`optimizely.track(eventKey, userId, attrs, tags)` /
+`user.trackEvent(eventKey, tags)` map to Confidence's **track** API
+(`confidence.track(eventKey, data)`), NOT to OpenFeature (which has no
+track). Use the Confidence SDK's `track` from the Step 2 guide; the
+evaluation context / subject carries through. Keep the event keys.
+
+**Delete Optimizely scaffolding that Confidence handles automatically:**
+- **Notification listeners** (`addNotificationListener`, `DECISION` /
+  `NotificationCenter`, custom impression bridges) — Confidence logs
+  exposure automatically. Delete them.
+- **Datafile management** (`datafileOptions`, polling intervals,
+  `OptimizelyConfig`, manual datafile fetch) — Confidence's provider
+  refresh replaces it.
+- **Event dispatcher / batch event processor** config — Confidence
+  handles event delivery internally.
+- **Readiness scaffolding** (`onReady()`, `await optimizely.onReady()`,
+  Android handler delays) — Confidence's
+  `setProviderAndWait` / `setEvaluationContextAndWait` already block until
+  flags are ready; delete the hand-rolled wait.
+
+**Bandits.** Optimizely multi-armed and contextual bandits (CMAB) are
+**rule types** read through the normal `decide` API — the adaptive
+allocation lives server-side (already snapshotted in Phase 1). So the
+code transform for a bandit flag is the same as any `decide` read; just
+note in the plan that the live split was adaptive and no longer auto-tunes
+after migration. (This differs from sources that expose a separate
+bandit-action call.)
+
+### Step 5: Generate plan
+
+Save the plan to `.claude/plans/optimizely-code-migration-<date>.md`
+using the template below.
+
+**Two Confidence-wide truths every code transform must honor:**
+
+- **Flags are structs — read a property, not the bare key** (`<flag>.<property>`).
+- **Client SDKs use ambient context; server SDKs pass it per call.**
+
+## Plan Code: Template
+
+```markdown
+# Optimizely to Confidence Code Migration Plan
+
+**Created:** <date>
+**Scope:** Code transformation only
+**Language:** <detected>
+**Framework:** <detected>
+
+---
+
+## Generation Status
+
+| Step | Status | Result |
+|------|--------|--------|
+| 1. Detect language | ○ not started | |
+| 2. Fetch SDK guide | ○ not started | |
+| 3. Scan codebase | ○ not started | |
+| 4. Transform rules | ○ not started | |
+| 5. Group by flag | ○ not started | |
+
+**Overall:** in progress
+
+---
+
+## 1. SDK Setup
+
+### Resolve mode
+
+| | |
+|---|---|
+| **Source mode** | <in-process eval / on-device eval / remote (Agent) — per surface> |
+| **Target mode** | <in-process / cached client / server-precomputed / remote — from Step 2a> |
+| **Change** | <unchanged / ⚠️ in-process → remote / ⚠️ on-device → cached client / …> |
+
+<If changed: one-paragraph notice of what actually shifts. If unchanged: "Resolve mode is preserved.">
+
+### Install
+
+<install commands from MCP response>
+
+### API Reference (from MCP: confidence-docs)
+
+<code examples from MCP response>
+
+### Create Confidence Wrapper
+
+**File:** <appropriate path for detected framework>
+
+**Must match source API surface:**
+
+| Method | Signature |
+|--------|-----------|
+<detected from source SDK usage>
+
+---
+
+## 2. Transform Rules
+
+### Source Files
+
+| Find | Replace |
+|------|---------|
+| <Optimizely import> | <Confidence import> |
+| <Optimizely usage (decide / legacy)> | <Confidence usage> |
+
+### Test Files
+
+| Find | Replace |
+|------|---------|
+| <Optimizely mock> | <Confidence mock> |
+
+---
+
+## 3. Files to Transform
+
+<list from codebase scan, grouped by flag key (experiment keys resolved to their parent flag); note any sites flagged for human review — activate/getVariation key-switches, event tracking, unsupported SDKs>
+
+---
+
+## 4. Progress
+
+| # | Item | Status |
+|---|------|--------|
+| 0 | SDK Setup | :white_circle: |
+```
+
+---
+
 ## Required Prerequisites
 
-This skill needs the Confidence MCP listed in "Prerequisites: Confidence
-Side" above, plus the Optimizely REST API — no MCP, just `curl` with
-`Authorization: Bearer $OPTIMIZELY_API_TOKEN`.
+This skill needs the Confidence-side MCPs listed in "Prerequisites:
+Confidence Side" above (`confidence` for `plan flags`/`execute`,
+`confidence-docs` for `plan code`), plus the Optimizely REST API — no
+MCP, just `curl` with `Authorization: Bearer $OPTIMIZELY_API_TOKEN`.
 
 | Source | What's used |
 |--------|-------------|
 | Confidence MCP | `listClients`, `createClient`, `getContextSchema`, `addContextField`, `createFlag`, `addFlagToClient`, `unarchiveFlag`, `addTargetingRule`, `resolveFlag` |
+| Confidence Docs MCP (`plan code`) | `getLocalResolveIntegrationGuide`, `getCodeSnippetAndSdkIntegrationTips`, `searchDocumentation`, `getFullSource` |
 | Confidence REST API (`CONFIDENCE_TOKEN`, OPTIONAL — full-fidelity Phase 1) | `POST /v1/segments` + `:allocate`, `POST /v1/flags/{flag}/rules` + `PATCH …?updateMask=enabled`; token via `POST https://iam.confidence.dev/v1/oauth/token` |
 | Optimizely Flags API (`OPTIMIZELY_API_TOKEN`) | `GET /flags/v1/projects/{id}/flags[/{key}]`, `GET …/flags/{key}/variations`, `GET …/flags/{key}/environments/{env}/ruleset` |
 | Optimizely Platform API v2 (`OPTIMIZELY_API_TOKEN`) | `GET /v2/audiences[/{id}]`, `GET /v2/environments`, `GET /v2/projects` |

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1593,6 +1593,13 @@ Routing:
     sdk: "<detected>"
   ```
 
+  > **Python note.** The documented Confidence Python OpenFeature
+  > provider (`spotify-confidence-sdk`) is the **remote** provider and is
+  > in maintenance mode; an experimental local-resolve Python provider
+  > exists (`spotify/confidence-resolver`). Default to the remote provider
+  > unless the user opts into the experimental one — and if so, flag it as
+  > experimental in the plan.
+
 - **Server-rendered React / Next.js (RSC)** → **server-precomputed**.
   Use Confidence's React local-resolve provider (`<ConfidenceProvider>`
   + `useFlag`); fetch `getLocalResolveIntegrationGuide sdk: "JS"`.

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1569,10 +1569,10 @@ Preference"):
 
 | Target mode | Confidence SDKs | How evaluation works | Network profile |
 |-------------|-----------------|----------------------|-----------------|
-| **In-process** (local resolve) | backend **Java, Go, JS/Node, Rust** | Periodically fetch the resolver **state** (full ruleset); evaluate locally via WASM | No per-eval network call; network only for state refresh |
+| **In-process** (local resolve) | backend **Java, Go, JS/Node, Rust**, **Python** (Alpha provider) | Periodically fetch the resolver **state** (full ruleset); evaluate locally via WASM | No per-eval network call; network only for state refresh |
 | **Cached client** | **Android, iOS, web/browser JS, React, React Native** | Backend resolves; device **prefetches and caches resolved VALUES** (not the ruleset). Reads are local + offline. Context change triggers a refetch | Network on init / context change / refresh — NOT per read |
 | **Server-precomputed** | server-rendered React/Next.js (RSC) | Server resolves for a bound subject; client reads resolved values offline | Resolution on the server; client reads are offline |
-| **Remote** (per-call) | backend **Python, Ruby, .NET** | Each resolve is a service call to Confidence | One call per resolve (with default-value fallback on failure) |
+| **Remote** (per-call) | backend **Ruby, .NET**, **Python** (remote fallback) | Each resolve is a service call to Confidence | One call per resolve (with default-value fallback on failure) |
 
 Routing:
 
@@ -1585,20 +1585,26 @@ Routing:
     sdk: "JAVA" | "GO" | "JS" | "RUST"
   ```
 
+- Backend **Python** → prefer **in-process** (local resolve). Per the
+  "prefer local resolve" policy, default to the
+  **`confidence-openfeature-provider`** package (`from confidence import
+  ConfidenceProvider` + `api.set_provider_and_wait(provider)`; local WASM
+  eval). It is **Alpha** — flag that in the plan. The
+  `getLocalResolveIntegrationGuide` tool does not list Python yet, so use
+  the provider repo README (`spotify/confidence-resolver`,
+  `openfeature-provider/python`) for the exact API. Fall back to the
+  **remote** provider (`spotify-confidence-sdk` →
+  `ConfidenceOpenFeatureProvider` + `api.set_provider`, maintenance mode)
+  only if the user declines the Alpha provider; for that form fetch
+  `getCodeSnippetAndSdkIntegrationTips sdk: "python"`.
+
 - Client app (mobile / browser / React Native) → **cached client**.
-  Backend **Python / Ruby / .NET** → **remote**. Either way fetch:
+  Backend **Ruby / .NET** → **remote**. Fetch:
 
   ```
   mcp__confidence-docs__getCodeSnippetAndSdkIntegrationTips
     sdk: "<detected>"
   ```
-
-  > **Python note.** The documented Confidence Python OpenFeature
-  > provider (`spotify-confidence-sdk`) is the **remote** provider and is
-  > in maintenance mode; an experimental local-resolve Python provider
-  > exists (`spotify/confidence-resolver`). Default to the remote provider
-  > unless the user opts into the experimental one — and if so, flag it as
-  > experimental in the plan.
 
 - **Server-rendered React / Next.js (RSC)** → **server-precomputed**.
   Use Confidence's React local-resolve provider (`<ConfidenceProvider>`
@@ -1639,9 +1645,11 @@ exception.** Map the source surface to a mode:
 
 Then the Step 2b transitions apply:
 
-- Optimizely backend → Confidence **in-process** (Java/Go/JS/Rust): unchanged.
-- Optimizely backend → Confidence **remote** (Python/Ruby/.NET): ⚠️ in-process
-  → remote — each resolve becomes a service call.
+- Optimizely backend → Confidence **in-process** (Java/Go/JS/Rust, or
+  **Python** via the Alpha local-resolve provider): unchanged.
+- Optimizely backend → Confidence **remote** (Ruby/.NET, or Python on the
+  remote-fallback provider): ⚠️ in-process → remote — each resolve becomes
+  a service call.
 - Optimizely client → Confidence **cached client** (mobile/web): ⚠️ on-device
   → cached client. Reads stay local/offline and fast (NOT per-call
   network), but evaluation moves to the backend: the device caches

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1,0 +1,1494 @@
+---
+description: Migrate feature flag definitions from Optimizely to Confidence. Use when the user says /migrate-optimizely or asks to migrate Optimizely flags/rollouts/experiments to Confidence.
+---
+
+# Optimizely to Confidence Migration
+
+REST-driven, self-sufficient migration from Optimizely Feature
+Experimentation to Confidence. This skill is fully self-contained: it
+defines both the Optimizely-specific migration logic AND all the
+Confidence-side conventions it relies on (payload formats, naming rules,
+the flag setup sequence, the execute flow, etc.).
+
+## Plan Philosophy
+
+**Plans must be self-sufficient and agent-agnostic.**
+
+| Principle | Meaning |
+|-----------|---------|
+| **Source-boxed** | Every external data fetch uses one explicit channel (the Optimizely REST API with curl, the Confidence MCP) — no ad-hoc browsing |
+| **Self-sufficient** | Plan contains ALL information needed — no "query the source for X" at execute time |
+| **Agent-agnostic** | Any agent with the prerequisites can execute the plan without prior context |
+| **Language-agnostic** | Detect framework, fetch SDK guide from `confidence-docs` MCP dynamically |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/migrate-optimizely plan flags` | Phase 1: plan flag definitions migration |
+| `/migrate-optimizely execute <plan-file>` | Execute a plan interactively |
+
+---
+
+## Migration Overview (MUST display at start of `plan flags`)
+
+**Every time** the user runs `plan flags`, display this overview FIRST
+— before doing any work.
+
+```
+═══════════════════════════════════════════════════════════════
+  Optimizely → Confidence Migration
+═══════════════════════════════════════════════════════════════
+
+  The migration happens in two phases: flags first, then code.
+
+  ┌─────────────────────────────────────────────────────────┐
+  │  PHASE 1 — Flag Definitions                            │
+  │                                                        │
+  │  Move all flags, targeted-delivery rollouts, and A/B   │
+  │  tests from Optimizely to Confidence with their        │
+  │  audiences, traffic allocation, variations, and        │
+  │  variable values.                                      │
+  │                                                        │
+  │  Steps:                                                │
+  │    1. Scan Optimizely (flags, rulesets, audiences)     │
+  │    2. Choose a Confidence client (your app)            │
+  │    3. Map the bucketing ID to an entity field          │
+  │    4. Generate migration plan with targeting rules     │
+  │    5. Execute: create each flag in Confidence          │
+  │                                                        │
+  │  Result: All flags live in Confidence, ready to resolve│
+  ├─────────────────────────────────────────────────────────┤
+  │  PHASE 2 — Code Transformation (ships separately)      │
+  │                                                        │
+  │  Once flags exist in Confidence, the code that         │
+  │  evaluates them is migrated flag-by-flag, one PR each. │
+  │  Phase 2 is delivered as a follow-up to this skill.    │
+  └─────────────────────────────────────────────────────────┘
+
+  Why flags first?
+  Flags must exist in Confidence before code can resolve them.
+
+  Why one PR per flag?
+  Keeps changes small, reviewable, and independently shippable.
+  If one flag's migration has issues, it doesn't block the others.
+
+═══════════════════════════════════════════════════════════════
+```
+
+After displaying the overview, say: "Starting **Phase 1** — Flag
+Definitions", then proceed with the normal workflow.
+
+---
+
+## Prerequisites: Confidence Side
+
+### Confidence MCP
+
+Test: `mcp__confidence__listClients`
+
+If not available, install it:
+```
+claude mcp add confidence --transport http --url https://mcp.confidence.dev/mcp/flags
+```
+
+The user will be prompted to authenticate via OAuth in their browser.
+
+### Confidence REST API token (OPTIONAL — for full-fidelity Phase 1)
+
+The MCP `createFlag`/`addTargetingRule` tools cover the common cases but
+**cannot** express a few Optimizely constructs faithfully: partial
+traffic allocation with true fall-through (a rollout or A/B test whose
+non-included traffic should continue to the next rule rather than be
+served the default), reusable audiences shared across many flags, and
+mutual-exclusion groups. To migrate those faithfully, the skill uses the
+Confidence **management REST API** (`https://flags.confidence.dev/v1`),
+which needs a short-lived access token obtained via the
+client-credentials flow.
+
+Only ask for this if the scan finds features that need it (the plan
+flags them). To set it up:
+
+1. In Confidence, go to **Admin > API Clients**, create a client, and
+   copy its **client ID** and **client secret**.
+2. Exchange them for an access token (valid ~1h):
+   ```bash
+   curl -sS -X POST "https://iam.confidence.dev/v1/oauth/token" \
+     -H "Content-Type: application/json" \
+     -d '{"grantType":"client_credentials","clientId":"<id>","clientSecret":"<secret>"}'
+   # → { "accessToken": "eyJ...", "expiresIn": "86400" }
+   ```
+3. Store the token for the session as `CONFIDENCE_TOKEN` and send it as
+   `Authorization: Bearer $CONFIDENCE_TOKEN`. Never write the token or
+   the client secret to the plan file (same secret-handling rule as the
+   Optimizely token).
+
+## Two execution backends (MCP vs REST)
+
+Phase 1 has two ways to write to Confidence. Pick per flag based on what
+the flag needs — the plan records which backend each flag uses.
+
+| Backend | Use when | Auth | Limitations |
+|---------|----------|------|-------------|
+| **MCP** (default) | Flags whose rules are 100%-allocated, with inline audience targeting | OAuth (`mcp__confidence__*`) | No partial allocation with fall-through, no reusable audiences/segments, no exclusivity groups |
+| **REST** (full-fidelity) | Anything needing partial traffic allocation with fall-through, reusable audiences shared across flags, or exclusion-group mutual exclusion | Bearer token (above) | More verbose; segments must be allocated before use |
+
+The MCP backend is the tested default. Reach for REST only for the
+specific constructs listed; the operator/handling sections below point to
+the matching REST recipe ("Full-Fidelity Phase 1 via the Confidence REST
+API") wherever it applies.
+
+## User-Facing Communication Rules
+
+**NEVER expose internal technical details to the user.** The user should
+see human-readable descriptions of what's happening, not internal
+implementation details like targeting payload formats, rule types, or
+operator names.
+
+- Do NOT say "creating plan based on eqRule / rangeRule / setRule" etc.
+- Do NOT show raw targeting payloads or JSON structures in conversation
+- Do NOT echo any user-provided secret (API tokens) back into the
+  conversation or write them to the plan file — store them only as
+  environment variables for the session
+- DO say things like: "Creating flag with rule: plan equals 'pro' AND country is US or UK"
+- DO describe rules in plain English: "app version is at least 1.2.0", "country is US or CA"
+- The plan FILE may contain MCP command payloads (for machine execution),
+  but conversation output must be human-friendly
+
+## Prerequisites: Optimizely Side
+
+Optimizely does not publish a Claude MCP server, so the migration talks
+to Optimizely's **REST API** directly using `curl` from the Bash tool.
+
+### Required
+
+1. An **Optimizely API token** (a Personal Access Token, or a Service
+   Account token). Created in the Optimizely app under **Account
+   Settings > API Access** (`app.optimizely.com` → profile → API
+   Access). The token needs read access to flags, rulesets, and
+   audiences.
+2. The **Project ID** of the Optimizely Feature Experimentation project
+   to migrate. Find it in the app URL:
+   `https://app.optimizely.com/v2/projects/<PROJECT_ID>/flags/list`.
+3. Two base URLs are used (both authenticate with the same token):
+   - **Flags API** — `https://api.optimizely.com/flags/v1` (flags,
+     rulesets, rules, variations, environments)
+   - **Platform API v2** — `https://api.optimizely.com/v2` (audiences,
+     projects)
+
+**Authentication header (both APIs):**
+- `Authorization: Bearer <api-token>`
+
+### ASK the user (only if not already provided)
+
+> To read your Optimizely flags, rollouts, and experiments, I need:
+> 1. An Optimizely **API token** (Account Settings > API Access — a
+>    Personal Access Token is fine, with read access).
+> 2. Your **Project ID** (the number in the app URL, e.g.
+>    `app.optimizely.com/v2/projects/<PROJECT_ID>/flags/list`).
+>
+> Paste the token here, or set it in your shell as `OPTIMIZELY_API_TOKEN`
+> before continuing, and tell me the project ID.
+
+### Storing the token
+
+Once provided, store the token for the session in the environment
+variable `OPTIMIZELY_API_TOKEN` (export it in the Bash session the agent
+uses) and reference it via `$OPTIMIZELY_API_TOKEN` in every `curl` call —
+never hardcode the token into the plan file, the conversation output, or
+any committed file. If the user pastes a token inline, scrub it from the
+plan file and only keep a placeholder like `<your-optimizely-api-token>`.
+(See also the "never echo secrets" rule in the User-Facing Communication
+Rules above.) The project ID is not a secret and may be written to the
+plan.
+
+### Smoke test before scanning
+
+```bash
+curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
+  "https://api.optimizely.com/flags/v1/projects/$OPTIMIZELY_PROJECT_ID/flags?per_page=1" \
+  | head -c 200
+```
+
+If this returns a `401`/`403` or an HTML error page, stop and surface
+the error to the user — do not start scanning.
+
+### Local testing (no Optimizely account needed)
+
+For development and CI smoke tests, this skill ships with a fake
+Optimizely REST API server under
+`skills/migrate-optimizely/test-fixtures/`. It implements the read
+endpoints with curated fixtures that exercise every operator-mapping
+branch. See that directory's `README.md` for usage — short version is
+`python3 server.py`, then point this skill at `http://127.0.0.1:4100`
+when prompted for the base URL (the fake server serves both the
+`/flags/v1` and `/v2` routes on one port).
+
+---
+
+## Optimizely REST API Reference
+
+The migration uses these endpoints. All require
+`-H "Authorization: Bearer $OPTIMIZELY_API_TOKEN"`. `PROJECT_ID` is the
+project being migrated; `ENV_KEY` is an environment key (e.g.
+`production`).
+
+> **Source of truth.** Field names and shapes here are taken from
+> Optimizely's published API docs at
+> <https://docs.developers.optimizely.com/feature-experimentation/reference>.
+> Refer back to it if you encounter a field that isn't documented below.
+
+| Purpose | Endpoint |
+|---------|----------|
+| List flags (paginated) | `GET {flags}/projects/{PROJECT_ID}/flags?per_page=100&page=<n>` |
+| Get one flag (variable definitions, environments) | `GET {flags}/projects/{PROJECT_ID}/flags/{FLAG_KEY}` |
+| List a flag's variations | `GET {flags}/projects/{PROJECT_ID}/flags/{FLAG_KEY}/variations` |
+| Get the ruleset for a flag in an environment | `GET {flags}/projects/{PROJECT_ID}/flags/{FLAG_KEY}/environments/{ENV_KEY}/ruleset` |
+| List audiences (paginated) | `GET {v2}/audiences?project_id={PROJECT_ID}&per_page=100&page=<n>` |
+| Get one audience | `GET {v2}/audiences/{AUDIENCE_ID}` |
+| List environments | `GET {v2}/environments?project_id={PROJECT_ID}` |
+
+`{flags}` = `https://api.optimizely.com/flags/v1`,
+`{v2}` = `https://api.optimizely.com/v2`.
+
+**Convention.** Field names are `snake_case`. Flag keys may be
+`snake_case` or `kebab-case` and IDs are integers. **Percentages are in
+basis points out of 10000** (`10000` = 100%, `5000` = 50%, `2500` =
+25%). Audience `conditions` is a **JSON-encoded string** (parse it, then
+walk it). The list endpoints return `{ "items": [...], "page": N,
+"total_pages": M, ... }`.
+
+### Optimizely's flag model
+
+Optimizely Feature Experimentation has one configurable type — the
+**flag** — but a flag's behavior in each environment is governed by an
+ordered **ruleset**. All become Confidence flags:
+
+| Optimizely concept | What it is | Confidence flag shape |
+|--------------------|-----------|-----------------------|
+| **Flag** (no variables) | Boolean on/off feature | Boolean flag (`{ enabled }`); variations `on`/`off` |
+| **Flag with variables** | Returns typed variable values | Struct flag; one property per variable; each **variation** → a variant carrying its variable values |
+| **Targeted delivery rule** | Roll a flag out to an audience at a % | One targeting rule: audience → payload, rollout % → variant split |
+| **A/B test rule** | Experiment with weighted variations | One targeting rule: audience → payload, variation split by `percentage_included` |
+
+> **Groups (exclusion groups).** Optimizely can place several rules/
+> experiments in a **mutually exclusive group** sharing a traffic budget.
+> Migrate each rule as its own Confidence targeting rule. The mutual
+> exclusion maps to a Confidence **exclusivity group** via segment
+> coordination on the **REST** backend — see "Exclusion-group mutual
+> exclusion" under "Full-Fidelity Phase 1 via the Confidence REST API".
+> On the MCP backend, mutual exclusion can't be reproduced; record the
+> shared group as a note and surface the gap.
+
+### The Flag object
+
+- `key` (string used in code as the flag name), `name`, `description`
+- `archived` (boolean) — archived flags are skipped by default
+- `variable_definitions` — map of `key → { type, default_value }`.
+  `type` is one of `boolean`, `string`, `integer`, `double`, `json`.
+  `default_value` is always a **string** (parse per `type`). A flag with
+  no variables (or a single boolean variable) is a boolean flag.
+- `environments` — map of `env_key → { enabled, status, rules_detail[],
+  priority }`. `enabled` is whether the flag is ON in that environment.
+  Each flag has a **separate ruleset per environment** — the migration
+  reads the ruleset for the chosen environment (Step 1).
+
+### The Variation object (from `.../variations`)
+
+- `key` (e.g. `on`, `off`, or a custom variation key), `name`
+- `variables` — map of `variable_key → { value }` (the variable values
+  this variation serves). For a bare boolean flag the variations are
+  `on` (feature enabled) and `off` (feature disabled) with no variables.
+
+### The Ruleset object (per environment)
+
+- `rules` — map of `rule_key → Rule` (see below)
+- `rule_priorities` — **ordered list of rule keys, first wins.**
+  Confidence evaluates targeting rules top-down, so emit one rule per
+  Optimizely rule in `rule_priorities` order.
+- `enabled` — whether the ruleset (flag in this environment) is live. If
+  `false`, migrate the flag but keep it OFF (see disabled handling).
+- `default_variation_key` / `default_variation_name` — the variation
+  served when **no rule matches** (typically `off`). Maps to the
+  catch-all final rule's variant.
+
+### The Rule object
+
+- `key`, `name`
+- `type` — `targeted_delivery` (rollout), `a/b` (experiment),
+  `multi_armed_bandit` (adaptive — see notes), `feature_test` (legacy
+  experiment, treat like `a/b`)
+- `enabled` — a disabled rule contributes nothing; skip it (but keep the
+  catch-all default)
+- `percentage_included` — **rule-level traffic allocation** in basis
+  points (10000 = 100%). For `targeted_delivery` this is the rollout
+  percent; for `a/b` this is the percent of matched users who enter the
+  experiment.
+- `variations` — map of `variation_key → { percentage_included,
+  variation_id }`. `percentage_included` here (basis points) is the
+  split **within** the included traffic and sums to 10000 across the
+  rule's variations. A `targeted_delivery` rule usually has a single
+  `on` variation at 10000.
+- `audience_conditions` — the audience targeting (see "Audience
+  conditions"). Empty `[]` means "everyone".
+- `audience_ids` — the numeric ids referenced by `audience_conditions`.
+- `distribution_mode` — `manual` (fixed split), `stats_accelerator` /
+  `stats_engine` (adaptive — snapshot the current split and note it).
+
+**Pagination.** Optimizely uses `page` (1-based) + `per_page` (≤ 100).
+List responses carry `items[]`, `page`, and `total_pages`:
+
+```
+page = 1
+LOOP:
+  resp = GET .../flags?per_page=100&page=<page>
+  process resp.items
+  if page >= resp.total_pages OR resp.items is empty → STOP
+  page += 1 → continue LOOP
+```
+
+Repeat the loop for `flags` AND `audiences`.
+
+---
+
+## Step Trackers
+
+### Status markers
+
+- `○ pending` — not started yet
+- `◉ in progress` — currently running
+- `⏸ awaiting user` — blocked on user input (e.g. picking a client or entity)
+- `✓ done` — completed (add brief user-facing result)
+- `⊘ skipped` — skipped by user
+
+Use `⏸ awaiting user` whenever the workflow has asked a question and is
+waiting for an explicit reply. This makes "I'm blocked on you" visible
+to both agent and user, and prevents drifting into auto-progression
+while a question is open.
+
+**Never expose internal/technical details in the tracker.** No
+pagination info, no API page counts, no internal field names. Show only
+what matters to the user. **Update and re-display the tracker** at the
+start and after each step completes.
+
+### Execute progress bar
+
+The execute step tracker includes a progress bar. Use `█` for completed
+and `░` for remaining, 20 characters wide.
+
+```
+  Progress: [██████░░░░░░░░░░░░░░] 5/15 (1 skipped)
+  Current:  pricing-experiment
+```
+
+After each flag completes, show one of:
+
+```
+  ✓ flag-key — MATCH (variant-name)
+  ⊘ flag-key — skipped
+```
+
+### Final summary (Execute)
+
+At the end of execution, show a complete summary:
+
+```
+───── Migration Complete ──────────────────────────────────
+  Progress: [████████████████████] 15/15 done
+  Migrated: 14  |  Skipped: 1  |  Failed: 0
+
+  ✓ flag-key-1                100%   user_id
+  ✓ flag-key-2                50/50  user_id
+  ⊘ flag-key-3                —      skipped
+  ...
+────────────────────────────────────────────────────────────
+```
+
+### Plan Flags step tracker
+
+```
+───── Plan Flags ──────────────────────────────────────────
+  [1] Scan Optimizely  ○ pending
+  [2] Choose client    ○ pending
+  [3] Map bucketing ID ○ pending
+  [4] Generate plan    ○ pending
+────────────────────────────────────────────────────────────
+```
+
+Example after Step 1 completes:
+```
+───── Plan Flags ──────────────────────────────────────────
+  [1] Scan Optimizely  ✓ 12 flags, 4 audiences (env: production)
+  [2] Choose client    ◉ in progress
+  [3] Map bucketing ID ○ pending
+  [4] Generate plan    ○ pending
+────────────────────────────────────────────────────────────
+```
+
+### Execute step tracker
+
+```
+───── Execute Migration ───────────────────────────────────
+  Client: test  |  Unit: user_id  |  Flags: 15
+  Progress: [░░░░░░░░░░░░░░░░░░░░] 0/15
+────────────────────────────────────────────────────────────
+```
+
+---
+
+## Confidence Naming Rules
+
+- **Flag names:** lowercase letters, digits, and hyphens only (`[a-z0-9-]`).
+  Optimizely flag keys often use `snake_case` (`new_checkout_flow`);
+  normalize to hyphens (`new-checkout-flow`) and record the mapping in
+  the plan so the code phase can find the right replacement.
+- **Entity references:** Confidence entity names do NOT support underscores.
+  The entity reference (e.g. `entities/company`) is separate from the context
+  field name (e.g. `company_id`). When creating entity fields with
+  `addContextField`, always provide an explicit `entityReference` with a
+  clean name (no underscores). If omitted, the tool auto-generates one from
+  the field name which will fail.
+
+  | Field name | Entity reference | Works? |
+  |------------|-----------------|--------|
+  | `user_id` | `entities/user` | Yes |
+  | `company_id` | `entities/company` | Yes |
+  | `visitor_id` | `entities/visitor` | Yes |
+  | `company_id` | *(omitted — auto: `entities/company_id`)* | **No** |
+
+## Plan Files: Resume Check & Progressive Updates
+
+`plan flags` uses a progressive plan file. Created at Step 1, updated
+after each step, so a closed session can resume.
+
+### Resume check (MUST do first)
+
+Before starting any plan workflow, check for an existing in-progress
+plan:
+
+- `plan flags` → `.claude/plans/optimizely-flag-migration-*.md`
+
+If a plan file exists, read its `## Generation Status` section:
+
+- If status is `complete` → tell user a plan already exists, ask if
+  they want to start fresh or use the existing one
+- If status is NOT `complete` → **resume from the last incomplete step**.
+  Tell the user: "Found an in-progress plan. Resuming from step <N>."
+- If no plan file exists → start fresh
+
+### Generation Status table
+
+Every plan file MUST include a `## Generation Status` section at the
+top that tracks which steps are done. Status values: `✓ complete`,
+`◉ in progress`, `○ not started`. **After each step completes**, update
+the status table AND write that step's data to the plan file. Do NOT
+wait until the end to write.
+
+## Plan Flag: Steps
+
+The migration follows a 4-step plan flow: Step 1 scan Optimizely (and
+pick the environment), Step 2 choose a Confidence client, Step 3 map the
+bucketing ID, Step 4 generate the MCP commands.
+
+### Plan-file path
+
+`.claude/plans/optimizely-flag-migration-<date>.md`
+
+### Step 1: Scan Optimizely
+
+**Step 1a — pick the environment.** Optimizely keeps a separate ruleset
+per environment (e.g. `development`, `production`). List environments and
+ASK which one to migrate (default: `production`):
+
+```bash
+curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
+  "https://api.optimizely.com/v2/environments?project_id=$OPTIMIZELY_PROJECT_ID"
+```
+
+Record the chosen `ENV_KEY` in the plan — every ruleset fetch uses it.
+
+**Step 1b — list all flags. CRITICAL: paginate until exhausted.**
+
+```
+page = 1
+LOOP:
+  resp = GET .../projects/{PROJECT_ID}/flags?per_page=100&page=<page>
+  process resp.items
+  if page >= resp.total_pages OR resp.items empty → STOP
+  page += 1 → continue LOOP
+```
+
+```bash
+curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
+  "https://api.optimizely.com/flags/v1/projects/$OPTIMIZELY_PROJECT_ID/flags?per_page=100&page=1"
+```
+
+Ask once up-front: "Include archived flags too? Default: no". Skip flags
+whose `archived` is `true` unless the user opts in.
+
+**Step 1c — for each flag, fetch its variations and the ruleset for the
+chosen environment (in batches of 5).**
+
+```bash
+# variations (variable values per variation)
+curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
+  "https://api.optimizely.com/flags/v1/projects/$OPTIMIZELY_PROJECT_ID/flags/<FLAG_KEY>/variations"
+# ruleset for the chosen environment (rules, priorities, default variation)
+curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
+  "https://api.optimizely.com/flags/v1/projects/$OPTIMIZELY_PROJECT_ID/flags/<FLAG_KEY>/environments/<ENV_KEY>/ruleset"
+```
+
+**After each batch of 5**, write the data to the plan file — append the
+sections to Section 4. This way if the session closes mid-scan, the
+flags fetched so far are saved.
+
+Extract from each flag:
+
+- `key`, `name`, `description`
+- `variable_definitions` — determines the Confidence flag shape (boolean
+  vs struct; see "Optimizely's flag model")
+- the variations and their variable values
+- the chosen environment's ruleset: `rule_priorities` (order),
+  `default_variation_key`, and `enabled`
+- For each rule (in `rule_priorities` order): `type`,
+  `percentage_included`, the `variations` split, `audience_conditions` /
+  `audience_ids`, `enabled`, `distribution_mode`
+- Whether the flag needs the **REST backend** (partial allocation that
+  must fall through, reusable audiences, or an exclusion group) — record
+  the backend on the flag's plan entry so `execute` knows which path to
+  take
+
+**Step 1d — fetch referenced audiences (once per unique id).** While
+scanning rules, collect every `audience_id` referenced by any rule's
+`audience_conditions`. For each unique id:
+
+```bash
+curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
+  "https://api.optimizely.com/v2/audiences/<AUDIENCE_ID>"
+```
+
+Parse the audience's `conditions` (a JSON-encoded string) and translate
+its conditions with the operator table. The Confidence MCP in this plugin
+has no `createSegment` tool, so **inline** the audience's conditions into
+each referencing flag's targeting (see "Audiences"). On the REST backend,
+a reusable audience referenced by many flags becomes one Confidence
+segment.
+
+**Bucketing ID.** Optimizely buckets each user on the ID passed to the
+SDK (`decide` / `activate`), optionally overridden by a `$opt_bucketing_id`
+attribute. There is no per-flag unit type — the user maps the bucketing
+ID to one Confidence entity field in Step 3.
+
+**After scan completes:** Update Generation Status step 1 to `✓ complete`.
+
+### Step 2: Select Confidence client
+
+```
+mcp__confidence__listClients
+```
+
+**EDUCATE then ASK the user:**
+
+> **What is a client?**
+> A client represents the application that resolves flags — your website,
+> backend service, or mobile app. Each client has its own secret for
+> authentication and can be scoped to environments (dev, staging, prod).
+> Flags are associated with one or more clients, so Confidence knows which
+> application should receive which flags.
+>
+> Think of it like: "Where will these flags be evaluated?"
+>
+> Your existing clients:
+> 1. <client-1>
+> 2. <client-2>
+> ...
+> N. Create a new client
+>
+> Which client should I use as the default for all flags?
+> You can always rearrange them later in the Confidence UI.
+
+**Wait for an explicit pick.** Set the step to `⏸ awaiting user` and
+stop. A re-run of the migration command, an empty message, or any reply
+that is not a number from the list / `new <name>` is **not** consent —
+NEVER infer the recommendation from silence. If the reply is ambiguous,
+re-ask, listing the choices again.
+
+- If user picks existing → use it
+- If user wants new → ASK for name → `mcp__confidence__createClient`
+
+**After client selected:** Write the "Default Client" section to the
+plan file and update Generation Status step 2 to `✓ complete`.
+
+### Step 3: Map Bucketing ID (Optimizely-specific)
+
+This step maps Optimizely's bucketing ID (the user ID handed to the SDK)
+to a Confidence entity field.
+
+**EDUCATE then ASK:**
+
+> **What is a randomization unit (entity)?**
+> An entity is the "thing" that gets randomly assigned to a variant —
+> usually a user. The entity field (like `user_id` or `visitor_id`) is
+> the identifier Confidence uses to ensure **consistent assignment**: the
+> same user always sees the same variant.
+>
+> In Confidence, it maps to the `targetingKey` in the evaluation context.
+>
+> In Optimizely, every flag buckets on the **user ID** you pass to
+> `decide()` (or a `$opt_bucketing_id` override).
+>
+> Common choices:
+> - **user_id** — for authenticated users
+> - **visitor_id** — for anonymous visitors (auto-generated by Confidence
+>   client SDKs)
+> - **company_id** — for a company/org/tenant unit
+>
+> Your client's existing entity fields:
+> 1. <entity-field-1>
+> 2. <entity-field-2>
+> ...
+> N. Create a new field
+>
+> Which Confidence field represents the Optimizely user/bucketing ID?
+
+Same wait-for-explicit-pick rule as Step 2 above. Silence is not
+consent.
+
+- If user picks existing → use it as `targetingKey`
+- If user wants new → ASK for name + type → `mcp__confidence__addContextField`
+  (always provide an explicit `entityReference` — see Confidence Naming
+  Rules above)
+
+### Step 4: Generate MCP commands
+
+**Confirmation gate (MUST pass before generating).** Before writing the
+Flags to Migrate section, summarize the choices made in earlier steps
+(environment, client, bucketing-ID → entity mapping) and ask:
+
+> Plan will assume environment `<env>`, client `<client>`, with the
+> Optimizely user ID → entity `<entity>`. All flags will be defaulted to
+> `[ ] Migrate  [ ] Skip` (neither pre-checked) — you'll opt each one in
+> during review. Confirm or change?
+
+Set the step to `⏸ awaiting user` and stop. Only proceed on an explicit
+`yes` / `confirm` / equivalent. A re-run or ambiguous reply is **not**
+confirmation.
+
+For each flag, generate the MCP command payloads (`createFlag`,
+`addFlagToClient`, `addTargetingRule`, `resolveFlag`) using the Operator
+Mapping table together with the Confidence Targeting Payload Format
+(below). Write them into each flag's section in the plan.
+
+**After all commands generated:** Update Generation Status step 4 to
+`✓ complete`, set the overall status to `complete`, and tell the user:
+
+> Plan generated! Review it at `.claude/plans/optimizely-flag-migration-<date>.md`
+>
+> Migration is **opt-in**: every flag starts with both checkboxes empty.
+> Tick `[x] Migrate` or `[x] Skip` for each flag — `execute` will refuse
+> any flag with neither box set. When ready, run:
+> `/migrate-optimizely execute <plan-file>`
+
+**Rule → targeting-rule order.** Optimizely rules form a waterfall —
+the first matching rule (by `rule_priorities`) wins. Confidence
+evaluates targeting rules in declared order, so emit one
+`addTargetingRule` call per Optimizely rule, in the same order.
+
+---
+
+## Confidence Targeting Payload Format
+
+This is how Confidence targeting rules are structured. Use this when
+generating `addTargetingRule` payloads.
+
+**CRITICAL:** The payload uses a `criteria` + `expression` pattern.
+Criteria are named references (`ref-0`, `ref-1`, ...) that define
+individual conditions. The `expression` combines them with boolean
+logic (`and`, `or`, `not`, `ref`).
+
+```json
+{
+  "criteria": {
+    "ref-0": {
+      "attribute": {
+        "attributeName": "<field>",
+        "<rule>": { ... }
+      }
+    }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+**DO NOT use nested rule objects like `{"or": {"operands": [{"eqRule": ...}]}}`
+at the top level.** That format is silently parsed as empty targeting
+(matching ALL contexts) due to `ignoringUnknownFields()` in the proto
+parser.
+
+### Criterion rules
+
+These mirror the canonical `Targeting` proto in the open-source
+resolver (`spotify/confidence-resolver`,
+`protos/confidence/flags/types/v1/target.proto`). The JSON wire form is
+proto3 → JSON (camelCase keys).
+
+| Match | Form |
+|---|---|
+| String eq | `"eqRule": { "value": { "stringValue": "X" } }` |
+| Number eq | `"eqRule": { "value": { "numberValue": N } }` |
+| Bool eq | `"eqRule": { "value": { "boolValue": true } }` |
+| Version eq | `"eqRule": { "value": { "versionValue": { "version": "1.2.3" } } }` |
+| String set (in) | `"setRule": { "values": [{ "stringValue": "A" }, { "stringValue": "B" }] }` |
+| `>=` | `"rangeRule": { "startInclusive": { "numberValue": N } }` |
+| `>` | `"rangeRule": { "startExclusive": { "numberValue": N } }` |
+| `<` | `"rangeRule": { "endExclusive": { "numberValue": N } }` |
+| `<=` | `"rangeRule": { "endInclusive": { "numberValue": N } }` |
+| Version `>=` | `"rangeRule": { "startInclusive": { "versionValue": { "version": "2.0.0" } } }` |
+| Version `<` | `"rangeRule": { "endExclusive": { "versionValue": { "version": "3.0.0" } } }` |
+| Timestamp `>=` | `"rangeRule": { "startInclusive": { "timestampValue": "2022-11-17T15:16:17Z" } }` |
+| starts with | `"startsWithRule": { "value": "prefix" }` |
+| ends with | `"endsWithRule": { "value": "suffix" }` |
+| list attr: any item matches | `"anyRule": { "rule": { "setRule": { "values": [...] } } }` (inner rule may be `eqRule`/`setRule`/`rangeRule`/`startsWithRule`/`endsWithRule`; no match on empty/missing list) |
+| list attr: every item matches | `"allRule": { "rule": { ... } }` (same inner rules; matches on empty/missing list) |
+
+> **No working presence operator.** A bare attribute criterion with **no
+> inner rule** (`{ "attribute": { "attributeName": "X" } }`) is *accepted*
+> by `addTargetingRule` but stores with `operator: "unknown"` and
+> **errors at resolve** (verified live: the rule returns
+> `Status: ERROR — Resolve status unknown` and is treated as no-match).
+> So there is **no reliable "attribute exists / is null" targeting** via
+> the current tooling — do NOT emit ruleless criteria. Map Optimizely's
+> `exists` match type to **BLOCKED** (see Operator Mapping).
+
+**Value types.** A `Value` is a oneof: `boolValue`, `numberValue`,
+`stringValue`, `timestampValue` (RFC-3339 string), `versionValue`
+(`{ "version": "X.Y.Z" }`), or `listValue`. Equality (`==`, `!=`, set
+membership) is defined for all types; comparison (`<`, `<=`, `>`, `>=`
+via `rangeRule`) is defined for **number, timestamp, and version**.
+
+**Version semantics.** The resolver parses version strings with 2–4
+numeric segments (`1.2`, `1.2.3`, `1.2.3.4`), strips any pre-release
+suffix after `-` (`1.2.3-beta` compares as `1.2.3`), and rejects
+non-numeric or `v`-prefixed strings (`v1.0.0` → does not parse).
+Send the version in the evaluation context as a plain string; the
+`versionValue` criterion makes Confidence compare it as a version
+rather than lexically.
+
+**Set rule vs OR-of-eq.** `setRule` with multiple values is the native
+"is one of" and is preferred over an `or` of `eqRule`s when realizing
+list membership. Both resolve identically.
+
+**Existence / null checks are NOT supported.** A bare attribute
+criterion with no inner rule (`{ "attribute": { "attributeName": "X" } }`)
+looks like a presence check, but it is **broken at resolve**: it stores
+with `operator: "unknown"` and the resolver returns
+`Status: ERROR — Resolve status unknown`, which is treated as no-match
+(verified live against the resolver). There is therefore **no reliable
+way to target "attribute is set" or "attribute is null/absent"**. Do NOT
+emit ruleless criteria. Map Optimizely's `exists` match type (and any
+negated-exists) to **BLOCKED** — see the Operator Mapping table and the
+Blocked section.
+
+### Default value (no server-side default → emit a catch-all rule)
+
+Confidence has **no server-side flag default**. The `Flag` resource
+carries variants and an ordered list of rules but no default-value
+field. The resolver's contract is explicit: *"each rule is tried in
+order; the first match assigns a variant; if no rule matches, no variant
+is assigned."* When no rule matches, the SDK returns **the default the
+caller passed at the call site** (e.g. `decide` falls back to the
+flag-off default).
+
+So an Optimizely default — the ruleset's `default_variation_key`
+(typically `off`) — does **not** map to any flag-level field. To
+preserve it faithfully, emit it as an explicit **catch-all final rule**:
+
+- `addTargetingRule` with `variantAllocations` =
+  `{ "<defaultVariant>": 100 }` and **no `payload`** (an omitted/empty
+  payload targets all contexts).
+- Add it **last**, after every specific rule, so it only catches
+  subjects that matched nothing above it.
+
+For a **boolean flag**, the catch-all variant is `disabled` (`off`) —
+reached only by users who matched **no** rule. For a **flag with
+variables**, the catch-all variant carries the `default_variation`'s
+variable values (usually the `off` variation's values).
+
+### Expression combinators
+
+| Pattern | Expression |
+|---------|-----------|
+| Single condition | `{ "ref": "ref-0" }` |
+| AND | `{ "and": { "operands": [{ "ref": "ref-0" }, { "ref": "ref-1" }] } }` |
+| OR | `{ "or": { "operands": [{ "ref": "ref-0" }, { "ref": "ref-1" }] } }` |
+| NOT | `{ "not": { "ref": "ref-0" } }` |
+| NOT IN (list) | Prefer one `setRule` criterion wrapped in `not`: `{ "not": { "ref": "ref-0" } }`. |
+| attribute IS null / IS set | **Not supported** — ruleless presence criteria error at resolve (see "Existence / null checks"); BLOCK these. |
+
+### Worked examples
+
+**Single equality (country = "US"):**
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "country", "eqRule": { "value": { "stringValue": "US" } } } }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+**Version range (appVersion >= 2.0.0):**
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "appVersion", "rangeRule": { "startInclusive": { "versionValue": { "version": "2.0.0" } } } } }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+**Set membership (country in [US, UK, SE]):**
+```json
+{
+  "criteria": {
+    "ref-0": { "attribute": { "attributeName": "country", "setRule": { "values": [{ "stringValue": "US" }, { "stringValue": "UK" }, { "stringValue": "SE" }] } } }
+  },
+  "expression": { "ref": "ref-0" }
+}
+```
+
+## Audiences
+
+An Optimizely **audience** is a named, reusable targeting condition.
+Confidence **has** reusable segments, but the **MCP** backend in this
+plugin exposes no `createSegment` tool. So the handling depends on the
+backend:
+
+- **REST backend (preferred for reuse):** create one Confidence segment
+  per Optimizely audience and reference it from every flag that uses it —
+  see "Audiences as reusable segments" under "Full-Fidelity Phase 1 via
+  the Confidence REST API". This preserves reuse/de-duplication.
+- **MCP backend (inline fallback):** with no `createSegment` tool,
+  **inline** the audience's conditions into each referencing flag. Parse
+  the audience's `conditions` string, translate each leaf condition with
+  the operator table, and combine them per the condition language's
+  `and` / `or` / `not` operators into the flag's `criteria` +
+  `expression`. Repeat the inlined criteria in each referencing flag (no
+  de-dup without a segment primitive — note in the plan).
+
+### Audience condition language
+
+An audience's `conditions` is a **JSON-encoded string**. Parse it first.
+The structure is a nested list whose first element is an operator:
+
+```
+["and", cond_or_list, cond_or_list, ...]
+["or",  cond_or_list, cond_or_list, ...]
+["not", cond_or_list]                       # exactly one operand
+{ ...leaf condition... }
+```
+
+A `["and", X]` / `["or", X]` with a single operand just matches `X`.
+Optimizely's UI commonly emits deeply nested wrappers like
+`["and", ["or", ["or", {leaf}]]]` — flatten single-operand wrappers
+when translating.
+
+**Leaf condition (custom attribute):**
+
+```json
+{ "type": "custom_attribute", "name": "<attr>", "match_type": "<mt>", "value": <v> }
+```
+
+- `name` → the Confidence attribute name (the evaluation-context field).
+- `match_type` → the rule shape (see Operator Mapping).
+- `value` → the comparison value (string, number, or boolean).
+- A missing `match_type` defaults to `exact` when a `value` is present,
+  or `exists` when no value is present.
+
+**Audience references (combinations).** A rule's `audience_conditions`
+may also contain `{ "audience_id": <id> }` leaves that reference whole
+audiences. Resolve each referenced audience and inline its conditions
+(MCP), or reference the corresponding Confidence segment (REST), then
+combine with the surrounding `and` / `or` / `not`.
+
+**Non-custom-attribute leaves.** Optimizely Web audiences can use
+`type`s like `browser`, `device`, `query`, `cookie`, `location`. In
+Feature Experimentation, audiences are almost always `custom_attribute`
+(the SDK passes attributes explicitly). Any non-`custom_attribute` leaf
+has no Confidence equivalent — mark it **BLOCKED** for manual review.
+
+## Multivariant / Traffic Allocation Handling
+
+**CRITICAL — there is no separate `rolloutPercentage` knob.** The
+Confidence `addTargetingRule` tool takes only `variantAllocations` (a
+map of variant → percent that **must sum to exactly 100**), `payload`,
+and `targetingKey`. Encode the entire rollout or variation split *inside*
+`variantAllocations` — do NOT expect a rule-level rollout field.
+
+**Percentages are basis points in Optimizely.** Divide by 100:
+`percentage_included` 10000 → 100, 5000 → 50, 2500 → 25.
+
+- **Targeted-delivery rule** (rollout): ONE Confidence rule with the
+  audience as `payload` and `variantAllocations` =
+  `{ "<on-variant>": <pct>, "<off/default-variant>": <100 − pct> }`,
+  where `pct` is the rule's `percentage_included / 100`. A 100% rollout
+  is `{ "<on>": 100 }`. An empty `audience_conditions` ("everyone") is
+  the same but with **no payload** (targets all).
+- **A/B test rule** (experiment): ONE Confidence rule (audience as
+  `payload`, or no payload) with `variantAllocations` = each variation's
+  key → its `percentage_included / 100` (e.g.
+  `{ "off": 50, "on": 50 }`). If the rule-level `percentage_included` is
+  < 100 (partial allocation), see the note below.
+
+**Do NOT create separate rules per variant.** One targeting rule = one
+set of targeting conditions, with the variant split defined inside that
+rule via `variantAllocations`.
+
+### Partial / fall-through allocation (`percentage_included` < 100)
+
+Optimizely's waterfall has **true fall-through**: a user who matches a
+rule's audience but isn't in its `percentage_included` traffic continues
+to the **next** rule in `rule_priorities`. The MCP backend can't be
+exact (`variantAllocations` must sum to 100, no rollout knob).
+
+- If the un-included traffic in Optimizely would just land on the
+  default variation anyway (the common case for the last/"everyone"
+  rule), the MCP approximation is faithful: fold the remainder into the
+  default variant inside `variantAllocations`.
+- If un-included traffic must **fall through to a later rule**, **prefer
+  the REST backend**, which represents it exactly via a segment
+  `allocation.proportion` + variant bucket ranges (users not in the
+  segment fall through to the next rule) — see "Partial allocation with
+  fall-through" under "Full-Fidelity Phase 1 via the Confidence REST
+  API". If REST isn't available, fall back to the MCP approximation and
+  **record that it's approximate** in the plan.
+
+### Adaptive distribution (`multi_armed_bandit` / `stats_accelerator`)
+
+When `type` is `multi_armed_bandit`, or `distribution_mode` is
+`stats_accelerator` / `stats_engine`, Optimizely adjusts the split
+dynamically. Confidence allocations are static, so **snapshot the
+current `percentage_included` split** as the `variantAllocations` and
+**note in the plan** that the live split was adaptive (it won't keep
+auto-tuning after migration).
+
+## Operator Mapping (Optimizely → Confidence)
+
+This is how Optimizely audience conditions map to the Confidence
+targeting payloads defined above. Within an audience, leaves are combined
+by the condition language's `and` / `or` / `not`. Across rules in a
+flag's ruleset, the waterfall means each rule becomes a **separate
+Confidence targeting rule** in `rule_priorities` order.
+
+A leaf is `{ type: "custom_attribute", name, match_type, value }`. The
+**`name`** selects the attribute; the **`match_type`** selects the rule
+shape; the JSON type of **`value`** selects the `Value` type
+(`stringValue` / `numberValue` / `boolValue`).
+
+### `match_type` → Confidence rule shape
+
+| Optimizely `match_type` | Confidence payload strategy |
+|---|---|
+| `exact` (string) | one criterion `eqRule` with `stringValue`, expression `ref` |
+| `exact` (number) | one criterion `eqRule` with `numberValue`, expression `ref` |
+| `exact` (boolean) | one criterion `eqRule` with `boolValue`, expression `ref` |
+| `exists` | **BLOCKED** (no working presence operator — ruleless criteria error at resolve) |
+| `gt` | `rangeRule.startExclusive: { numberValue: N }` |
+| `ge` | `rangeRule.startInclusive: { numberValue: N }` |
+| `lt` | `rangeRule.endExclusive: { numberValue: N }` |
+| `le` | `rangeRule.endInclusive: { numberValue: N }` |
+| `semver_eq` | `eqRule.value.versionValue: { version }` |
+| `semver_gt` | `rangeRule.startExclusive: { versionValue: { version } }` |
+| `semver_ge` | `rangeRule.startInclusive: { versionValue: { version } }` |
+| `semver_lt` | `rangeRule.endExclusive: { versionValue: { version } }` |
+| `semver_le` | `rangeRule.endInclusive: { versionValue: { version } }` |
+| `substring` | **BLOCKED** (Confidence has no substring/contains rule) |
+| `regex` | **BLOCKED** (Confidence has no general regex rule) |
+
+**Negation.** A leaf inside a `["not", ...]` list is wrapped in `not` in
+the Confidence expression. `["not", {exact value}]` is "not equals" (a
+real `eqRule` under `not`, which works). `["not", {exists}]` ("attribute
+is null/absent") is **BLOCKED** — it depends on the unsupported presence
+criterion.
+
+**Set membership.** Optimizely expresses "is one of" as an `["or", ...]`
+of `exact` leaves on the same attribute. Collapse those into a single
+`setRule` (preferred), or keep them as an `or` of `eqRule`s — both
+resolve identically.
+
+**Booleans.** Optimizely attributes are untyped; a boolean audience uses
+`value: true/false` with `match_type: exact`. Map to `boolValue`. The
+evaluation context must send a real boolean (not the string `"true"`).
+
+### Blocked (manual review)
+
+These genuinely have no clean Confidence translation:
+
+- **`substring`** — Confidence has no substring/contains rule. Reason:
+  `Uses a 'contains' match on '<attribute>'; Confidence has no substring
+  rule.` (Workaround: change the context field to send a list of strings
+  and use set matching.)
+- **`regex`** — Confidence has no general regex rule. Reason: `Uses a
+  regex on '<attribute>'; Confidence has no general regex rule.`
+- **`exists`** (and negated-exists) — Confidence has no working presence
+  operator; a ruleless attribute criterion stores as `operator: unknown`
+  and errors at resolve. Reason: `Uses an 'exists'/presence match on
+  '<attribute>'; Confidence has no presence operator.` (Workaround: if
+  the attribute has a small known set of values, target those explicitly
+  with a `setRule`; otherwise migrate manually.)
+- **Non-`custom_attribute` audience leaves** (`browser`, `device`,
+  `query`, `cookie`, `location`, ODP `qualified` segments) — no
+  Confidence equivalent. Reason: `Uses a '<type>' audience condition with
+  no Confidence equivalent; migrate manually.`
+
+When a rule/condition is blocked, mark it in Section 4 (per the
+template). A flag is fully blocked only when *every* non-default rule is
+blocked.
+
+### Worked example (ruleset waterfall)
+
+A two-rule flag — a targeted-delivery rollout to a "Beta users" audience
+at 25%, then an "everyone" rollout at 100% — becomes `addTargetingRule`
+calls plus a catch-all (the split lives entirely in `variantAllocations`;
+there is no separate rollout field):
+
+1. Rule 1 (`targeted_delivery`, `percentage_included` 2500, audience
+   "Beta users" = `is_beta exact true`) → payload `eqRule boolValue
+   true` on `is_beta`, `variantAllocations { "on": 25, "off": 75 }`
+2. Rule 2 (`targeted_delivery`, `percentage_included` 10000, no
+   audience) → no payload, `variantAllocations { "on": 100 }`
+3. Catch-all (default): no payload → `off` at 100%. Reproduces the
+   ruleset's `default_variation` (`off`); MUST come last. (When Rule 2
+   already covers everyone at 100%, the catch-all is only reached if no
+   earlier rule matched — keep it for safety / disabled-flag cases.)
+
+---
+
+## Full-Fidelity Phase 1 via the Confidence REST API
+
+Use this path for the constructs the MCP can't express: partial traffic
+allocation with fall-through, reusable audiences shared across flags, and
+exclusion-group mutual exclusion. It needs the `CONFIDENCE_TOKEN` from
+"Prerequisites: Confidence Side". Base URL
+`https://flags.confidence.dev/v1`; every call sends
+`-H "Authorization: Bearer $CONFIDENCE_TOKEN"`.
+
+### The REST rule model (different from the MCP model)
+
+A REST flag rule does **not** carry an inline payload + `variantAllocations`.
+Instead it references a **segment** (which holds the targeting + the
+allocation proportion) and assigns variants by **bucket ranges**:
+
+```bash
+curl -sS -X POST "https://flags.confidence.dev/v1/flags/<flag>/rules" \
+  -H "Authorization: Bearer $CONFIDENCE_TOKEN" -H "Content-Type: application/json" \
+  -d '{
+  "segment": "segments/<segment-id>",
+  "assignmentSpec": {
+    "bucketCount": 100,
+    "assignments": [
+      { "variant": { "variant": "flags/<flag>/variants/off" }, "bucketRanges": [{"lower":0,"upper":50}] },
+      { "variant": { "variant": "flags/<flag>/variants/on" }, "bucketRanges": [{"lower":50,"upper":100}] }
+    ]
+  },
+  "targetingKeySelector": "user_id"
+}'
+```
+
+Key facts:
+- **Targeting lives in the segment**, not the rule. The rule picks the
+  segment + the variant split (bucket ranges over `bucketCount`).
+- **Allocation/rollout = the segment's `allocation.proportion`** (0.0–1.0):
+  the fraction of the matched audience that is *in* the segment. Users
+  not in the segment fall through to the next rule — this is exactly
+  Optimizely's `percentage_included` fall-through behavior.
+- Special assignments: `{"fallthrough":{}}` (matched → continue to next
+  rule) and `{"clientDefault":{}}` (serve the caller's default).
+- **Rules start disabled.** Enable each with
+  `PATCH /v1/flags/<flag>/rules/<ruleId>?updateMask=enabled` body
+  `{"enabled":true}`. Order via the `priority` field (lower = first).
+- Flags/variants still need to exist first — create them with the MCP
+  `createFlag` (recommended, since it also wires the client) or via
+  `POST /v1/flags`. Either way the REST rules then reference
+  `flags/<flag>/variants/<variant>`.
+
+### Audiences as reusable segments
+
+Create once, allocate, reference from many flag rules:
+
+```bash
+# segment from an Optimizely audience's conditions
+curl -sS -X POST "https://flags.confidence.dev/v1/segments?segmentId=<id>" \
+  -H "Authorization: Bearer $CONFIDENCE_TOKEN" -H "Content-Type: application/json" \
+  -d '{ "displayName": "<name>",
+        "targeting": { "criteria": { ... }, "expression": { ... } },
+        "allocation": { "proportion": { "value": "1.0" } } }'
+# segments MUST be allocated before use in a rule:
+curl -sS -X POST "https://flags.confidence.dev/v1/segments/<id>:allocate" \
+  -H "Authorization: Bearer $CONFIDENCE_TOKEN"
+```
+
+- The `targeting` uses the **same** `criteria` + `expression` payload as
+  the MCP path (the Operator Mapping table is unchanged — only the
+  transport differs).
+- **De-duplicate:** an Optimizely audience referenced by N flags becomes
+  ONE Confidence segment, referenced N times. Track the
+  `optimizely-audience-id → segments/<id>` map in the plan.
+- **Composing audiences (e.g. audience A AND NOT audience B in one
+  rule):** a REST flag rule references exactly ONE segment, but segment
+  targeting supports **segment criteria** — create a wrapper segment
+  whose expression combines the reusable ones:
+
+  ```json
+  "targeting": {
+    "criteria": { "s0": { "segment": { "segment": "segments/beta-users" } },
+                   "s1": { "segment": { "segment": "segments/internal-staff" } } },
+    "expression": { "and": { "operands": [ { "ref": "s0" }, { "not": { "ref": "s1" } } ] } }
+  }
+  ```
+
+### Partial allocation with fall-through
+
+A rule whose `percentage_included` < 100 and whose un-included traffic
+must fall through to a later rule maps exactly:
+
+1. Create a segment for the rule's audience targeting (or empty
+   `targeting: {}` for "everyone"), with `allocation.proportion =
+   percentage_included / 10000` (e.g. `"0.25"` for 2500 basis points).
+2. Allocate the segment.
+3. Add a flag rule referencing it whose `assignmentSpec` splits the
+   variations across the full `0–100` bucket range by their
+   `percentage_included` (basis points).
+4. Subsequent rules (the next entries in `rule_priorities`) become later
+   rules — users not in the segment fall through to them, exactly like
+   Optimizely.
+
+This reproduces "25% get the rollout, the other 75% fall through to the
+next rule" faithfully, which the MCP `variantAllocations` (sum-to-100, no
+rollout knob) cannot.
+
+### Exclusion-group mutual exclusion
+
+Optimizely **exclusion groups** make their experiments mutually
+exclusive. Map each group to a Confidence **exclusivity group** via
+segment coordination: every rule in group `G` gets a segment whose
+`allocation` carries matching coordination tags:
+
+```json
+"allocation": { "proportion": { "value": "0.5" },
+                "exclusivityTags": ["<group-id>"],
+                "exclusiveTo": ["<group-id>"] }
+```
+
+Segments sharing an `exclusivityTags`/`exclusiveTo` group never overlap —
+no user lands in two of the group's experiments. The sum of proportions
+across a coordination group must fit in 100% (allocation can fail
+otherwise — surface that to the user). Record the
+`group-id → exclusivity tag` mapping in the plan.
+
+### Verification
+
+REST-created flags resolve through the same client. Verify with the MCP
+`resolveFlag` (positive + negative + waterfall) exactly as the MCP path
+does — the resolve behavior is identical regardless of which backend
+wrote the rules.
+
+---
+
+## Plan Flag: Template
+
+```markdown
+# Optimizely to Confidence Flag Migration Plan
+
+**Created:** <date>
+**Scope:** Flag definitions only
+**Optimizely project:** <PROJECT_ID>
+**Environment:** <env-key>
+
+---
+
+## Generation Status
+
+| Step | Status | Result |
+|------|--------|--------|
+| 1. Scan Optimizely | ○ not started | |
+| 2. Choose client | ○ not started | |
+| 3. Map bucketing ID | ○ not started | |
+| 4. Generate rules | ○ not started | |
+
+**Overall:** in progress
+
+---
+
+## 1. Default Client
+
+A client represents the application that resolves flags (e.g. your
+website, backend service, or mobile app). Each client authenticates
+with its own secret and can be scoped to environments (dev, staging,
+prod). Flags are associated with clients so Confidence knows which
+application receives which flags.
+
+**Available Clients:** <list from MCP>
+
+**Selected:** `<client>`
+
+---
+
+## 2. Bucketing ID Mapping
+
+An entity is the "thing" being randomly assigned to a variant — usually
+a user. The entity field (like `user_id` or `visitor_id`) is the
+identifier Confidence uses for consistent assignment: the same subject
+always sees the same variant.
+
+Optimizely buckets on the user ID passed to the SDK; it maps to one
+Confidence entity field.
+
+| Optimizely bucketing ID | Confidence entity field |
+|-------------------------|-------------------------|
+| user id (`decide`) | `<selected-entity>` |
+
+---
+
+## 3. Context Schema
+
+The context schema defines what fields Confidence expects in the
+evaluation context when resolving flags — the custom attributes the
+audiences use (e.g. `country`, `plan`, `appVersion`).
+
+> Note: Optimizely attributes are untyped and passed explicitly by your
+> SDK calls. Confidence needs these in the evaluation context with the
+> right type (string/number/boolean/version) — Phase 2 must supply them.
+
+### Already in Confidence
+
+| Field | Type | Entity | Optimizely attribute |
+|-------|------|--------|----------------------|
+<matching fields>
+
+### Need to Create
+
+| Field | Type | Entity | Optimizely attribute |
+|-------|------|--------|----------------------|
+<missing fields — execute will create these>
+
+### Confidence-only (not in Optimizely)
+
+| Field | Type | Entity |
+|-------|------|--------|
+<reference only, no action needed>
+
+---
+
+## 4. Flags to Migrate
+
+**Migration is opt-in.** Each flag starts with both checkboxes empty.
+Tick `[x] Migrate` for every flag you want to bring across, or
+`[x] Skip` to drop it. Flags with neither box ticked will be refused
+by `execute` — no implicit defaults.
+
+### Flag: `<flag-key>`
+
+**Description:** <from Optimizely if available, otherwise empty>
+**Backend:** <MCP (default) / REST — REST is required for partial allocation with fall-through, reusable audiences, or exclusion-group exclusivity>
+**Confidence schema:** <e.g. `{ enabled: boolean }` for a boolean flag; the variable shape for a flag with variables>
+**Variants:** <variant list — e.g. "on, off" for a boolean flag; variation keys for a flag with variations, each carrying its variable values>
+**Confidence resolve path:** `<flag-key>.<property>` (Phase 2 reads this; `.enabled` for boolean flags, `.<variable>` per variable)
+**Unit:** Optimizely user id → entity `<entity>`
+**Enabled in Optimizely (env `<env>`):** <yes / no — if no, set every rule's on-share to 0 (boolean flag rules become `variantAllocations { off: 100 }`) so the flag stays OFF until intentionally enabled>
+**Rules (Optimizely, in priority order):**
+  1. `<rule key>` (<targeted_delivery / a/b>) — <plain-English audience>, traffic <X>%, <variant split>
+  2. ...
+**Default:** <ruleset default_variation (e.g. off) → catch-all rule>
+**Rollout/split:** <how percentage_included / variation split are encoded — variantAllocations (MCP) or segment proportion + bucketRanges (REST)>
+**Audiences:** <none, or list of Confidence segments created (REST) / inlined (MCP) with the optimizely-audience-id → segments/<id> mapping>
+**Exclusion group:** <none, or group-id → exclusivity tag (REST)>
+**Adaptive:** <none, or "multi_armed_bandit / stats_accelerator — split snapshotted, no longer auto-tunes">
+**Presence/exists conditions:** <none, or "BLOCKED — `exists`/null match on '<attr>'; Confidence has no working presence operator">
+**Confidence rules:** one targeting rule per Optimizely rule, in priority order, plus a final catch-all rule for the default
+**Action:** [ ] Migrate  [ ] Skip
+
+If any rule or the whole flag is BLOCKED, replace the **Action** line
+with:
+
+**Status:** BLOCKED — <one-line reason from the BLOCKED rules above>
+**Action:** [ ] Skip (no migrate option available until the block is resolved)
+
+**Commands:**
+<For MCP backend: createFlag, addFlagToClient, addTargetingRule (ONE per Optimizely rule, in priority order) THEN a final catch-all addTargetingRule (no payload, 100% → default variant). For REST backend: createFlag (MCP, to wire the client), then per audience a POST /v1/segments + :allocate, then POST /v1/flags/<flag>/rules (segment + assignmentSpec) + PATCH enabled=true, in order. Finish with resolveFlag (MCP) — positive AND negative case (negative must land on the catch-all and return the default variant)>
+
+---
+
+## 5. Progress
+
+| # | Flag | Status |
+|---|------|--------|
+| 1 | <flag> | :white_circle: |
+```
+
+---
+
+## Execute: How It Works
+
+`execute <plan-file>` walks through the plan interactively, step by step.
+
+### For flag plans
+
+```
+1. READ the plan file
+   - Client is already in the plan — use it, do NOT re-ask
+   - Bucketing-ID → entity mapping is in the plan
+   - REFUSE TO PROCEED if any flag has neither `[x] Migrate` nor
+     `[x] Skip` ticked. List those flags back and ask the user to tick a
+     box for each. Migration is opt-in — never assume a default.
+   - REFUSE TO PROCEED if any flag is marked `BLOCKED` and the user
+     hasn't either resolved the block or ticked `[x] Skip`. Surface the
+     BLOCKED flags and the reason for each.
+2. FOR EACH FLAG marked [x] Migrate:
+   - Show flag name, type, description, and rules in plain English
+   - ASK: "Create this flag in Confidence? [Yes / Skip / Pause]"
+   - If Yes → run the Flag Setup Sequence (below)
+   - CHECKPOINT: "Flag done. [Continue / Pause]?"
+   - Wait for user response
+3. COMPLETION
+   - Show summary: created vs skipped
+```
+
+### Flag Setup Sequence (MUST complete all steps before resolving)
+
+**Pick the backend from the flag's `Backend` field first.** The sequence
+below is the **MCP** path (the default). For a flag marked `Backend: REST`,
+use the **REST sequence** instead (next subsection), then verify with the
+same `resolveFlag` step 4. Either way, do NOT call `resolveFlag` until all
+prior steps succeed.
+
+#### MCP sequence
+
+```
+STEP 1: createFlag
+  → If flag already exists, check the response for which clients
+    it's enabled on.
+
+STEP 2: Ensure flag is active and on the correct client
+  → If createFlag response does NOT list the target client:
+    a. Try addFlagToClient
+    b. If that fails with "Cannot update an archived flag":
+       → unarchiveFlag first, then retry addFlagToClient
+  → If createFlag response lists the target client: proceed
+
+STEP 3: addTargetingRule
+  → Add the targeting rule(s) from the plan. Emit one addTargetingRule
+    call per Optimizely rule in the SAME ORDER (rule_priorities;
+    Confidence evaluates rules top-down — order is semantically
+    significant).
+  → Add the default LAST as a catch-all rule: addTargetingRule with
+    variantAllocations { <defaultVariant>: 100 } and NO payload (empty
+    payload = targets all contexts). Confidence has no flag-level default
+    (see "Default value" above), so this is the only way to reproduce a
+    ruleset's default_variation. It MUST come after every specific rule.
+  → IMPORTANT: targeting rules added while a flag is archived OR
+    immediately after unarchiving may become inactive. Always complete
+    steps 1-2 fully BEFORE calling addTargetingRule.
+
+STEP 4: resolveFlag (verification)
+  → Resolver state propagates asynchronously: a resolveFlag immediately
+    after flag/rule creation can fail with "No active flags found for
+    the client" even though the flag is ACTIVE and wired (observed
+    live). Wait a few seconds and retry before treating it as an error.
+  → MUST test BOTH positive AND negative cases:
+    a. Resolve with a context that SHOULD match → verify expected variant
+    b. Resolve with a context that SHOULD NOT match any specific rule →
+       verify it lands on the catch-all and returns the default variant
+  → For multi-rule flags, also resolve with a context that misses the
+    first rule but matches a later one — verifies waterfall order.
+  → For attribute-based targeting, the resolve call MUST include those
+    attributes in the evaluation context.
+  → Do NOT report a flag as successfully migrated until both positive and
+    negative resolve tests pass.
+```
+
+#### REST sequence (Backend: REST)
+
+For flags needing partial allocation with fall-through, reusable
+audiences, or exclusion-group exclusivity. Requires `CONFIDENCE_TOKEN`
+(confirm it's set; if not, prompt the user — see prerequisites). Follow
+the recipes in "Full-Fidelity Phase 1 via the Confidence REST API".
+
+```
+STEP 1: createFlag + client  (MCP createFlag — also wires the client and variants)
+STEP 2: For each audience this flag needs (in the plan's Audiences list):
+  → POST /v1/segments?segmentId=<id>  (targeting + allocation.proportion
+    + exclusivityTags/exclusiveTo for exclusion-group rules)
+  → POST /v1/segments/<id>:allocate   (MUST allocate before use)
+  → Reuse already-created segments (check the plan's segment map) — do
+    not recreate
+STEP 3: For each Optimizely rule, in priority order:
+  → POST /v1/flags/<flag>/rules  (segment + assignmentSpec bucketRanges
+    + targetingKeySelector)
+  → PATCH /v1/flags/<flag>/rules/<ruleId>?updateMask=enabled  {enabled:true}
+  → Set priority so order matches the Optimizely waterfall (lower = first)
+  → Add the trailing catch-all rule LAST (default variant)
+STEP 4: resolveFlag (verification) — identical to the MCP sequence's
+  STEP 4 (positive + negative + waterfall).
+```
+
+### Rules
+
+- **NEVER auto-continue** — always wait for user at each checkpoint
+- **Flag-by-flag** — each flag is one unit (its files + tests)
+- **Preserve source order** — one Confidence rule per Optimizely rule, in
+  `rule_priorities` order
+- **Resumable** — update the Progress table in the plan file after each step
+
+## Execute: Optimizely-Specific Notes
+
+**Audiences first.** REST-backend flags: create + allocate every segment
+the flag references **before** adding its rules (rules reference segments
+by name), reusing any already-created segment per the plan's segment map.
+MCP-backend flags: the audience conditions are already inlined into the
+flag's payload in the plan, so no separate step is needed — apply the
+payload as written.
+
+**Disabled-in-Optimizely handling.** If the flag's ruleset for the chosen
+environment has `enabled: false`, surface that during execute:
+
+> This flag is DISABLED in Optimizely (environment `<env>`). I'll create
+> it in Confidence but keep it OFF (every rule's on-share set to 0 —
+> boolean flag rules become `variantAllocations { off: 100 }`) until you
+> turn it on intentionally. Continue?
+
+**Flag shape → Confidence schema (and the resolve-path handoff to Phase
+2).** A Confidence flag is a struct, not a bare scalar, so each flag needs
+named **properties** that hold the migrated values:
+
+| Optimizely flag | Confidence schema (`schemaObject`) | Resolve path |
+|-----------------|------------------------------------|--------------|
+| **Boolean flag** (no variables) | `{ "enabled": "boolean" }` (the `createFlag` default) | `<flag>.enabled` |
+| **Flag with variables** | one property per `variable_definition` (typed by the variable's `type`) | `<flag>.<variable>` per variable |
+
+For boolean flags, variants are `on` (`{ enabled: true }`) and `off`
+(`{ enabled: false }`). For flags with variables, create one variant per
+Optimizely **variation**, each carrying that variation's variable values
+(`variable_definitions` give the `default_value`; the variation's
+`variables` map gives the per-variant overrides). Record the resolve path
+on the flag's plan entry — Phase 2's code transform reads it verbatim.
+
+**Waterfall verification.** Because Optimizely flags often have multiple
+rules, the Flag Setup Sequence Step 4 (above) requires you to also resolve
+with a context that misses the first rule but matches a later one — this
+verifies the waterfall (`rule_priorities`) order is preserved.
+
+---
+
+## Required Prerequisites
+
+This skill needs the Confidence MCP listed in "Prerequisites: Confidence
+Side" above, plus the Optimizely REST API — no MCP, just `curl` with
+`Authorization: Bearer $OPTIMIZELY_API_TOKEN`.
+
+| Source | What's used |
+|--------|-------------|
+| Confidence MCP | `listClients`, `createClient`, `getContextSchema`, `addContextField`, `createFlag`, `addFlagToClient`, `unarchiveFlag`, `addTargetingRule`, `resolveFlag` |
+| Confidence REST API (`CONFIDENCE_TOKEN`, OPTIONAL — full-fidelity Phase 1) | `POST /v1/segments` + `:allocate`, `POST /v1/flags/{flag}/rules` + `PATCH …?updateMask=enabled`; token via `POST https://iam.confidence.dev/v1/oauth/token` |
+| Optimizely Flags API (`OPTIMIZELY_API_TOKEN`) | `GET /flags/v1/projects/{id}/flags[/{key}]`, `GET …/flags/{key}/variations`, `GET …/flags/{key}/environments/{env}/ruleset` |
+| Optimizely Platform API v2 (`OPTIMIZELY_API_TOKEN`) | `GET /v2/audiences[/{id}]`, `GET /v2/environments`, `GET /v2/projects` |

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -480,6 +480,14 @@ Example after Step 1 completes:
   Optimizely flag keys often use `snake_case` (`new_checkout_flow`);
   normalize to hyphens (`new-checkout-flow`) and record the mapping in
   the plan so the code phase can find the right replacement.
+  - **Normalization MUST be injective.** Some flags (commonly experiments
+    created in the UI) have opaque, case-sensitive keys
+    (`b3MAcM5bzLAXbFqyzux82i`). Lowercasing + hyphenating can map two
+    distinct source keys to the **same** Confidence key. Detect collisions
+    across the whole project's key set and disambiguate deterministically
+    (append `-2`, `-3`, … by source-key sort order, or a short hash of the
+    original); record every original → Confidence key pair in the plan's
+    key map. Never silently merge two flags.
 - **Entity references:** Confidence entity names do NOT support underscores.
   The entity reference (e.g. `entities/company`) is separate from the context
   field name (e.g. `company_id`). When creating entity fields with
@@ -657,6 +665,17 @@ re-ask, listing the choices again.
 
 **After client selected:** Write the "Default Client" section to the
 plan file and update Generation Status step 2 to `✓ complete`.
+
+**Forked apps (shared code, independent flag sets).** Some apps are
+**forks** of another app — they share a codebase but each fork is its own
+Optimizely project with its **own, independent flag set** (often only
+partially overlapping keys). Migrate **each fork's project to its own
+Confidence client**; do NOT de-duplicate or merge keys across forks even
+when the keys match. The Phase 2 code transform is shared (run once on the
+shared repo) — which client a build resolves against is **build config**
+(the client/SDK secret per fork), not code. A flag present in the shared
+code but absent from a given fork's set resolves to the **call-site
+default** (fail-safe), the same as before. Run `plan flags` once per fork.
 
 ### Step 3: Map Bucketing ID (Optimizely-specific)
 
@@ -1846,6 +1865,24 @@ evaluation context / subject carries through. Keep the event keys.
   Android handler delays) — Confidence's
   `setProviderAndWait` / `setEvaluationContextAndWait` already block until
   flags are ready; delete the hand-rolled wait.
+
+**PRESERVE local control layers (do NOT delete).** Only delete
+*vendor-coupling* scaffolding (the bullets above). Many apps wrap the
+flag read in *vendor-neutral* control layers that sit ON TOP of whatever
+backend resolves the flag — these must survive the migration untouched:
+- **Local kill-switch / override** (a local preference or remote-config
+  toggle that short-circuits the flag read) — keep it; only the underlying
+  read changes from Optimizely to Confidence.
+- **Local/dev flag sources** (e.g. an in-memory provider reading a
+  `dev-flags.json` in dev/localhost) — vendor-neutral already; keep it and
+  swap only the *production* provider. An OpenFeature `InMemoryProvider`
+  carries over as-is.
+- **QA impersonation** (override cookies/headers/env that force a
+  group/segment for testers) — keep it; it feeds the evaluation context,
+  not the backend.
+
+When in doubt: delete things bound to the *old vendor's* SDK; keep things
+that would make sense regardless of which backend resolves the flag.
 
 **Bandits.** Optimizely multi-armed and contextual bandits (CMAB) are
 **rule types** read through the normal `decide` API — the adaptive

--- a/skills/migrate-optimizely/test-fixtures/.gitignore
+++ b/skills/migrate-optimizely/test-fixtures/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/skills/migrate-optimizely/test-fixtures/README.md
+++ b/skills/migrate-optimizely/test-fixtures/README.md
@@ -1,0 +1,198 @@
+# Fake Optimizely REST API Server
+
+A local HTTP server that mimics Optimizely Feature Experimentation's
+REST API for testing the `migrate-optimizely` skill end-to-end without
+needing an Optimizely account.
+
+The server is read-only and serves the read endpoints the skill calls,
+across both Optimizely base paths on one port: the **Flags API**
+(`/flags/v1`, for flags / variations / rulesets) and the **Platform API
+v2** (`/v2`, for audiences / environments). Fixtures are inline in
+`server.py` and chosen to exercise every branch of the skill's
+operator-mapping table — both the auto-migratable translations (semver
+ranges, numeric comparisons, set membership, audience inlining,
+presence) and the genuinely BLOCKED paths.
+
+## Schema source of truth
+
+JSON shapes are derived from Optimizely's published Feature
+Experimentation API docs at
+<https://docs.developers.optimizely.com/feature-experimentation/reference>.
+It is the authoritative reference for field names, the ruleset/rule
+shapes, the audience condition language, and pagination semantics.
+
+If you suspect the fixtures have drifted from real Optimizely, fetch the
+docs fresh and diff against `server.py`. Key facts the fixtures encode:
+
+- **Percentages are basis points out of 10000** (10000 = 100%).
+- A ruleset has an ordered `rule_priorities` (first wins) and a
+  `default_variation_key` served when no rule matches.
+- A rule references audiences via `audience_conditions` (the list-based
+  condition language) + `audience_ids`; the custom-attribute leaves live
+  in each **audience's** `conditions`, which is a **JSON-encoded string**.
+
+## Run
+
+Python 3.10+ stdlib, no dependencies.
+
+```bash
+python3 server.py
+# Fake Optimizely REST API listening on http://127.0.0.1:4100
+#   14 flags (13 non-archived), 11 audiences, 2 environments
+#   Project ID: 4100100100
+```
+
+Override the port if 4100 is taken:
+
+```bash
+python3 server.py --port 4155
+```
+
+## Smoke test
+
+In another terminal:
+
+```bash
+export OPTIMIZELY_API_TOKEN=fake-token-for-testing
+curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
+  "http://127.0.0.1:4100/flags/v1/projects/4100100100/flags?per_page=3&page=1" | jq
+```
+
+You should see three flag summaries plus `page`/`total_pages`. If you
+forget the header, the server returns
+`401 {"message": "Missing or malformed Authorization header"}`.
+
+## Drive the skill against this server
+
+In Claude Code / Cursor, with the server running:
+
+```
+export OPTIMIZELY_API_TOKEN=fake-token-for-testing
+```
+
+Then run `/migrate-optimizely plan flags`. When the skill prompts for the
+Optimizely API base URLs, answer `http://127.0.0.1:4100` (the fake server
+serves both `/flags/v1` and `/v2` there), use project id `4100100100`,
+and pick the `production` environment.
+
+Pick a throwaway Confidence client and map the Optimizely user ID to a
+`user_id` entity field, confirm, and review the generated plan file.
+
+## Fixture flags and what each one tests
+
+| `key` | What it tests | Expected status |
+|---|---|---|
+| `new-homepage` | 100% targeted-delivery to everyone → catch-all rule at 100% on | Migrate |
+| `beta_feature` | 25% targeted-delivery to a boolean audience → `eqRule boolValue` + 25/75 split | Migrate |
+| `na_promo` | audience `country US OR CA` → `setRule` | Migrate |
+| `mobile_checkout` | audience `app_version semver_ge 1.2.0 AND os exact ios` → version `rangeRule` + string `eqRule` | Migrate |
+| `winback_banner` | audience `days_since_last_order le 14` → numeric `rangeRule.endInclusive` | Migrate |
+| `substring_gate` | audience `email substring` → no Confidence substring rule | BLOCKED |
+| `product_sort` | flag WITH variables (`sort_algorithm` string, `show_amounts` bool), a/b 50/50 → struct flag, variant split | Migrate |
+| `pricing_test` | a/b at 50% allocation THEN an everyone fallback rule → REST backend (un-allocated traffic must fall through) | Migrate (REST) |
+| `headline_mab` | `multi_armed_bandit` / `stats_accelerator` → adaptive split snapshotted, with a note | Migrate (note) |
+| `legacy_banner` | ruleset `enabled: false` → flag created OFF, rules at 0% | Migrate (with warning) |
+| `members_dashboard` | combo `Authenticated AND NOT Internal` → inline both audiences, internal negated | Migrate |
+| `plan_badge` | audience `plan exists` → Confidence has no working presence operator (ruleless criteria error at resolve) | BLOCKED |
+| `browser_gate` | non-`custom_attribute` (`browser`) audience leaf → no Confidence equivalent | BLOCKED |
+| `old_experiment` | `archived: true` → hidden from list unless opted in | Skipped (archived) |
+
+## Fixture audiences
+
+| `id` | Targeting | Notes |
+|---|---|---|
+| 1 `Beta users` | `is_beta exact true` | boolean → `eqRule boolValue` |
+| 2 `North America` | `country exact US OR country exact CA` | set membership → `setRule` |
+| 3 `Modern mobile` | `app_version semver_ge 1.2.0 AND os exact ios` | version range + string eq |
+| 4 `Recent purchasers` | `days_since_last_order le 14` | numeric → `rangeRule.endInclusive` |
+| 5 `Test email substring` | `email substring @test` | BLOCKED |
+| 6 `Regex email` | `email regex .*@test\.com` | BLOCKED |
+| 7 `Authenticated users` | `is_logged_in exact true` | used alone + in a combo |
+| 9 `Internal staff` | `is_internal exact true` | used NEGATED in a combo |
+| 10 `Has plan` | `plan exists` | BLOCKED — no working presence operator |
+| 11 `Chrome users` | `browser exact gc` | non-custom_attribute → BLOCKED |
+
+## What a successful test looks like
+
+After running `plan flags`, the generated plan file at
+`.claude/plans/optimizely-flag-migration-<date>.md` should:
+
+- Include the 13 non-archived flags in Section 4 (`old_experiment` is
+  archived and excluded by default)
+- For `na_promo`, render the audience as a set membership (country is US
+  or CA → `setRule`)
+- For `mobile_checkout`, translate `app_version >= 1.2.0` as a version
+  range (not numeric) AND `os` equals `ios`
+- For `winback_banner`, translate `days_since_last_order <= 14` as a
+  numeric `rangeRule.endInclusive`
+- For `product_sort`, create a struct flag with one property per variable
+  and one variant per variation, split 50/50
+- For `pricing_test`, mark `Backend: REST` (50% A/B with a fall-through
+  fallback rule that the MCP `variantAllocations` can't represent)
+- For `headline_mab`, snapshot the 33/33/34 split and note the live
+  allocation was adaptive
+- For `legacy_banner`, note "Enabled in Optimizely: no" and warn rules go
+  in at 0% rollout
+- For `members_dashboard`, inline the `Authenticated` and `Internal`
+  audiences, with `Internal` wrapped in `not`
+- Mark `substring_gate`, `browser_gate`, and `plan_badge` as **BLOCKED**
+  (`plan_badge` uses an `exists` match, which has no working Confidence
+  presence operator). `execute` should refuse to proceed on them unless
+  they're `[x] Skip`'d
+
+## Verifying the translation logic (`verify_migration.py`)
+
+`verify_migration.py` models Optimizely's deterministic evaluation
+(audience matching + the ruleset waterfall) over the fixtures and prints
+a flag × context matrix of expected results — including which flags are
+BLOCKED, which need the REST backend, and which rules are adaptive. Run
+it before/after `execute` to spot-check that Confidence resolves match
+Optimizely for the same context:
+
+```bash
+python3 verify_migration.py
+```
+
+It imports the fixtures directly from `server.py`, so no network or
+running server is needed. The random percentage dimension
+(`percentage_included` / variation split) is reported as metadata rather
+than simulated, since bucketing is a property of the hashing, not the
+config translation.
+
+## Seeding a real Optimizely project (`seed_optimizely.py`)
+
+To test end-to-end against **real** Optimizely instead of this fake
+server, `seed_optimizely.py` pushes the same fixtures into an actual
+Feature Experimentation project via the REST API:
+
+1. Sign up at <https://www.optimizely.com> and create a Feature
+   Experimentation project (manual — the signup flow can't be automated).
+2. Create an **API token** under Account Settings > API Access.
+3. Seed (the numeric project id is in the app URL):
+
+   ```bash
+   export OPTIMIZELY_API_TOKEN=...
+   python3 seed_optimizely.py --project-id 12345   # --dry-run to preview, --teardown to clean up
+   ```
+
+This is a **best-effort** seeder. Optimizely auto-creates the `on`/`off`
+variations on flag create; rules are added to the `development`
+environment and left disabled (enable/promote them in the UI first), and
+some constructs (multi-armed bandit, stats-accelerator distribution) may
+require a plan that supports them or manual setup in the UI. See the
+script's docstring for the full list of caveats.
+
+Then run `/confidence:migrate-optimizely plan flags` against the standard
+base URLs with your project id and the `development` environment, and
+compare the plan with `python3 verify_migration.py`.
+
+## What this does NOT test
+
+- **Real Optimizely evaluation.** This server is config-only; it never
+  decides "given user X, what value?". The migration translates
+  *configs*; post-migration evaluation happens on Confidence's side.
+- **Authentication semantics.** The server validates the `Bearer` header
+  is present but doesn't check the value, scope, or rate limits.
+- **Mutations.** All write methods (POST/PATCH/PUT/DELETE) return 405.
+  Migration is read-only on the Optimizely side; writes happen against
+  Confidence.

--- a/skills/migrate-optimizely/test-fixtures/README.md
+++ b/skills/migrate-optimizely/test-fixtures/README.md
@@ -186,6 +186,14 @@ Then run `/confidence:migrate-optimizely plan flags` against the standard
 base URLs with your project id and the `development` environment, and
 compare the plan with `python3 verify_migration.py`.
 
+## Phase 2 (code transformation) fixtures
+
+`phase2-examples/` holds small example apps that use the Optimizely SDKs
+(Decide API, legacy Full Stack API, and the React SDK) the way real
+codebases do. They give `/migrate-optimizely plan code` something
+concrete to scan and transform. Their flag keys match the Phase 1
+fixtures so the two phases line up. See `phase2-examples/README.md`.
+
 ## What this does NOT test
 
 - **Real Optimizely evaluation.** This server is config-only; it never

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
@@ -16,7 +16,7 @@ line up: `product_sort` (struct flag with variables), `beta_feature`
 | `node-legacy-fullstack/` | `@optimizely/optimizely-sdk` (Node) | legacy Full Stack | server | `isFeatureEnabled`, `getFeatureVariable*`, `activate` (variation-key switch — flagged for review), `track`, notification listener (delete) |
 | `react-client/` | `@optimizely/react-sdk` | Decide + legacy | client | `<OptimizelyProvider>`, `useDecision`, `<OptimizelyFeature>` → ambient context + `useFlag` |
 | `java-server/` | `com.optimizely.ab:core-api` | Decide API | server | `createUserContext` + `decide`, `decision.getVariables().getValue(..)`, `MutableContext` (in-process → in-process, mode preserved) |
-| `python-server/` | `optimizely-sdk` | Decide API | server | `create_user_context` + `decide`, `decision.variables[..]` → **remote** provider (⚠️ in-process → remote, a resolve-mode change) |
+| `python-server/` | `optimizely-sdk` | Decide API | server | `create_user_context` + `decide`, `decision.variables[..]` → prefer the **local-resolve** provider `confidence-openfeature-provider` (Alpha; `ConfidenceProvider` + `set_provider_and_wait`, in-process → in-process). Remote `spotify-confidence-sdk` is the fallback (⚠️ resolve-mode change) |
 
 ## Expected transform (summary)
 

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
@@ -1,0 +1,44 @@
+# Phase 2 code-transformation examples
+
+Small, realistic apps that use the Optimizely SDKs the way real codebases
+do. They give the `migrate-optimizely plan code` / `execute` flow
+something concrete to scan and transform. They are **source fixtures**,
+not run end-to-end here — the point is the shape of the Optimizely usage,
+not a working build.
+
+The flag keys match the Phase 1 fixtures (`server.py`) so the two phases
+line up: `product_sort` (struct flag with variables), `beta_feature`
+(boolean rollout), `na_promo` (boolean, audience-targeted).
+
+| Example | SDK / package | API generation | Side | Exercises |
+|---------|---------------|----------------|------|-----------|
+| `node-decide-server/` | `@optimizely/optimizely-sdk` (Node) | Decide API | server | `createUserContext` + `decide`, `decision.enabled` / `decision.variables`, `trackEvent`, `onReady` wait → server per-call context |
+| `node-legacy-fullstack/` | `@optimizely/optimizely-sdk` (Node) | legacy Full Stack | server | `isFeatureEnabled`, `getFeatureVariable*`, `activate` (variation-key switch — flagged for review), `track`, notification listener (delete) |
+| `react-client/` | `@optimizely/react-sdk` | Decide + legacy | client | `<OptimizelyProvider>`, `useDecision`, `<OptimizelyFeature>` → ambient context + `useFlag` |
+
+## Expected transform (summary)
+
+- **Flag key → resolve path.** Confidence flags are structs; reads become
+  `<confidence-flag>.<property>`. Phase 1 normalizes underscores to
+  hyphens, so `product_sort` → `product-sort` and
+  `decision.variables["sort_algorithm"]` →
+  `getStringValue("product-sort.sort_algorithm", default, ctx)`.
+  `decision.enabled` / `isFeatureEnabled("beta_feature", …)` →
+  `getBooleanValue("beta-feature.enabled", false, ctx)`.
+- **Context model.** The Node servers pass `userId` + attributes per
+  call → fold into the evaluation context argument. The React app sets
+  context once (`<OptimizelyProvider user={…}>` → `<ConfidenceProvider>`
+  + ambient context) and `useDecision` becomes `useFlag`.
+- **`activate` / `getVariation`** return a variation key; the legacy
+  example switches on it (`if (variation === "treatment")`). That is
+  flagged for **human review** — prefer reading the variable that drives
+  behavior over branching on a raw variant label.
+- **Tracking.** `track` / `trackEvent` map to Confidence's `track` API
+  (not OpenFeature). Keep the event keys.
+- **Delete scaffolding.** `onReady()` waits, notification listeners,
+  datafile polling, and event-dispatcher config all go away — Confidence
+  handles readiness and exposure logging itself.
+
+Drive it with `/migrate-optimizely plan code` pointed at one of these
+directories, then review the generated
+`.claude/plans/optimizely-code-migration-<date>.md`.

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
@@ -12,9 +12,11 @@ line up: `product_sort` (struct flag with variables), `beta_feature`
 
 | Example | SDK / package | API generation | Side | Exercises |
 |---------|---------------|----------------|------|-----------|
-| `node-decide-server/` | `@optimizely/optimizely-sdk` (Node) | Decide API | server | `createUserContext` + `decide`, `decision.enabled` / `decision.variables`, `trackEvent`, `onReady` wait → server per-call context |
+| `node-decide-server/` | `@optimizely/optimizely-sdk` (Node) | Decide API | server | `createUserContext` + `decide`, `decision.enabled` / `decision.variables`, `trackEvent`, `onReady` wait → server per-call context (in-process → in-process, mode preserved) |
 | `node-legacy-fullstack/` | `@optimizely/optimizely-sdk` (Node) | legacy Full Stack | server | `isFeatureEnabled`, `getFeatureVariable*`, `activate` (variation-key switch — flagged for review), `track`, notification listener (delete) |
 | `react-client/` | `@optimizely/react-sdk` | Decide + legacy | client | `<OptimizelyProvider>`, `useDecision`, `<OptimizelyFeature>` → ambient context + `useFlag` |
+| `java-server/` | `com.optimizely.ab:core-api` | Decide API | server | `createUserContext` + `decide`, `decision.getVariables().getValue(..)`, `MutableContext` (in-process → in-process, mode preserved) |
+| `python-server/` | `optimizely-sdk` | Decide API | server | `create_user_context` + `decide`, `decision.variables[..]` → **remote** provider (⚠️ in-process → remote, a resolve-mode change) |
 
 ## Expected transform (summary)
 

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
@@ -17,6 +17,22 @@ line up: `product_sort` (struct flag with variables), `beta_feature`
 | `react-client/` | `@optimizely/react-sdk` | Decide + legacy | client | `<OptimizelyProvider>`, `useDecision`, `<OptimizelyFeature>` → ambient context + `useFlag` |
 | `java-server/` | `com.optimizely.ab:core-api` | Decide API | server | `createUserContext` + `decide`, `decision.getVariables().getValue(..)`, `MutableContext` (in-process → in-process, mode preserved) |
 | `python-server/` | `optimizely-sdk` | Decide API | server | `create_user_context` + `decide`, `decision.variables[..]` → prefer the **local-resolve** provider `confidence-openfeature-provider` (Alpha; `ConfidenceProvider` + `set_provider_and_wait`, in-process → in-process). Remote `spotify-confidence-sdk` is the fallback (⚠️ resolve-mode change) |
+| `openfeature-provider-swap/` | `@openfeature/*` + custom `OptimizelyProvider` | **already on OpenFeature** | client (React) | **Provider swap, NOT a rewrite** (the custom-provider pattern): `useFlag` call sites are untouched; only `provider.ts` + the `OpenFeature.setProvider(...)` registration change. Exercises re-homing the custom provider's on/off-string + anonymous-suppression semantics on top of the Confidence provider |
+
+## Two migration styles
+
+- **Call-site rewrite** — the app calls the Optimizely SDK directly
+  (`decide`, `isFeatureEnabled`, …). The transform rewrites call sites to
+  OpenFeature + Confidence. This is the `node-*`, `java-server`,
+  `python-server`, and `react-client` examples.
+- **Provider swap** — the app is *already* on OpenFeature (standard
+  `useFlag` / `get*Value` call sites, Optimizely hidden behind a
+  registered provider). Migration only swaps the registered provider to
+  Confidence; **call sites don't change**. This is the
+  `openfeature-provider-swap` example (the custom-provider pattern).
+
+`/migrate-optimizely plan code` detects which style applies (Step 1b) and
+plans accordingly.
 
 ## Expected transform (summary)
 

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/java-server/pom.xml
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/java-server/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>optimizely-decide-server-example</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <!-- Phase 2 fixture: Java server using the Optimizely Decide API. -->
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.optimizely.ab</groupId>
+      <artifactId>core-api</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.optimizely.ab</groupId>
+      <artifactId>core-httpclient-impl</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/java-server/src/main/java/com/example/HomepageService.java
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/java-server/src/main/java/com/example/HomepageService.java
@@ -1,0 +1,42 @@
+package com.example;
+
+import com.optimizely.ab.Optimizely;
+import com.optimizely.ab.OptimizelyFactory;
+import com.optimizely.ab.optimizelydecision.OptimizelyDecision;
+import com.optimizely.ab.OptimizelyUserContext;
+
+import java.util.Map;
+
+public class HomepageService {
+
+    private final Optimizely optimizely;
+
+    public HomepageService() {
+        // Datafile is fetched + polled in-process; evaluation is local.
+        this.optimizely = OptimizelyFactory.newDefaultInstance(System.getenv("OPTIMIZELY_SDK_KEY"));
+    }
+
+    public Map<String, Object> render(String userId, String country, String plan, boolean isBeta) {
+        OptimizelyUserContext user = optimizely.createUserContext(userId, Map.of(
+                "country", country,
+                "plan", plan,
+                "is_beta", isBeta));
+
+        // Boolean rollout flag.
+        OptimizelyDecision beta = user.decide("beta_feature");
+        boolean betaEnabled = beta.getEnabled();
+
+        // Struct flag with variables.
+        OptimizelyDecision sort = user.decide("product_sort");
+        String algorithm = sort.getVariables().getValue("sort_algorithm", String.class);
+        Boolean showAmounts = sort.getVariables().getValue("show_amounts", Boolean.class);
+
+        // Conversion event.
+        user.trackEvent("homepage_viewed");
+
+        return Map.of(
+                "betaEnabled", betaEnabled,
+                "sortAlgorithm", algorithm,
+                "showAmounts", showAmounts);
+    }
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/node-decide-server/package.json
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/node-decide-server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "optimizely-decide-server-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Phase 2 fixture: Node server using the Optimizely Decide API.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "@optimizely/optimizely-sdk": "^5.3.0",
+    "express": "^4.19.2"
+  }
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/node-decide-server/src/server.js
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/node-decide-server/src/server.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const optimizelySdk = require('@optimizely/optimizely-sdk');
+
+const optimizely = optimizelySdk.createInstance({
+  sdkKey: process.env.OPTIMIZELY_SDK_KEY,
+  datafileOptions: { autoUpdate: true, updateInterval: 60000 },
+});
+
+const app = express();
+
+// Server-side readiness gate — Optimizely needs the datafile before the
+// first decide. (Confidence's setProviderAndWait replaces this.)
+let ready = false;
+optimizely.onReady().then(() => {
+  ready = true;
+});
+
+function userContextFor(req) {
+  const userId = req.header('x-user-id') || 'anonymous';
+  const attributes = {
+    country: req.header('x-country'),
+    plan: req.header('x-plan'),
+    is_beta: req.header('x-beta') === 'true',
+  };
+  return optimizely.createUserContext(userId, attributes);
+}
+
+app.get('/homepage', (req, res) => {
+  if (!ready) return res.status(503).json({ error: 'flags not ready' });
+
+  const user = userContextFor(req);
+
+  // Boolean rollout flag.
+  const beta = user.decide('beta_feature');
+
+  // Struct flag with variables (sort_algorithm: string, show_amounts: boolean).
+  const sort = user.decide('product_sort');
+  const algorithm = sort.variables['sort_algorithm'];
+  const showAmounts = sort.variables['show_amounts'];
+
+  // Conversion event.
+  user.trackEvent('homepage_viewed', { source: 'web' });
+
+  res.json({
+    betaEnabled: beta.enabled,
+    sortAlgorithm: algorithm,
+    showAmounts,
+    sortVariation: sort.variationKey,
+  });
+});
+
+app.get('/promo', (req, res) => {
+  const user = userContextFor(req);
+  const promo = user.decide('na_promo');
+  res.json({ promoEnabled: promo.enabled });
+});
+
+app.listen(3000, () => console.log('listening on :3000'));

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/node-legacy-fullstack/package.json
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/node-legacy-fullstack/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "optimizely-legacy-fullstack-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Phase 2 fixture: Node server using the legacy Optimizely Full Stack API.",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "@optimizely/optimizely-sdk": "^4.10.0"
+  }
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/node-legacy-fullstack/src/index.js
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/node-legacy-fullstack/src/index.js
@@ -1,0 +1,46 @@
+const optimizelySdk = require('@optimizely/optimizely-sdk');
+
+const optimizely = optimizelySdk.createInstance({
+  sdkKey: process.env.OPTIMIZELY_SDK_KEY,
+});
+
+// Notification listener bridging Optimizely decisions to the analytics
+// pipeline. Confidence logs exposure automatically — this is deleted on
+// migration.
+optimizely.notificationCenter.addNotificationListener(
+  optimizelySdk.enums.NOTIFICATION_TYPES.DECISION,
+  ({ type, userId, decisionInfo }) => {
+    analytics.track('optimizely_decision', { type, userId, ...decisionInfo });
+  }
+);
+
+function renderHomepage(userId, attributes) {
+  // Legacy feature gate (boolean).
+  const betaOn = optimizely.isFeatureEnabled('beta_feature', userId, attributes);
+
+  // Legacy feature variables on a struct flag.
+  const algorithm = optimizely.getFeatureVariableString(
+    'product_sort',
+    'sort_algorithm',
+    userId,
+    attributes
+  );
+  const showAmounts = optimizely.getFeatureVariableBoolean(
+    'product_sort',
+    'show_amounts',
+    userId,
+    attributes
+  );
+
+  // Legacy experiment API: returns a variation key and logs an impression.
+  // The code switches on the raw variation key — flagged for human review
+  // in the migration plan.
+  const variation = optimizely.activate('checkout_redesign', userId, attributes);
+  const newCheckout = variation === 'treatment';
+
+  optimizely.track('homepage_viewed', userId, attributes);
+
+  return { betaOn, algorithm, showAmounts, newCheckout };
+}
+
+module.exports = { renderHomepage };

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/package.json
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "openfeature-provider-swap-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Phase 2 fixture: app ALREADY on OpenFeature with a custom Optimizely provider. Migration = provider swap, call sites unchanged.",
+  "dependencies": {
+    "@openfeature/web-sdk": "^1.6.2",
+    "@openfeature/react-sdk": "^1.0.1",
+    "@openfeature/core": "^1.9.1",
+    "@optimizely/optimizely-sdk": "^6.1.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/App.tsx
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/App.tsx
@@ -1,0 +1,47 @@
+/**
+ * Call sites are STANDARD OpenFeature (useFlag). The provider-swap
+ * migration leaves this entire file untouched — only provider.ts and the
+ * registration below change (Optimizely provider → Confidence provider).
+ */
+import React, { useEffect } from 'react';
+import { OpenFeature } from '@openfeature/web-sdk';
+import { OpenFeatureProvider, useFlag } from '@openfeature/react-sdk';
+import { OptimizelyProvider } from './provider';
+
+// --- The ONLY lines that change on migration: the provider registration. ---
+OpenFeature.setProvider(new OptimizelyProvider(process.env.OPTIMIZELY_SDK_KEY ?? ''));
+// On migration → OpenFeature.setProvider(createConfidenceWebProvider({ flagClientSecret: ... }))
+
+export function App({ currentUser }: { currentUser: { email: string; group: string } }) {
+  useEffect(() => {
+    OpenFeature.setContext({
+      targetingKey: currentUser.email,
+      nike_email: currentUser.email,
+      nike_group_id: currentUser.group,
+    });
+  }, [currentUser]);
+
+  return (
+    <OpenFeatureProvider>
+      <Homepage />
+    </OpenFeatureProvider>
+  );
+}
+
+function Homepage() {
+  // Standard OpenFeature React hooks — unchanged by the migration.
+  const analytics = useFlag('analytics', 'off');
+  const classification = useFlag('nike_classification', 'on');
+  const showAnalytics = String(analytics.value ?? 'off').toLowerCase().trim() === 'on';
+
+  return (
+    <main>
+      {showAnalytics && <Analytics />}
+      <div data-classification={classification.value} />
+    </main>
+  );
+}
+
+function Analytics() {
+  return <div className="analytics" />;
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/provider.ts
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/provider.ts
@@ -1,0 +1,78 @@
+/**
+ * A hand-written OpenFeature provider wrapping the Optimizely SDK
+ * (a common pattern: a custom provider behind the OpenFeature global
+ * API). This is the ONLY file the provider-swap
+ * migration touches: replace this class + its registration with the
+ * Confidence OpenFeature provider. The call sites in App.tsx (useFlag)
+ * do NOT change.
+ *
+ * Note the business semantics encoded here (on/off-string modelling +
+ * anonymous suppression). On migration these must be re-homed on top of
+ * the Confidence provider, not silently dropped — see the skill's
+ * "Already on OpenFeature → provider swap".
+ */
+import type {
+  Provider,
+  ResolutionDetails,
+  EvaluationContext,
+} from '@openfeature/web-sdk';
+import { createInstance, type Client } from '@optimizely/optimizely-sdk';
+
+const ON_OFF_STRING_FLAGS = new Set(['analytics', 'nike_classification', 'new_ui']);
+
+export class OptimizelyProvider implements Provider {
+  readonly runsOn = 'client';
+  readonly metadata = { name: 'Optimizely Provider' } as const;
+
+  private client: Client;
+  private ready = false;
+
+  constructor(sdkKey: string) {
+    this.client = createInstance({
+      sdkKey,
+      datafileOptions: { autoUpdate: true, updateInterval: 300000 },
+    });
+    this.client.onReady().then(() => {
+      this.ready = true;
+    });
+  }
+
+  private attrs(context: EvaluationContext): Record<string, unknown> {
+    const { targetingKey, ...rest } = context;
+    return rest;
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext
+  ): ResolutionDetails<boolean> {
+    if (!this.ready) return { value: defaultValue, reason: 'ERROR', errorCode: 'PROVIDER_NOT_READY' as never };
+    if (context.targetingKey === 'anonymous') return { value: defaultValue, reason: 'DEFAULT' };
+    const enabled = this.client.isFeatureEnabled(flagKey, String(context.targetingKey), this.attrs(context));
+    return { value: enabled, reason: 'TARGETING_MATCH' };
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext
+  ): ResolutionDetails<string> {
+    if (!this.ready) return { value: defaultValue, reason: 'ERROR', errorCode: 'PROVIDER_NOT_READY' as never };
+    // on/off-string modelling: these flags resolve to 'on'/'off' from isFeatureEnabled.
+    if (ON_OFF_STRING_FLAGS.has(flagKey)) {
+      const enabled = this.client.isFeatureEnabled(flagKey, String(context.targetingKey), this.attrs(context));
+      return { value: enabled ? 'on' : 'off', reason: 'TARGETING_MATCH' };
+    }
+    const value = this.client.getFeatureVariableString(flagKey, 'value', String(context.targetingKey), this.attrs(context));
+    return { value: value ?? defaultValue, reason: 'TARGETING_MATCH' };
+  }
+
+  resolveNumberEvaluation(): ResolutionDetails<number> {
+    throw new Error('not used in this fixture');
+  }
+
+  resolveObjectEvaluation<T extends object>(): ResolutionDetails<T> {
+    throw new Error('not used in this fixture');
+  }
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/python-server/app.py
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/python-server/app.py
@@ -1,0 +1,31 @@
+import os
+
+from optimizely import optimizely
+
+# Datafile fetched + polled in-process; evaluation is local.
+optimizely_client = optimizely.Optimizely(sdk_key=os.environ["OPTIMIZELY_SDK_KEY"])
+
+
+def render_homepage(user_id, country, plan, is_beta):
+    user = optimizely_client.create_user_context(
+        user_id,
+        {"country": country, "plan": plan, "is_beta": is_beta},
+    )
+
+    # Boolean rollout flag.
+    beta = user.decide("beta_feature")
+    beta_enabled = beta.enabled
+
+    # Struct flag with variables.
+    sort = user.decide("product_sort")
+    algorithm = sort.variables["sort_algorithm"]
+    show_amounts = sort.variables["show_amounts"]
+
+    # Conversion event.
+    user.track_event("homepage_viewed")
+
+    return {
+        "beta_enabled": beta_enabled,
+        "sort_algorithm": algorithm,
+        "show_amounts": show_amounts,
+    }

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/python-server/requirements.txt
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/python-server/requirements.txt
@@ -1,0 +1,2 @@
+# Phase 2 fixture: Python server using the Optimizely Decide API.
+optimizely-sdk==5.1.0

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/react-client/package.json
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/react-client/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "optimizely-react-client-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Phase 2 fixture: React client using the Optimizely React SDK.",
+  "dependencies": {
+    "@optimizely/react-sdk": "^3.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/react-client/src/App.jsx
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/react-client/src/App.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {
+  createInstance,
+  OptimizelyProvider,
+  useDecision,
+  OptimizelyFeature,
+} from '@optimizely/react-sdk';
+
+const optimizely = createInstance({ sdkKey: process.env.REACT_APP_OPTIMIZELY_SDK_KEY });
+
+// Ambient user context: set once at the provider, not per read.
+export function App({ currentUser }) {
+  return (
+    <OptimizelyProvider
+      optimizely={optimizely}
+      user={{
+        id: currentUser.id,
+        attributes: { country: currentUser.country, plan: currentUser.plan, is_beta: currentUser.isBeta },
+      }}
+    >
+      <Homepage />
+    </OptimizelyProvider>
+  );
+}
+
+function Homepage() {
+  // Decide API via hook — boolean rollout.
+  const [betaDecision] = useDecision('beta_feature');
+
+  // Decide API — struct flag with variables.
+  const [sortDecision] = useDecision('product_sort');
+  const algorithm = sortDecision.variables['sort_algorithm'];
+  const showAmounts = sortDecision.variables['show_amounts'];
+
+  return (
+    <main>
+      {betaDecision.enabled && <BetaBanner />}
+      <ProductList algorithm={algorithm} showAmounts={showAmounts} />
+
+      {/* Legacy render-prop component. */}
+      <OptimizelyFeature feature="na_promo">
+        {(enabled) => (enabled ? <PromoBanner /> : null)}
+      </OptimizelyFeature>
+    </main>
+  );
+}
+
+function BetaBanner() {
+  return <div className="beta">Beta</div>;
+}
+function PromoBanner() {
+  return <div className="promo">Promo</div>;
+}
+function ProductList({ algorithm, showAmounts }) {
+  return <div data-algorithm={algorithm} data-amounts={String(showAmounts)} />;
+}

--- a/skills/migrate-optimizely/test-fixtures/seed_optimizely.py
+++ b/skills/migrate-optimizely/test-fixtures/seed_optimizely.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Seed a real Optimizely project with the migrate-optimizely test fixtures.
+
+Pushes the fixtures defined in `server.py` into an actual Optimizely
+Feature Experimentation project through the REST API, so the migration
+skill can be tested end-to-end against real Optimizely (wire format,
+pagination, auth) instead of the fake server.
+
+Prerequisites:
+  * An Optimizely account + Feature Experimentation project.
+  * An API token (Personal Access Token, Account Settings > API Access),
+    exported as OPTIMIZELY_API_TOKEN.
+  * The numeric project id, passed via --project-id.
+
+Run:
+    export OPTIMIZELY_API_TOKEN=...
+    python3 seed_optimizely.py --project-id 12345          # create everything
+    python3 seed_optimizely.py --project-id 12345 --dry-run
+    python3 seed_optimizely.py --project-id 12345 --teardown
+
+What gets seeded (mirrors server.py):
+  * audiences  — one per fixture audience (POST /v2/audiences)
+  * flags      — one per fixture flag, with variable_definitions
+                 (POST /flags/v1/projects/{id}/flags)
+  * variations — struct flags get their non-default variations
+  * rules      — added to each flag's `development` ruleset via a
+                 json-patch PATCH on the ruleset
+
+KNOWN LIMITATIONS — this is a BEST-EFFORT seeder and a few steps need the
+Optimizely UI:
+  * Optimizely auto-creates `on`/`off` variations on flag create; only
+    extra/struct variations are created here.
+  * Ruleset rules are added to the `development` environment and left
+    DISABLED; enable + push to production in the UI (or via the
+    ruleset/enabled endpoint) before running the migration against the
+    `production` env. The fake server serves everything under
+    `production`, so when seeding real Optimizely, run the migration
+    against the `development` env (or promote the rules first).
+  * `multi_armed_bandit` and `stats_accelerator` distribution require a
+    plan that supports them; the MAB fixture may need to be created as a
+    plain a/b in the UI on lower tiers.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+from server import AUDIENCES, FLAGS
+
+FLAGS_BASE = "https://api.optimizely.com/flags/v1"
+V2_BASE = "https://api.optimizely.com/v2"
+SEED_ENV = "development"
+
+
+class Api:
+    def __init__(self, token: str, dry_run: bool):
+        self.token = token
+        self.dry_run = dry_run
+
+    def call(self, method: str, url: str, body: Any = None, content_type: str = "application/json") -> tuple[int, Any]:
+        if self.dry_run:
+            print(f"  DRY-RUN {method} {url}" + (f" {json.dumps(body)[:120]}..." if body else ""))
+            return 200, {}
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self.token}")
+        req.add_header("Accept", "application/json")
+        if data:
+            req.add_header("Content-Type", content_type)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.status, json.loads(resp.read() or b"{}")
+        except urllib.error.HTTPError as e:
+            try:
+                payload = json.loads(e.read() or b"{}")
+            except json.JSONDecodeError:
+                payload = {}
+            return e.code, payload
+
+
+def step(api: Api, label: str, method: str, url: str, body: Any = None, content_type: str = "application/json") -> bool:
+    code, payload = api.call(method, url, body, content_type)
+    if 200 <= code < 300:
+        print(f"  ✓ {label}")
+        return True
+    detail = payload.get("message") or payload.get("errors") or payload
+    msg = json.dumps(detail) if not isinstance(detail, str) else detail
+    if code in (400, 409) and any(s in msg.lower() for s in ("already", "duplicate", "exists")):
+        print(f"  ⊘ {label} — already exists, skipping")
+        return True
+    print(f"  ✗ {label} — HTTP {code}: {msg[:300]}")
+    return False
+
+
+def _td_rule_patch(rule_key: str, rule: dict[str, Any]) -> dict[str, Any]:
+    """A json-patch 'add' op that creates a rule in the ruleset."""
+    variations = {
+        vk: {"key": vk, "percentage_included": v["percentage_included"]}
+        for vk, v in rule["variations"].items()
+    }
+    value: dict[str, Any] = {
+        "key": rule_key,
+        "name": rule["name"],
+        "type": rule["type"],
+        "percentage_included": rule["percentage_included"],
+        "audience_conditions": rule["audience_conditions"],
+        "variations": variations,
+        "enabled": False,
+    }
+    if rule["type"] != "targeted_delivery":
+        value["distribution_mode"] = rule["distribution_mode"]
+    return {"op": "add", "path": f"/rules/{rule_key}", "value": value}
+
+
+def seed(api: Api, project_id: int) -> int:
+    failures = 0
+
+    print("\n## Audiences")
+    for aud in AUDIENCES:
+        body = {"name": aud["name"], "description": aud["description"],
+                "conditions": aud["conditions"], "project_id": project_id}
+        if not step(api, f"audience {aud['name']}", "POST", f"{V2_BASE}/audiences", body):
+            failures += 1
+
+    print("\n## Flags + rules")
+    for flag in FLAGS:
+        body = {"key": flag["key"], "name": flag["name"],
+                "description": flag["description"],
+                "variable_definitions": flag["variable_definitions"]}
+        url = f"{FLAGS_BASE}/projects/{project_id}/flags"
+        if not step(api, f"flag {flag['key']}", "POST", url, body):
+            failures += 1
+            continue
+
+        # Extra (non on/off) variations for struct flags.
+        for var in flag["_variations"]:
+            if var["key"] in ("on", "off") and not var["variables"]:
+                continue
+            vbody = {"key": var["key"], "name": var["name"], "variables": var["variables"]}
+            step(api, f"  variation {flag['key']}/{var['key']}", "POST",
+                 f"{url}/{flag['key']}/variations", vbody)
+
+        # Add rules to the dev ruleset via json-patch.
+        patch = [_td_rule_patch(rk, flag["_rules"][rk]) for rk in flag["_rule_priorities"]]
+        ruleset_url = f"{url}/{flag['key']}/environments/{SEED_ENV}/ruleset"
+        if not step(api, f"  rules {flag['key']} ({len(patch)})", "PATCH", ruleset_url,
+                    patch, content_type="application/json-patch+json"):
+            failures += 1
+
+        if flag["archived"]:
+            step(api, f"  archive {flag['key']}", "POST",
+                 f"{url}/archived", {"keys": [flag["key"]]})
+
+    return failures
+
+
+def teardown(api: Api, project_id: int) -> None:
+    print("\n## Teardown (best-effort)")
+    for flag in FLAGS:
+        step(api, f"delete flag {flag['key']}", "DELETE",
+             f"{FLAGS_BASE}/projects/{project_id}/flags/{flag['key']}")
+    print("  (audiences are not auto-deleted — archive them in the UI if needed)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--project-id", type=int, required=True, help="Optimizely project id")
+    parser.add_argument("--dry-run", action="store_true", help="print calls without sending")
+    parser.add_argument("--teardown", action="store_true", help="delete the seeded flags")
+    args = parser.parse_args()
+
+    token = os.environ.get("OPTIMIZELY_API_TOKEN", "")
+    if not token and not args.dry_run:
+        sys.exit("Set OPTIMIZELY_API_TOKEN to an API token with write access "
+                 "(Account Settings > API Access).")
+
+    api = Api(token, args.dry_run)
+
+    if args.teardown:
+        teardown(api, args.project_id)
+        return
+
+    failures = seed(api, args.project_id)
+
+    print("\n" + "=" * 64)
+    if failures:
+        print(f"Done with {failures} failure(s) — see ✗ lines above.")
+    else:
+        print("All fixtures seeded.")
+    print("""
+NEXT STEPS:
+  Rules were added to the `development` environment and left disabled.
+  Enable them (or promote to production) in the Optimizely UI, then run:
+    /confidence:migrate-optimizely plan flags
+  pointing at the standard base URLs, project id {pid}, and the
+  `development` environment. Diff the plan against:
+    python3 verify_migration.py""".replace("{pid}", str(args.project_id)))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/migrate-optimizely/test-fixtures/server.py
+++ b/skills/migrate-optimizely/test-fixtures/server.py
@@ -1,0 +1,725 @@
+#!/usr/bin/env python3
+"""Fake Optimizely REST API server for testing the migrate-optimizely skill.
+
+Implements the read endpoints the skill calls, across the two Optimizely
+base paths (served together on one port):
+
+  Flags API (/flags/v1):
+    GET /flags/v1/projects/{pid}/flags?per_page=N&page=N
+    GET /flags/v1/projects/{pid}/flags/{key}
+    GET /flags/v1/projects/{pid}/flags/{key}/variations
+    GET /flags/v1/projects/{pid}/flags/{key}/environments/{env}/ruleset
+
+  Platform API v2 (/v2):
+    GET /v2/audiences?project_id=N&per_page=N&page=N
+    GET /v2/audiences/{id}
+    GET /v2/environments?project_id=N
+    GET /v2/projects
+
+JSON shapes are derived from Optimizely's published Feature
+Experimentation API docs
+(<https://docs.developers.optimizely.com/feature-experimentation/reference>).
+
+Notable conventions:
+  * snake_case everywhere (`percentage_included`, `audience_conditions`)
+  * IDs are integers; flag/rule/variation keys are strings
+  * Percentages are BASIS POINTS out of 10000 (10000 = 100%, 5000 = 50%)
+  * A ruleset has an ordered `rule_priorities` (first wins) and a
+    `default_variation_key` served when no rule matches
+  * A rule references audiences via `audience_conditions` (list-based
+    condition language) + `audience_ids`; the custom-attribute leaves
+    live in each AUDIENCE's `conditions` (a JSON-encoded string)
+  * List endpoints wrap results under `items` with `page`/`total_pages`
+
+Fixtures are curated to exercise every branch of the skill's
+operator-mapping table and BLOCKED markers — see README.md.
+
+Run:
+    python3 server.py [--port 4100]
+"""
+
+import argparse
+import json
+import re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+PROJECT_ID = 4100100100
+ACCOUNT_ID = 4100200200
+
+ENVIRONMENTS = [
+    {"key": "production", "name": "Production", "id": 9001, "archived": False, "priority": 1},
+    {"key": "development", "name": "Development", "id": 9002, "archived": False, "priority": 2},
+]
+
+
+def _cond(name: str, match_type: str, value: Any = None, ctype: str = "custom_attribute") -> dict:
+    leaf: dict[str, Any] = {"type": ctype, "name": name, "match_type": match_type}
+    if value is not None:
+        leaf["value"] = value
+    return leaf
+
+
+# ---------------------------------------------------------------------------
+# Audiences — the reusable targeting conditions. `conditions` is a
+# JSON-encoded STRING of the list-based condition language; the leaves are
+# {type: custom_attribute, name, match_type, value}.
+# ---------------------------------------------------------------------------
+
+def _conditions(*tree: Any) -> str:
+    return json.dumps(list(tree))
+
+
+AUDIENCES: list[dict[str, Any]] = [
+    # 1. boolean exact → eqRule boolValue
+    {
+        "id": 1,
+        "name": "Beta users",
+        "description": "Users opted into beta.",
+        "conditions": _conditions("and", ["or", ["or", _cond("is_beta", "exact", True)]]),
+    },
+    # 2. string set membership via OR of exact → setRule
+    {
+        "id": 2,
+        "name": "North America",
+        "description": "US or Canada.",
+        "conditions": _conditions(
+            "and", ["or", _cond("country", "exact", "US"), _cond("country", "exact", "CA")]
+        ),
+    },
+    # 3. semver_ge (version range) AND string exact, in one audience
+    {
+        "id": 3,
+        "name": "Modern mobile",
+        "description": "iOS on app v1.2.0+.",
+        "conditions": _conditions(
+            "and",
+            ["or", ["or", _cond("app_version", "semver_ge", "1.2.0")]],
+            ["or", ["or", _cond("os", "exact", "ios")]],
+        ),
+    },
+    # 4. numeric le → rangeRule endInclusive
+    {
+        "id": 4,
+        "name": "Recent purchasers",
+        "description": "Ordered within 14 days.",
+        "conditions": _conditions("and", ["or", ["or", _cond("days_since_last_order", "le", 14)]]),
+    },
+    # 5. substring → BLOCKED (no Confidence substring rule)
+    {
+        "id": 5,
+        "name": "Test email substring",
+        "description": "Email contains @test.",
+        "conditions": _conditions("and", ["or", ["or", _cond("email", "substring", "@test")]]),
+    },
+    # 6. regex → BLOCKED (no general regex rule)
+    {
+        "id": 6,
+        "name": "Regex email",
+        "description": "Email matches a regex.",
+        "conditions": _conditions("and", ["or", ["or", _cond("email", "regex", ".*@test\\.com")]]),
+    },
+    # 7. boolean exact (authenticated)
+    {
+        "id": 7,
+        "name": "Authenticated users",
+        "description": "Logged-in users.",
+        "conditions": _conditions("and", ["or", ["or", _cond("is_logged_in", "exact", True)]]),
+    },
+    # 9. boolean exact (internal) — used negated in a combo
+    {
+        "id": 9,
+        "name": "Internal staff",
+        "description": "Internal employees.",
+        "conditions": _conditions("and", ["or", ["or", _cond("is_internal", "exact", True)]]),
+    },
+    # 10. exists (presence) → BLOCKED (no working Confidence presence operator)
+    {
+        "id": 10,
+        "name": "Has plan",
+        "description": "Any plan attribute set.",
+        "conditions": _conditions("and", ["or", ["or", _cond("plan", "exists")]]),
+    },
+    # 11. non-custom_attribute leaf → BLOCKED (no Confidence equivalent)
+    {
+        "id": 11,
+        "name": "Chrome users",
+        "description": "Browser-based audience (Web-style).",
+        "conditions": _conditions("and", ["or", ["or", _cond("browser", "exact", "gc", ctype="browser")]]),
+    },
+]
+
+AUDIENCES_BY_ID = {a["id"]: a for a in AUDIENCES}
+
+
+# ---------------------------------------------------------------------------
+# Variations — per flag, the named variation objects (with variable values).
+# Boolean flags carry the implicit on/off variations with no variables.
+# ---------------------------------------------------------------------------
+
+BOOL_VARIATIONS = [
+    {"key": "on", "name": "On", "variables": {}},
+    {"key": "off", "name": "Off", "variables": {}},
+]
+
+SORT_VARIATIONS = [
+    {
+        "key": "off",
+        "name": "Off",
+        "variables": {
+            "sort_algorithm": {"value": "popular_first"},
+            "show_amounts": {"value": "false"},
+        },
+    },
+    {
+        "key": "on",
+        "name": "On",
+        "variables": {
+            "sort_algorithm": {"value": "personalized"},
+            "show_amounts": {"value": "true"},
+        },
+    },
+]
+
+MAB_VARIATIONS = [
+    {"key": "off", "name": "Off", "variables": {}},
+    {"key": "on", "name": "On", "variables": {}},
+    {"key": "on_hide", "name": "On Hide", "variables": {}},
+]
+
+
+def _rule(
+    key: str,
+    name: str,
+    rule_type: str,
+    *,
+    pct: int = 10000,
+    variations: dict[str, int],
+    audience_ids: list[int] | None = None,
+    audience_conditions: list | None = None,
+    enabled: bool = True,
+    distribution_mode: str = "manual",
+) -> dict[str, Any]:
+    audience_ids = audience_ids or []
+    if audience_conditions is None:
+        audience_conditions = ["or", *[{"audience_id": a} for a in audience_ids]] if audience_ids else []
+    return {
+        "key": key,
+        "name": name,
+        "type": rule_type,
+        "enabled": enabled,
+        "percentage_included": pct,
+        "distribution_mode": distribution_mode,
+        "audience_conditions": audience_conditions,
+        "audience_ids": audience_ids,
+        "variations": {
+            vk: {"key": vk, "percentage_included": vp, "variation_id": 1000 + i}
+            for i, (vk, vp) in enumerate(variations.items())
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Flags — each carries variable_definitions, environments (with `enabled`),
+# its variations, and a per-environment ruleset (rules + priorities +
+# default_variation).
+# ---------------------------------------------------------------------------
+
+FLAGS: list[dict[str, Any]] = [
+    # 1. Boolean flag, single 100% targeted-delivery rule to everyone.
+    {
+        "key": "new-homepage",
+        "name": "New homepage",
+        "description": "100% rollout to everyone.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["everyone"],
+        "_rules": {
+            "everyone": _rule("everyone", "Everyone", "targeted_delivery", variations={"on": 10000}),
+        },
+    },
+    # 2. Boolean, 25% targeted-delivery to a boolean audience.
+    {
+        "key": "beta_feature",
+        "name": "Beta feature",
+        "description": "25% rollout to beta users.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["beta_rollout"],
+        "_rules": {
+            "beta_rollout": _rule(
+                "beta_rollout", "Beta rollout", "targeted_delivery",
+                pct=2500, variations={"on": 10000}, audience_ids=[1],
+            ),
+        },
+    },
+    # 3. Boolean, 100% to a set-membership audience (country US/CA).
+    {
+        "key": "na_promo",
+        "name": "NA promo",
+        "description": "Promo for US/CA.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["na_only"],
+        "_rules": {
+            "na_only": _rule(
+                "na_only", "NA only", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[2],
+            ),
+        },
+    },
+    # 4. Boolean, version-range + string audience (semver_ge AND exact).
+    {
+        "key": "mobile_checkout",
+        "name": "Mobile checkout",
+        "description": "iOS on v1.2.0+.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["modern_ios"],
+        "_rules": {
+            "modern_ios": _rule(
+                "modern_ios", "Modern iOS", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[3],
+            ),
+        },
+    },
+    # 5. Boolean, numeric le audience.
+    {
+        "key": "winback_banner",
+        "name": "Winback banner",
+        "description": "Recent purchasers only.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["recent"],
+        "_rules": {
+            "recent": _rule(
+                "recent", "Recent purchasers", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[4],
+            ),
+        },
+    },
+    # 6. substring audience → BLOCKED.
+    {
+        "key": "substring_gate",
+        "name": "Substring gate",
+        "description": "Email contains a substring — not migratable.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["substr"],
+        "_rules": {
+            "substr": _rule(
+                "substr", "Substring", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[5],
+            ),
+        },
+    },
+    # 7. Flag WITH variables, a/b experiment 50/50 (two variations).
+    {
+        "key": "product_sort",
+        "name": "Product sort",
+        "description": "Sort algorithm experiment.",
+        "archived": False,
+        "variable_definitions": {
+            "sort_algorithm": {"key": "sort_algorithm", "type": "string", "default_value": "popular_first"},
+            "show_amounts": {"key": "show_amounts", "type": "boolean", "default_value": "false"},
+        },
+        "_variations": SORT_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["sort_experiment"],
+        "_rules": {
+            "sort_experiment": _rule(
+                "sort_experiment", "Sort experiment", "a/b",
+                variations={"off": 5000, "on": 5000},
+            ),
+        },
+    },
+    # 8. a/b with partial allocation (50%) + an everyone fallback rule →
+    #    REST backend (non-allocated traffic must fall through).
+    {
+        "key": "pricing_test",
+        "name": "Pricing test",
+        "description": "50% into the experiment, rest fall through to a default rollout.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["price_ab", "fallback_on"],
+        "_rules": {
+            "price_ab": _rule(
+                "price_ab", "Price A/B", "a/b",
+                pct=5000, variations={"off": 5000, "on": 5000}, audience_ids=[7],
+            ),
+            "fallback_on": _rule(
+                "fallback_on", "Fallback rollout", "targeted_delivery",
+                variations={"on": 10000},
+            ),
+        },
+    },
+    # 9. multi_armed_bandit → adaptive split, snapshot + note.
+    {
+        "key": "headline_mab",
+        "name": "Headline MAB",
+        "description": "Multi-armed bandit over three headlines.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": MAB_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["mab"],
+        "_rules": {
+            "mab": _rule(
+                "mab", "Headline bandit", "multi_armed_bandit",
+                variations={"off": 3333, "on": 3333, "on_hide": 3334},
+                distribution_mode="stats_accelerator",
+            ),
+        },
+    },
+    # 10. Disabled ruleset → migrate OFF.
+    {
+        "key": "legacy_banner",
+        "name": "Legacy banner",
+        "description": "Turned off in production.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": False,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["us_only"],
+        "_rules": {
+            "us_only": _rule(
+                "us_only", "US only", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[2],
+            ),
+        },
+    },
+    # 11. Combo audience: authenticated AND NOT internal → inline both,
+    #     internal negated.
+    {
+        "key": "members_dashboard",
+        "name": "Members dashboard",
+        "description": "Authenticated non-staff.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["members"],
+        "_rules": {
+            "members": _rule(
+                "members", "Members", "targeted_delivery",
+                variations={"on": 10000},
+                audience_ids=[7, 9],
+                audience_conditions=["and", {"audience_id": 7}, ["not", {"audience_id": 9}]],
+            ),
+        },
+    },
+    # 12. exists audience → BLOCKED (no working Confidence presence operator).
+    {
+        "key": "plan_badge",
+        "name": "Plan badge",
+        "description": "Anyone with a plan attribute set.",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["has_plan"],
+        "_rules": {
+            "has_plan": _rule(
+                "has_plan", "Has plan", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[10],
+            ),
+        },
+    },
+    # 13. Non-custom_attribute audience (browser) → BLOCKED.
+    {
+        "key": "browser_gate",
+        "name": "Browser gate",
+        "description": "Chrome-only (Web-style audience).",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": True,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["chrome"],
+        "_rules": {
+            "chrome": _rule(
+                "chrome", "Chrome", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[11],
+            ),
+        },
+    },
+    # 14. Archived flag — hidden from list unless opted in.
+    {
+        "key": "old_experiment",
+        "name": "Old experiment",
+        "description": "Archived experiment from last quarter.",
+        "archived": True,
+        "variable_definitions": {},
+        "_variations": BOOL_VARIATIONS,
+        "_enabled": False,
+        "_default_variation_key": "off",
+        "_rule_priorities": ["us_only"],
+        "_rules": {
+            "us_only": _rule(
+                "us_only", "US only", "targeted_delivery",
+                variations={"on": 10000}, audience_ids=[2],
+            ),
+        },
+    },
+]
+
+FLAGS_BY_KEY = {f["key"]: f for f in FLAGS}
+
+
+# ---------------------------------------------------------------------------
+# Response shaping
+# ---------------------------------------------------------------------------
+
+def _flag_public(f: dict[str, Any], env_key: str = "production") -> dict[str, Any]:
+    """The flag object as the List/Fetch Flags endpoints return it."""
+    rules_detail = [
+        {
+            "key": rk,
+            "name": f["_rules"][rk]["name"],
+            "type": f["_rules"][rk]["type"],
+            "enabled": f["_rules"][rk]["enabled"],
+            "audience_ids": f["_rules"][rk]["audience_ids"],
+            "traffic_allocation": f["_rules"][rk]["percentage_included"],
+            "distribution_mode": f["_rules"][rk]["distribution_mode"],
+        }
+        for rk in f["_rule_priorities"]
+    ]
+    return {
+        "key": f["key"],
+        "name": f["name"],
+        "description": f["description"],
+        "archived": f["archived"],
+        "variable_definitions": f["variable_definitions"],
+        "id": abs(hash(f["key"])) % 10_000_000,
+        "urn": f"flags.flags.optimizely.com::{f['key']}",
+        "project_id": PROJECT_ID,
+        "account_id": ACCOUNT_ID,
+        "environments": {
+            env["key"]: {
+                "key": env["key"],
+                "name": env["name"],
+                "enabled": f["_enabled"] if env["key"] == "production" else False,
+                "priority": env["priority"],
+                "status": "running" if f["_enabled"] else "draft",
+                "rules_summary": {},
+                "rules_detail": rules_detail if env["key"] == "production" else [],
+                "id": env["id"],
+            }
+            for env in ENVIRONMENTS
+        },
+    }
+
+
+def _ruleset_public(f: dict[str, Any], env_key: str) -> dict[str, Any]:
+    enabled = f["_enabled"] if env_key == "production" else False
+    rules = f["_rules"] if env_key == "production" else {}
+    priorities = f["_rule_priorities"] if env_key == "production" else []
+    return {
+        "url": f"/projects/{PROJECT_ID}/flags/{f['key']}/environments/{env_key}/ruleset",
+        "rules": rules,
+        "rule_priorities": priorities,
+        "id": abs(hash(f["key"] + env_key)) % 10_000_000,
+        "archived": False,
+        "enabled": enabled,
+        "flag_key": f["key"],
+        "environment_key": env_key,
+        "default_variation_key": f["_default_variation_key"],
+        "default_variation_name": f["_default_variation_key"].title(),
+        "status": "running" if enabled else "paused",
+    }
+
+
+def _audience_public(a: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": a["id"],
+        "name": a["name"],
+        "description": a["description"],
+        "conditions": a["conditions"],
+        "archived": False,
+        "is_classic": False,
+        "project_id": PROJECT_ID,
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer
+# ---------------------------------------------------------------------------
+
+R_FLAGS_LIST = re.compile(r"^/flags/v1/projects/(?P<pid>\d+)/flags/?$")
+R_FLAG_ONE = re.compile(r"^/flags/v1/projects/(?P<pid>\d+)/flags/(?P<key>[^/]+)/?$")
+R_FLAG_VARIATIONS = re.compile(r"^/flags/v1/projects/(?P<pid>\d+)/flags/(?P<key>[^/]+)/variations/?$")
+R_RULESET = re.compile(
+    r"^/flags/v1/projects/(?P<pid>\d+)/flags/(?P<key>[^/]+)/environments/(?P<env>[^/]+)/ruleset/?$"
+)
+R_AUDIENCES_LIST = re.compile(r"^/v2/audiences/?$")
+R_AUDIENCE_ONE = re.compile(r"^/v2/audiences/(?P<id>\d+)/?$")
+R_ENVIRONMENTS = re.compile(r"^/v2/environments/?$")
+R_PROJECTS = re.compile(r"^/v2/projects/?$")
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "FakeOptimizely/0.1"
+    per_page_default = 100
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"  {self.address_string()} → {fmt % args}")
+
+    def _send(self, code: int, body: Any) -> None:
+        payload = json.dumps(body).encode() if body is not None else b""
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if payload:
+            self.wfile.write(payload)
+
+    def _check_auth(self) -> bool:
+        auth = self.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            self._send(401, {"message": "Missing or malformed Authorization header"})
+            return False
+        return True
+
+    def _bool_param(self, query: dict[str, list[str]], name: str) -> bool:
+        return name in query and query[name][0].lower() in ("true", "1", "yes")
+
+    def _paginate(self, items: list, query: dict[str, list[str]], url: str) -> dict:
+        per_page = int(query.get("per_page", [str(self.per_page_default)])[0])
+        page = int(query.get("page", ["1"])[0])
+        total = len(items)
+        total_pages = max(1, (total + per_page - 1) // per_page)
+        start = (page - 1) * per_page
+        window = items[start : start + per_page]
+        return {
+            "items": window,
+            "page": page,
+            "total_pages": total_pages,
+            "count": len(window),
+            "total_count": total,
+            "url": url,
+        }
+
+    def do_GET(self) -> None:  # noqa: N802
+        if not self._check_auth():
+            return
+        parsed = urlparse(self.path)
+        path = parsed.path
+        query = parse_qs(parsed.query)
+
+        m = R_RULESET.match(path)
+        if m:
+            f = FLAGS_BY_KEY.get(m["key"])
+            if f is None:
+                self._send(404, {"message": f"flag {m['key']} not found"})
+                return
+            self._send(200, _ruleset_public(f, m["env"]))
+            return
+
+        m = R_FLAG_VARIATIONS.match(path)
+        if m:
+            f = FLAGS_BY_KEY.get(m["key"])
+            if f is None:
+                self._send(404, {"message": f"flag {m['key']} not found"})
+                return
+            self._send(200, {"items": f["_variations"], "count": len(f["_variations"])})
+            return
+
+        m = R_FLAG_ONE.match(path)
+        if m and not path.rstrip("/").endswith("/flags"):
+            f = FLAGS_BY_KEY.get(m["key"])
+            if f is None:
+                self._send(404, {"message": f"flag {m['key']} not found"})
+                return
+            self._send(200, _flag_public(f))
+            return
+
+        m = R_FLAGS_LIST.match(path)
+        if m:
+            include_archived = self._bool_param(query, "archived")
+            visible = [f for f in FLAGS if include_archived or not f["archived"]]
+            self._send(200, self._paginate([_flag_public(f) for f in visible], query, path))
+            return
+
+        m = R_AUDIENCE_ONE.match(path)
+        if m:
+            a = AUDIENCES_BY_ID.get(int(m["id"]))
+            if a is None:
+                self._send(404, {"message": f"audience {m['id']} not found"})
+                return
+            self._send(200, _audience_public(a))
+            return
+
+        m = R_AUDIENCES_LIST.match(path)
+        if m:
+            self._send(200, self._paginate([_audience_public(a) for a in AUDIENCES], query, path))
+            return
+
+        m = R_ENVIRONMENTS.match(path)
+        if m:
+            self._send(200, {"items": ENVIRONMENTS, "count": len(ENVIRONMENTS)})
+            return
+
+        m = R_PROJECTS.match(path)
+        if m:
+            self._send(200, {"items": [{"id": PROJECT_ID, "name": "Fixture project", "status": "active"}]})
+            return
+
+        self._send(404, {"message": f"No route for {path}"})
+
+    def _readonly(self) -> None:
+        self._send(405, {"message": "This fake server is read-only"})
+
+    do_POST = do_PUT = do_PATCH = do_DELETE = lambda self: self._readonly()  # noqa: E731
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=4100)
+    args = parser.parse_args()
+
+    server = HTTPServer(("127.0.0.1", args.port), Handler)
+    base = f"http://127.0.0.1:{args.port}"
+    n_active = sum(1 for f in FLAGS if not f["archived"])
+    print(f"Fake Optimizely REST API listening on {base}")
+    print(f"  {len(FLAGS)} flags ({n_active} non-archived), {len(AUDIENCES)} audiences, "
+          f"{len(ENVIRONMENTS)} environments")
+    print(f"  Project ID: {PROJECT_ID}")
+    print("  Point the migrate-optimizely skill at this base URL when prompted.")
+    print("  Set OPTIMIZELY_API_TOKEN to anything (any Bearer value passes).")
+    print("  Press Ctrl+C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/migrate-optimizely/test-fixtures/verify_migration.py
+++ b/skills/migrate-optimizely/test-fixtures/verify_migration.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Model Optimizely's evaluation over the fixtures to produce a ground-truth matrix.
+
+This computes, locally and with no network, what each fixture flag is
+expected to return for a set of test contexts. Use it to spot-check that
+Confidence resolves (after running `/migrate-optimizely execute`) match
+Optimizely for the same context.
+
+It deliberately models the **deterministic** part of evaluation: audience
+matching and the ruleset waterfall (`rule_priorities`, first match wins).
+The random percentage dimension (`percentage_included` / variation split)
+is reported as metadata, not simulated — bucketing is stable per
+bucketing ID but its exact split is a property of the hashing, not the
+config translation.
+
+Run:
+    python3 verify_migration.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from server import AUDIENCES_BY_ID, FLAGS
+
+# match_types with no clean Confidence translation → BLOCKED.
+# `exists` is blocked because Confidence has no working presence operator:
+# a ruleless attribute criterion stores as operator "unknown" and errors at
+# resolve (verified live against the resolver).
+BLOCKED_MATCH_TYPES = {"substring", "regex", "exists"}
+
+
+class Blocked(Exception):
+    """Raised when a condition cannot be migrated/evaluated."""
+
+
+def _ver_tuple(s: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in str(s).split("-", 1)[0].split("."))
+
+
+def eval_leaf(leaf: dict[str, Any], ctx: dict[str, Any]) -> bool:
+    ctype = leaf.get("type")
+    if ctype != "custom_attribute":
+        raise Blocked(f"non-custom_attribute audience leaf '{ctype}'")
+    mt = leaf.get("match_type") or ("exact" if "value" in leaf else "exists")
+    if mt in BLOCKED_MATCH_TYPES:
+        raise Blocked(f"match_type '{mt}'")
+
+    value = ctx.get(leaf["name"])
+    target = leaf.get("value")
+
+    if value is None:
+        return False
+    if mt == "exact":
+        return value == target
+    if mt in ("gt", "ge", "lt", "le"):
+        v, t = float(value), float(target)
+        return {"gt": v > t, "ge": v >= t, "lt": v < t, "le": v <= t}[mt]
+    if mt.startswith("semver_"):
+        v, t = _ver_tuple(value), _ver_tuple(target)
+        return {
+            "semver_eq": v == t,
+            "semver_gt": v > t,
+            "semver_ge": v >= t,
+            "semver_lt": v < t,
+            "semver_le": v <= t,
+        }[mt]
+    raise Blocked(f"unhandled match_type '{mt}'")
+
+
+def eval_tree(node: Any, ctx: dict[str, Any]) -> bool:
+    """Evaluate the list-based condition language (or an audience_id ref)."""
+    if isinstance(node, dict):
+        if "audience_id" in node:
+            aud = AUDIENCES_BY_ID.get(node["audience_id"])
+            if aud is None:
+                raise Blocked(f"unknown audience {node['audience_id']}")
+            return eval_tree(json.loads(aud["conditions"]), ctx)
+        return eval_leaf(node, ctx)
+    if isinstance(node, list):
+        if not node:
+            return True  # empty audience_conditions = everyone
+        op, rest = node[0], node[1:]
+        if op == "and":
+            return all(eval_tree(c, ctx) for c in rest)
+        if op == "or":
+            return any(eval_tree(c, ctx) for c in rest)
+        if op == "not":
+            return not eval_tree(rest[0], ctx)
+        # bare list of conditions → treat as AND
+        return all(eval_tree(c, ctx) for c in node)
+    raise Blocked(f"unexpected node {node!r}")
+
+
+def rule_matches(rule: dict[str, Any], ctx: dict[str, Any]) -> bool:
+    if not rule.get("enabled", True):
+        return False
+    return eval_tree(rule.get("audience_conditions", []), ctx)
+
+
+def rule_is_blocked(rule: dict[str, Any]) -> str | None:
+    try:
+        eval_tree(rule.get("audience_conditions", []), {})
+        return None
+    except Blocked as b:
+        return str(b)
+
+
+def flag_backend(flag: dict[str, Any]) -> str:
+    """REST if any non-last rule has partial allocation (fall-through)."""
+    prios = flag["_rule_priorities"]
+    for i, rk in enumerate(prios):
+        rule = flag["_rules"][rk]
+        partial = rule["percentage_included"] < 10000
+        not_last = i < len(prios) - 1
+        if partial and not_last:
+            return "REST"
+    return "MCP"
+
+
+CONTEXTS: dict[str, dict[str, Any]] = {
+    "beta-us": {"is_beta": True, "country": "US", "is_logged_in": True},
+    "us-ios-13": {"country": "US", "os": "ios", "app_version": "1.3.0"},
+    "us-ios-11": {"country": "US", "os": "ios", "app_version": "1.1.0"},
+    "ca-anon": {"country": "CA"},
+    "de-user": {"country": "DE", "is_logged_in": True},
+    "recent-buyer": {"days_since_last_order": 3},
+    "old-buyer": {"days_since_last_order": 40},
+    "member": {"is_logged_in": True, "is_internal": False, "plan": "pro"},
+    "staff": {"is_logged_in": True, "is_internal": True, "plan": "pro"},
+}
+
+
+def main() -> None:
+    print("=" * 72)
+    print("Optimizely fixture evaluation — ground-truth matrix (env: production)")
+    print("=" * 72)
+
+    for flag in FLAGS:
+        if flag["archived"]:
+            print(f"\n  {flag['key']:<22} ARCHIVED (excluded from default scan)")
+            continue
+
+        shape = "boolean" if not flag["variable_definitions"] else \
+            f"struct({', '.join(flag['variable_definitions'])})"
+        print(f"\n  {flag['key']}  [{shape}]")
+
+        if not flag["_enabled"]:
+            print("      DISABLED in Optimizely (off for every context; "
+                  "migrates OFF — rules at 0%)")
+            continue
+
+        prios = flag["_rule_priorities"]
+        blocked = [rule_is_blocked(flag["_rules"][rk]) for rk in prios]
+        if all(b is not None for b in blocked):
+            print(f"      BLOCKED ({blocked[0]})")
+            continue
+
+        backend = flag_backend(flag)
+        for rk in prios:
+            r = flag["_rules"][rk]
+            split = ", ".join(f"{vk}={vp/100:g}%" for vk, vp in
+                              {k: v["percentage_included"] for k, v in r["variations"].items()}.items())
+            adaptive = r["distribution_mode"] != "manual" or r["type"] == "multi_armed_bandit"
+            note = "  (ADAPTIVE — snapshot)" if adaptive else ""
+            print(f"      rule {rk} [{r['type']}] traffic={r['percentage_included']/100:g}% "
+                  f"split=[{split}]{note}")
+        print(f"      backend: {backend}"
+              + ("  (partial allocation must fall through)" if backend == "REST" else ""))
+
+        for cname, ctx in CONTEXTS.items():
+            matched = None
+            for rk in prios:
+                rule = flag["_rules"][rk]
+                if rule_is_blocked(rule):
+                    continue
+                if rule_matches(rule, ctx):
+                    matched = rk
+                    break
+            result = f"rule '{matched}'" if matched else f"default '{flag['_default_variation_key']}'"
+            print(f"        {cname:<14} -> {result}")
+
+    print("\nDone. Compare these against Confidence resolveFlag output.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a self-contained **Optimizely Feature Experimentation → Confidence** migration kit, modeled on the existing `migrate-eppo` / `migrate-statsig` kits. Covers **both phases**: flag definitions, then SDK code transformation.

### Phase 1 — Flag definitions
- **`skills/migrate-optimizely/SKILL.md`** — REST-driven scan of Optimizely's Flags API (`/flags/v1`) + Platform API v2 (`/v2` audiences), mapping flags → Confidence flags (boolean or struct), variations → variants, per-environment rulesets (`rule_priorities` waterfall) → ordered targeting rules, `targeted_delivery`/`a/b`/`multi_armed_bandit` types, basis-point percentages, `default_variation` catch-all, and audiences (list-based condition language + `custom_attribute` match types) → Confidence criteria. MCP (default) + full-fidelity REST backend, plus a complete operator-mapping table.

### Phase 2 — Code transformation (SDK migration)
- `plan code` flow (detect language → fetch Confidence SDK guide + resolve-mode signal → scan → transform rules → plan), flag-by-flag with one PR each.
- Covers **both Optimizely API generations**: the **Decide API** (`createUserContext` + `decide`, `decision.enabled`/`variables`/`variationKey`) and the **legacy Full Stack API** (`isFeatureEnabled`, `getFeatureVariable*`, `activate`/`getVariation`), plus the **React SDK** (`OptimizelyProvider`, `useDecision`, `OptimizelyFeature`) → `ConfidenceProvider` + `useFlag`.
- Maps source resolve modes (datafile in-process / on-device / Agent remote) to Confidence's four modes with change signalling; handles flag-key→resolve-path and client-ambient vs server-per-call context; deletes notification listeners / datafile polling / readiness waits; maps `track`/`trackEvent` to Confidence's track API; flags `activate`/`getVariation` key-switches for human review.

### Supporting
- **`commands/migrate-optimizely.md`** — slash command (`plan flags | plan code | execute`).
- **`test-fixtures/`** — fake Optimizely REST server, ground-truth evaluator, best-effort seeder, and `phase2-examples/` (Node decide-server, Node legacy Full Stack, React client) for the code transform to scan.
- Wires the kit into `CLAUDE.md`, `README.md`, `GEMINI.md`, and the Codex plugin manifest.

## Validation

- **Fixtures:** fake server smoke-tested (auth, pagination, all routes); `verify_migration.py` produces the expected flag × context matrix.
- **Real Confidence (live MCP):** ran Phase 1 end-to-end for a representative subset (fixture server → translate → `createFlag`/`addTargetingRule`/`resolveFlag` against a real client), and resolves matched the ground-truth matrix exactly — set membership, semver range + AND, 25/75 split + catch-all, combo AND-NOT, and a struct a/b returning variable values. Naming normalization confirmed. Test flags archived afterward.
- **Bug found + fixed during live testing:** the inherited "ruleless presence criterion" trick for `exists`/null targeting is broken — stores as `operator: "unknown"` and errors at resolve. `exists` (and negated-exists) is now mapped to **BLOCKED** in the skill, fixtures, and verifier. ⚠️ The same pattern exists in the statsig/posthog/eppo skills and is likely broken there too (not changed here).

## Notes / not covered

- The **REST-backend** Phase 1 path (partial allocation, segments, exclusivity) wasn't exercised live — it needs a Confidence management REST API token, not just the MCP.
- The live **Optimizely read side** wasn't validated against a real account: Optimizely has retired its self-serve free "Rollouts" signup (old URLs now redirect to a sales/demo form). The fixture server mirrors the documented API shapes in the meantime.
- Phase 2 transforms were authored against the documented Optimizely SDK surface + the `phase2-examples` fixtures; not yet run live against a real codebase.

## Test plan

- [ ] `cd skills/migrate-optimizely/test-fixtures && python3 server.py` and smoke-test endpoints
- [ ] `python3 verify_migration.py` and review the ground-truth matrix
- [ ] `/confidence:migrate-optimizely plan flags` against the fake server (base `http://127.0.0.1:4100`, project `4100100100`, env `production`); `execute` against a throwaway client and confirm resolves match
- [ ] `/confidence:migrate-optimizely plan code` against a `phase2-examples/` app; review the generated code-migration plan