### PR TITLE
feat(migrate-optimizely): OpenFeature provider-swap path for Phase 2

### DIFF
--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1934,9 +1934,10 @@ OpenFeature provider, plus Phase 1 (the flags must exist in Confidence).
    Step 2a's routing (server in-process / browser cached / React / remote):
    - Official vendor provider package → swap the import + the constructor
      line for the Confidence provider.
-   - Hand-written custom provider (wraps a vendor SDK directly, like Nike
-     NMP's OptimizelyProvider) → replace the class with the Confidence
-     provider. If that class encodes BUSINESS SEMANTICS (e.g. on/off-string
+   - Hand-written custom provider (a class wrapping a vendor SDK directly,
+     e.g. a custom `OptimizelyProvider` wrapping `@optimizely/optimizely-sdk`)
+     → replace the class with the Confidence provider. If that class encodes
+     BUSINESS SEMANTICS (e.g. on/off-string
      modelling, anonymous-context suppression, per-flag special-casing),
      re-home that logic into a thin wrapper or hooks layered ON TOP of the
      Confidence provider — do not silently drop it. Flag each such behavior

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1398,6 +1398,13 @@ with:
 **Each flag = one PR.** The code migration creates a separate pull
 request for each flag, keeping changes small and reviewable.
 
+**If the plan's Migration style is `provider swap` (already on
+OpenFeature) or `facade re-point`,** there is no per-flag call-site work.
+Do a single PR that swaps the registered provider (or repoints the
+facade's internal provider) to Confidence per "Already on OpenFeature →
+provider swap", leaving call sites unchanged, then verify. The per-flag
+loop below applies only to the `call-site rewrite` style.
+
 ```
 1. READ the plan file
 2. SDK SETUP (Section 1 of plan) — one-time, before any flag
@@ -1547,10 +1554,10 @@ verifies the waterfall (`rule_priorities`) order is preserved.
 
 ## Plan Code: Steps
 
-The code phase has 5 steps: Step 1 detect language/framework, Step 2
-fetch the Confidence SDK guide (and signal any resolve-mode change),
-Step 3 scan the codebase for Optimizely usage, Step 4 generate transform
-rules, Step 5 generate the plan.
+The code phase has 5 steps: Step 1 detect language/framework **and the
+migration style**, Step 2 fetch the Confidence SDK guide (and signal any
+resolve-mode change), Step 3 scan the codebase for Optimizely usage, Step
+4 generate transform rules, Step 5 generate the plan.
 
 ### Step 1: Detect language & framework
 
@@ -1559,6 +1566,44 @@ Grep: pattern="<Optimizely import/symbol patterns from Step 3>"  → Find Optimi
 Glob: pattern="package.json" or "build.gradle" or "*.csproj" or "go.mod" or "pyproject.toml"/"requirements.txt" or "Gemfile" etc
 Read: dependency file  → Determine language/framework AND which Optimizely SDK package
 ```
+
+### Step 1b: Detect the migration style (provider swap vs call-site rewrite)
+
+**This is the FIRST branch in the code phase — it changes everything
+below.** Before scanning for Optimizely calls, determine whether the app
+talks to Optimizely **directly** or **already through OpenFeature**.
+
+```
+Grep -i: pattern="@openfeature/|dev\.openfeature|open-feature/go-sdk|openfeature" → already on OpenFeature?
+Grep -i: pattern="OpenFeature\.(setProvider|setProviderAndWait)|SetProviderAndWait|getClient\(|useFlag\(" → OpenFeature wiring
+Grep -i: pattern="implements (Feature)?Provider|: Provider|class \w+Provider" → a custom OpenFeature provider class
+```
+
+Two styles result:
+
+| Style | When | Phase 2 work |
+|-------|------|--------------|
+| **Provider swap** | App **already uses OpenFeature** (standard `useFlag` / `get*Value` call sites; Optimizely is hidden behind a registered OpenFeature provider, official or custom) | Swap the **registered provider** to Confidence; **call sites do NOT change**. See "Already on OpenFeature → provider swap". |
+| **Call-site rewrite** | App calls the **Optimizely SDK directly** (`decide`, `isFeatureEnabled`, `getFeatureVariable*`, `activate`) | Rewrite call sites to OpenFeature + Confidence (Steps 2–5 below). |
+
+> **Why this matters.** A team already on OpenFeature did the hard part —
+> their call sites are vendor-neutral. Migrating them to Confidence is a
+> one-file provider swap, not a codebase-wide rewrite. Detecting this
+> first avoids needlessly rewriting `useFlag('x', false)` into itself.
+>
+> **Facade caveat.** Some teams hide the SDK behind a **home-grown facade**
+> (not OpenFeature) — e.g. an `ExperimentManager` exposing
+> `isFeatureEnabled(...)`. That is NOT the provider-swap case: the facade
+> is vendor-specific. The migration there is to repoint the facade's
+> internal provider at Confidence (a localized change inside the facade),
+> while its public API and call sites stay put. Treat it like a provider
+> swap scoped to the facade's implementation, and record the facade entry
+> point in the plan.
+
+If the style is **provider swap**, skip the call-site transform tables in
+Step 4 and follow "Already on OpenFeature → provider swap" instead. Step 2
+(SDK guide + resolve mode) and Phase 1 (flags must exist in Confidence)
+still apply.
 
 ### Step 2: Fetch SDK guide from `confidence-docs` MCP
 
@@ -1865,6 +1910,88 @@ using the template below.
 - **Flags are structs — read a property, not the bare key** (`<flag>.<property>`).
 - **Client SDKs use ambient context; server SDKs pass it per call.**
 
+---
+
+## Already on OpenFeature → provider swap
+
+When Step 1b found the app **already uses OpenFeature**, do NOT run the
+call-site transform. The call sites (`useFlag`, `get<Type>Value`,
+`get<Type>Evaluation`) are vendor-neutral and stay exactly as they are.
+The migration is to replace the **registered provider** with Confidence's
+OpenFeature provider, plus Phase 1 (the flags must exist in Confidence).
+
+### The swap, step by step
+
+```
+1. LOCATE the provider wiring:
+   - the registration call: OpenFeature.setProvider / setProviderAndWait /
+     SetProviderAndWait (JS/Java/Go), api.set_provider[_and_wait] (Python),
+     OpenFeatureAPI.getInstance().setProviderAndWait (Java), the
+     <OpenFeatureProvider> boundary (React)
+   - any CUSTOM provider class the team wrote (e.g. `class FooProvider
+     implements Provider`) wrapping the old vendor SDK
+2. REPLACE the provider with Confidence's, picking the package/mode from
+   Step 2a's routing (server in-process / browser cached / React / remote):
+   - Official vendor provider package → swap the import + the constructor
+     line for the Confidence provider.
+   - Hand-written custom provider (wraps a vendor SDK directly, like Nike
+     NMP's OptimizelyProvider) → replace the class with the Confidence
+     provider. If that class encodes BUSINESS SEMANTICS (e.g. on/off-string
+     modelling, anonymous-context suppression, per-flag special-casing),
+     re-home that logic into a thin wrapper or hooks layered ON TOP of the
+     Confidence provider — do not silently drop it. Flag each such behavior
+     in the plan.
+3. KEEP all call sites unchanged.
+4. CONTEXT: OpenFeature evaluation context is already standard. Only adjust
+   if attribute names differ from the Confidence flag's targeting (e.g. a
+   custom targetingKey or attribute rename). Usually nothing to do.
+5. DELETE vendor scaffolding the old provider carried: datafile polling,
+   vendor event/decision listeners, SDK-key plumbing — Confidence's
+   provider handles state refresh and exposure logging itself.
+6. Phase 1: re-create the flags + audiences in Confidence so the new
+   provider resolves them (this is the same Phase 1 as the rewrite path).
+```
+
+The result is typically a **one- or few-file change** at the bootstrap /
+provider module, plus the flag re-creation — independent of how many call
+sites read flags.
+
+### Source providers you may be swapping out
+
+The app's current OpenFeature provider can be an official vendor package or
+a hand-written class. Recognize it, then swap it for the Confidence
+provider regardless of which one it is. Common sources (package names are
+indicative — confirm against the repo's manifest):
+
+| Current provider | Typical package / shape | Swap to (Confidence) |
+|------------------|-------------------------|----------------------|
+| Optimizely (custom) | hand-written `class …Provider implements Provider` wrapping `@optimizely/optimizely-sdk` | Confidence provider for the platform/mode (Step 2a) |
+| LaunchDarkly | `@launchdarkly/openfeature-server-provider` / `…-client-provider`, `launchdarkly-openfeature-*` | ″ |
+| Flagsmith | `@flagsmith/openfeature-*`, `flagsmith-openfeature` | ″ |
+| Split | `@splitsoftware/openfeature-provider-*` | ″ |
+| Unleash | `@unleash/openfeature` / community provider | ″ |
+| ConfigCat | `@configcat/openfeature-*` | ″ |
+| DevCycle | `@devcycle/openfeature-*` | ″ |
+| GO Feature Flag | `@openfeature/go-feature-flag-provider` | ″ |
+| flagd (reference) | `@openfeature/flagd-provider` / `dev.openfeature.contrib…flagd` | ″ |
+| Statsig / PostHog | community OpenFeature providers | ″ |
+| In-house / custom | any `Provider` / `FeatureProvider` implementation | ″ |
+
+In every case the **call sites and the OpenFeature client API are
+identical** — only the registered provider changes. The
+language/mode-specific Confidence provider (and its `setProviderAndWait` /
+`set_provider` init) comes from the Step 2 SDK guide.
+
+### Verify
+
+- Confirm the flags referenced by call sites exist in Confidence (Phase 1)
+  with matching resolve paths (`<flag>.<property>`).
+- Re-run the app's existing flag tests/usages — because call sites are
+  unchanged, the existing assertions should hold once the provider resolves
+  the migrated flags.
+- Spot-check a positive and a negative context (same as the rewrite path's
+  resolve verification).
+
 ## Plan Code: Template
 
 ```markdown
@@ -1874,6 +2001,7 @@ using the template below.
 **Scope:** Code transformation only
 **Language:** <detected>
 **Framework:** <detected>
+**Migration style:** <provider swap (already on OpenFeature) | call-site rewrite (direct Optimizely SDK) | facade re-point (home-grown facade)>
 
 ---
 

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1957,6 +1957,54 @@ The result is typically a **one- or few-file change** at the bootstrap /
 provider module, plus the flag re-creation — independent of how many call
 sites read flags.
 
+### Re-homing custom-provider semantics (prefer the flag model over code)
+
+A hand-written provider (or facade) often **computes** a value at read
+time instead of passing the flag through — e.g. exposing a boolean
+feature as an on/off **string**, or reading a variable **only if** the
+feature is enabled. Don't port that logic verbatim into a new wrapper if
+you can avoid it: push it into the **Confidence flag model** so the
+swapped-in provider needs no special-casing.
+
+- **Boolean feature exposed as an on/off string** → model the Confidence
+  flag with a `string` property whose variants are the literal strings the
+  call site expects (e.g. `"on"` / `"off"`), plus a targeting rule
+  (in-audience → `on`, otherwise → `off`). The call site's
+  `useFlag` / `get<Type>Value` is unchanged.
+- **Conditional variable read** ("return variable X only if the feature is
+  enabled, else a default") → fold the condition into variant values: the
+  matched variant carries X's value, the default/off variant carries the
+  fallback. "Only if enabled" becomes "only the matched variant has the
+  value."
+
+Then **delete** the special-casing from the old provider rather than
+re-homing it as code.
+
+> **Confirm before folding.** This only works when the logic is **static /
+> enumerable** as variants + targeting. If the value is computed from
+> runtime inputs that can't be expressed as targeting (arbitrary
+> client-side math, values derived from non-context state), keep a **thin
+> wrapper** over the Confidence provider for that flag and note it in the
+> plan.
+
+### Live-update / change-observer APIs
+
+If the app or facade exposes a flag-change/observer API — an `onChange`
+callback that fires when a flag's state changes without a restart — wire
+it to OpenFeature's **provider events** instead of the old vendor's
+flag-update callback: register a handler for the
+`PROVIDER_CONFIGURATION_CHANGED` event on the OpenFeature client/provider
+(`addHandler(...)`) and re-fire the app's callback from there. The
+Confidence provider refreshes resolver state on its poll interval and
+surfaces that as a configuration-changed event.
+
+> **Confirm before relying on it.** Verify the target Confidence provider
+> for this platform actually emits a configuration-changed event, and at
+> what **granularity**. If it signals a whole-state refresh (not per-flag)
+> while the source callback fired only on a *specific* flag's change, the
+> wrapper must diff that flag's value across the event to preserve the
+> original granularity. Record the decision in the plan.
+
 ### Source providers you may be swapping out
 
 The app's current OpenFeature provider can be an official vendor package or

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
@@ -17,6 +17,22 @@ line up: `product_sort` (struct flag with variables), `beta_feature`
 | `react-client/` | `@optimizely/react-sdk` | Decide + legacy | client | `<OptimizelyProvider>`, `useDecision`, `<OptimizelyFeature>` → ambient context + `useFlag` |
 | `java-server/` | `com.optimizely.ab:core-api` | Decide API | server | `createUserContext` + `decide`, `decision.getVariables().getValue(..)`, `MutableContext` (in-process → in-process, mode preserved) |
 | `python-server/` | `optimizely-sdk` | Decide API | server | `create_user_context` + `decide`, `decision.variables[..]` → prefer the **local-resolve** provider `confidence-openfeature-provider` (Alpha; `ConfidenceProvider` + `set_provider_and_wait`, in-process → in-process). Remote `spotify-confidence-sdk` is the fallback (⚠️ resolve-mode change) |
+| `openfeature-provider-swap/` | `@openfeature/*` + custom `OptimizelyProvider` | **already on OpenFeature** | client (React) | **Provider swap, NOT a rewrite** (the Nike NMP pattern): `useFlag` call sites are untouched; only `provider.ts` + the `OpenFeature.setProvider(...)` registration change. Exercises re-homing the custom provider's on/off-string + anonymous-suppression semantics on top of the Confidence provider |
+
+## Two migration styles
+
+- **Call-site rewrite** — the app calls the Optimizely SDK directly
+  (`decide`, `isFeatureEnabled`, …). The transform rewrites call sites to
+  OpenFeature + Confidence. This is the `node-*`, `java-server`,
+  `python-server`, and `react-client` examples.
+- **Provider swap** — the app is *already* on OpenFeature (standard
+  `useFlag` / `get*Value` call sites, Optimizely hidden behind a
+  registered provider). Migration only swaps the registered provider to
+  Confidence; **call sites don't change**. This is the
+  `openfeature-provider-swap` example (the Nike NMP pattern).
+
+`/migrate-optimizely plan code` detects which style applies (Step 1b) and
+plans accordingly.
 
 ## Expected transform (summary)
 

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/README.md
@@ -17,7 +17,7 @@ line up: `product_sort` (struct flag with variables), `beta_feature`
 | `react-client/` | `@optimizely/react-sdk` | Decide + legacy | client | `<OptimizelyProvider>`, `useDecision`, `<OptimizelyFeature>` → ambient context + `useFlag` |
 | `java-server/` | `com.optimizely.ab:core-api` | Decide API | server | `createUserContext` + `decide`, `decision.getVariables().getValue(..)`, `MutableContext` (in-process → in-process, mode preserved) |
 | `python-server/` | `optimizely-sdk` | Decide API | server | `create_user_context` + `decide`, `decision.variables[..]` → prefer the **local-resolve** provider `confidence-openfeature-provider` (Alpha; `ConfidenceProvider` + `set_provider_and_wait`, in-process → in-process). Remote `spotify-confidence-sdk` is the fallback (⚠️ resolve-mode change) |
-| `openfeature-provider-swap/` | `@openfeature/*` + custom `OptimizelyProvider` | **already on OpenFeature** | client (React) | **Provider swap, NOT a rewrite** (the Nike NMP pattern): `useFlag` call sites are untouched; only `provider.ts` + the `OpenFeature.setProvider(...)` registration change. Exercises re-homing the custom provider's on/off-string + anonymous-suppression semantics on top of the Confidence provider |
+| `openfeature-provider-swap/` | `@openfeature/*` + custom `OptimizelyProvider` | **already on OpenFeature** | client (React) | **Provider swap, NOT a rewrite** (the custom-provider pattern): `useFlag` call sites are untouched; only `provider.ts` + the `OpenFeature.setProvider(...)` registration change. Exercises re-homing the custom provider's on/off-string + anonymous-suppression semantics on top of the Confidence provider |
 
 ## Two migration styles
 
@@ -29,7 +29,7 @@ line up: `product_sort` (struct flag with variables), `beta_feature`
   `useFlag` / `get*Value` call sites, Optimizely hidden behind a
   registered provider). Migration only swaps the registered provider to
   Confidence; **call sites don't change**. This is the
-  `openfeature-provider-swap` example (the Nike NMP pattern).
+  `openfeature-provider-swap` example (the custom-provider pattern).
 
 `/migrate-optimizely plan code` detects which style applies (Step 1b) and
 plans accordingly.

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/package.json
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/package.json
@@ -2,7 +2,7 @@
   "name": "openfeature-provider-swap-example",
   "version": "1.0.0",
   "private": true,
-  "description": "Phase 2 fixture: app ALREADY on OpenFeature with a custom Optimizely provider (NMP-style). Migration = provider swap, call sites unchanged.",
+  "description": "Phase 2 fixture: app ALREADY on OpenFeature with a custom Optimizely provider. Migration = provider swap, call sites unchanged.",
   "dependencies": {
     "@openfeature/web-sdk": "^1.6.2",
     "@openfeature/react-sdk": "^1.0.1",

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/package.json
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "openfeature-provider-swap-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Phase 2 fixture: app ALREADY on OpenFeature with a custom Optimizely provider (NMP-style). Migration = provider swap, call sites unchanged.",
+  "dependencies": {
+    "@openfeature/web-sdk": "^1.6.2",
+    "@openfeature/react-sdk": "^1.0.1",
+    "@openfeature/core": "^1.9.1",
+    "@optimizely/optimizely-sdk": "^6.1.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/App.tsx
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/App.tsx
@@ -1,0 +1,47 @@
+/**
+ * Call sites are STANDARD OpenFeature (useFlag). The provider-swap
+ * migration leaves this entire file untouched — only provider.ts and the
+ * registration below change (Optimizely provider → Confidence provider).
+ */
+import React, { useEffect } from 'react';
+import { OpenFeature } from '@openfeature/web-sdk';
+import { OpenFeatureProvider, useFlag } from '@openfeature/react-sdk';
+import { OptimizelyProvider } from './provider';
+
+// --- The ONLY lines that change on migration: the provider registration. ---
+OpenFeature.setProvider(new OptimizelyProvider(process.env.OPTIMIZELY_SDK_KEY ?? ''));
+// On migration → OpenFeature.setProvider(createConfidenceWebProvider({ flagClientSecret: ... }))
+
+export function App({ currentUser }: { currentUser: { email: string; group: string } }) {
+  useEffect(() => {
+    OpenFeature.setContext({
+      targetingKey: currentUser.email,
+      nike_email: currentUser.email,
+      nike_group_id: currentUser.group,
+    });
+  }, [currentUser]);
+
+  return (
+    <OpenFeatureProvider>
+      <Homepage />
+    </OpenFeatureProvider>
+  );
+}
+
+function Homepage() {
+  // Standard OpenFeature React hooks — unchanged by the migration.
+  const analytics = useFlag('analytics', 'off');
+  const classification = useFlag('nike_classification', 'on');
+  const showAnalytics = String(analytics.value ?? 'off').toLowerCase().trim() === 'on';
+
+  return (
+    <main>
+      {showAnalytics && <Analytics />}
+      <div data-classification={classification.value} />
+    </main>
+  );
+}
+
+function Analytics() {
+  return <div className="analytics" />;
+}

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/provider.ts
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/provider.ts
@@ -1,6 +1,7 @@
 /**
  * A hand-written OpenFeature provider wrapping the Optimizely SDK
- * (the Nike NMP pattern). This is the ONLY file the provider-swap
+ * (a common pattern: a custom provider behind the OpenFeature global
+ * API). This is the ONLY file the provider-swap
  * migration touches: replace this class + its registration with the
  * Confidence OpenFeature provider. The call sites in App.tsx (useFlag)
  * do NOT change.

--- a/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/provider.ts
+++ b/skills/migrate-optimizely/test-fixtures/phase2-examples/openfeature-provider-swap/src/provider.ts
@@ -1,0 +1,77 @@
+/**
+ * A hand-written OpenFeature provider wrapping the Optimizely SDK
+ * (the Nike NMP pattern). This is the ONLY file the provider-swap
+ * migration touches: replace this class + its registration with the
+ * Confidence OpenFeature provider. The call sites in App.tsx (useFlag)
+ * do NOT change.
+ *
+ * Note the business semantics encoded here (on/off-string modelling +
+ * anonymous suppression). On migration these must be re-homed on top of
+ * the Confidence provider, not silently dropped — see the skill's
+ * "Already on OpenFeature → provider swap".
+ */
+import type {
+  Provider,
+  ResolutionDetails,
+  EvaluationContext,
+} from '@openfeature/web-sdk';
+import { createInstance, type Client } from '@optimizely/optimizely-sdk';
+
+const ON_OFF_STRING_FLAGS = new Set(['analytics', 'nike_classification', 'new_ui']);
+
+export class OptimizelyProvider implements Provider {
+  readonly runsOn = 'client';
+  readonly metadata = { name: 'Optimizely Provider' } as const;
+
+  private client: Client;
+  private ready = false;
+
+  constructor(sdkKey: string) {
+    this.client = createInstance({
+      sdkKey,
+      datafileOptions: { autoUpdate: true, updateInterval: 300000 },
+    });
+    this.client.onReady().then(() => {
+      this.ready = true;
+    });
+  }
+
+  private attrs(context: EvaluationContext): Record<string, unknown> {
+    const { targetingKey, ...rest } = context;
+    return rest;
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext
+  ): ResolutionDetails<boolean> {
+    if (!this.ready) return { value: defaultValue, reason: 'ERROR', errorCode: 'PROVIDER_NOT_READY' as never };
+    if (context.targetingKey === 'anonymous') return { value: defaultValue, reason: 'DEFAULT' };
+    const enabled = this.client.isFeatureEnabled(flagKey, String(context.targetingKey), this.attrs(context));
+    return { value: enabled, reason: 'TARGETING_MATCH' };
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext
+  ): ResolutionDetails<string> {
+    if (!this.ready) return { value: defaultValue, reason: 'ERROR', errorCode: 'PROVIDER_NOT_READY' as never };
+    // on/off-string modelling: these flags resolve to 'on'/'off' from isFeatureEnabled.
+    if (ON_OFF_STRING_FLAGS.has(flagKey)) {
+      const enabled = this.client.isFeatureEnabled(flagKey, String(context.targetingKey), this.attrs(context));
+      return { value: enabled ? 'on' : 'off', reason: 'TARGETING_MATCH' };
+    }
+    const value = this.client.getFeatureVariableString(flagKey, 'value', String(context.targetingKey), this.attrs(context));
+    return { value: value ?? defaultValue, reason: 'TARGETING_MATCH' };
+  }
+
+  resolveNumberEvaluation(): ResolutionDetails<number> {
+    throw new Error('not used in this fixture');
+  }
+
+  resolveObjectEvaluation<T extends object>(): ResolutionDetails<T> {
+    throw new Error('not used in this fixture');
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **provider-swap** fast path to the Optimizely Phase 2 code migration, for customers who are **already on OpenFeature**.

When an app already reads flags through OpenFeature (standard `useFlag` / `get*Value` call sites, with the vendor hidden behind a registered provider — official or hand-written), migrating to Confidence is **not** a call-site rewrite. It's swapping the registered OpenFeature provider for Confidence's; the call sites don't change.

## Changes

- **Step 1b — detect the migration style** before scanning: `provider swap` (already OpenFeature) vs `call-site rewrite` (direct Optimizely SDK) vs `facade re-point` (home-grown facade).
- **"Already on OpenFeature → provider swap" section:** locate the provider registration + any custom provider class, swap it for the Confidence provider (per the Step 2a mode routing), **re-home business semantics** the custom provider encoded (on/off-string modelling, anonymous-context suppression, per-flag special-casing) on top rather than dropping them, keep call sites unchanged, delete vendor scaffolding, and run Phase 1 so the flags exist in Confidence.
- **Source-provider reference table:** recognizes common OpenFeature providers a company may have registered (LaunchDarkly, Flagsmith, Split, Unleash, ConfigCat, DevCycle, GO Feature Flag, flagd, Statsig/PostHog, custom) — all swap to the Confidence provider.
- **Execute flow + plan template** updated for the provider-swap / facade-re-point styles (single PR, no per-flag call-site loop).
- **Fixture:** `test-fixtures/phase2-examples/openfeature-provider-swap/` — a React app already on `@openfeature/*` with a custom `OptimizelyProvider`, to exercise the swap.

## Why

Real-world flag consumers are often already abstracted behind OpenFeature or a facade. For those, the correct (and far cheaper) migration is a provider swap, not a codebase-wide rewrite — and the kit now detects and plans that explicitly.

## Notes

- **Stacked on #27** (the Optimizely kit / Phase 2). Base is `optimizely` because the provider-swap path extends Phase 2, which only exists on that branch. Retarget after #27 merges.
- Replaces the earlier (closed) #28; identical content with all customer-specific naming removed.
- Validation posture matches the rest of Phase 2: authored against the real Confidence SDK guides + a representative fixture; not run as a live transform against a third-party repo.

Made with [Cursor](https://cursor.com)