### PR TITLE
feat: add missing commands for warehouse and dry-run skills

### DIFF
--- a/commands/onboard-confidence-dry-run.md
+++ b/commands/onboard-confidence-dry-run.md
@@ -1,0 +1,8 @@
+---
+name: onboard-confidence-dry-run
+description: Dry-run the Confidence onboarding flow without real API calls
+---
+
+All dry-run onboarding instructions are maintained in `skills/onboard-confidence-dry-run/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/onboard-confidence-dry-run/SKILL.md` and follow those instructions to handle this command.

--- a/commands/setup-warehouse-bigquery.md
+++ b/commands/setup-warehouse-bigquery.md
@@ -1,0 +1,8 @@
+---
+name: setup-warehouse-bigquery
+description: Set up BigQuery as a data warehouse for Confidence
+---
+
+All warehouse setup instructions are maintained in `skills/setup-warehouse-bigquery/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/setup-warehouse-bigquery/SKILL.md` and follow those instructions to handle this command.

--- a/commands/setup-warehouse-databricks.md
+++ b/commands/setup-warehouse-databricks.md
@@ -1,0 +1,8 @@
+---
+name: setup-warehouse-databricks
+description: Set up Databricks as a data warehouse for Confidence
+---
+
+All warehouse setup instructions are maintained in `skills/setup-warehouse-databricks/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/setup-warehouse-databricks/SKILL.md` and follow those instructions to handle this command.

--- a/commands/setup-warehouse-redshift.md
+++ b/commands/setup-warehouse-redshift.md
@@ -1,0 +1,8 @@
+---
+name: setup-warehouse-redshift
+description: Set up Redshift as a data warehouse for Confidence
+---
+
+All warehouse setup instructions are maintained in `skills/setup-warehouse-redshift/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/setup-warehouse-redshift/SKILL.md` and follow those instructions to handle this command.

--- a/commands/setup-warehouse-snowflake.md
+++ b/commands/setup-warehouse-snowflake.md
@@ -1,0 +1,8 @@
+---
+name: setup-warehouse-snowflake
+description: Set up Snowflake as a data warehouse for Confidence
+---
+
+All warehouse setup instructions are maintained in `skills/setup-warehouse-snowflake/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/setup-warehouse-snowflake/SKILL.md` and follow those instructions to handle this command.

--- a/commands/setup-warehouse.md
+++ b/commands/setup-warehouse.md
@@ -1,0 +1,9 @@
+---
+name: setup-warehouse
+description: Set up a data warehouse for Confidence experimentation analytics
+argument-hint: [bigquery | snowflake | databricks | redshift]
+---
+
+All warehouse setup instructions are maintained in `skills/setup-warehouse/SKILL.md` to prevent divergence.
+
+**Before doing anything else**, use the Read tool to read `skills/setup-warehouse/SKILL.md` and follow those instructions to handle this command.


### PR DESCRIPTION
## Summary
- Added command files for 6 skills that only had skills but no `/command` entry
- `setup-warehouse`, `setup-warehouse-bigquery`, `setup-warehouse-databricks`, `setup-warehouse-redshift`, `setup-warehouse-snowflake`, `onboard-confidence-dry-run`
- Every skill now has a matching command, consistent with the existing migrate/onboard patterns

## Test plan
- [ ] Run `/reload-plugins` and verify all new commands appear
- [ ] Test `/setup-warehouse` triggers the warehouse setup flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)