### PR TITLE
fix: add Cursor marketplace.json with correct description

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "confidence",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "Access Confidence feature flags, experiments, and migration tools directly from Codex.",
   "author": {
     "name": "Spotify Confidence",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "confidence",
+  "version": "0.4.0",
+  "owner": {
+    "name": "Spotify Confidence"
+  },
+  "plugins": [
+    {
+      "name": "confidence",
+      "version": "0.4.0",
+      "description": "Access Confidence feature flags, experiments, and migration tools directly from Cursor.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/spotify/confidence-ai-plugins.git"
+      }
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "confidence",
   "displayName": "Confidence",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "Access Confidence feature flags, experiments, and migration tools directly from Cursor.",
   "author": {
     "name": "Spotify Confidence",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "confidence",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "Access Confidence feature flags, experiments, and migration tools directly from Gemini CLI.",
   "mcpServers": {
     "confidence-flags": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,16 @@
           "type": "json",
           "path": ".claude-plugin/marketplace.json",
           "jsonpath": "$.plugins[0].version"
+        },
+        {
+          "type": "json",
+          "path": ".cursor-plugin/marketplace.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".cursor-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
         }
       ]
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,6 +22,11 @@
         },
         {
           "type": "json",
+          "path": ".cursor-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": ".cursor-plugin/marketplace.json",
           "jsonpath": "$.version"
         },
@@ -29,6 +34,16 @@
           "type": "json",
           "path": ".cursor-plugin/marketplace.json",
           "jsonpath": "$.plugins[0].version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "gemini-extension.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Added `.cursor-plugin/marketplace.json` so the Cursor marketplace listing shows "directly from Cursor" instead of falling back to the Claude plugin's "directly from Claude Code"

## Test plan
- [ ] Verify Cursor marketplace listing shows the correct description after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)