### PR TITLE
feat(migrate-optimizely): support migration from exported JSON files

### DIFF
--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -195,10 +195,36 @@ operator names.
 
 ## Prerequisites: Optimizely Side
 
-Optimizely does not publish a Claude MCP server, so the migration talks
-to Optimizely's **REST API** directly using `curl` from the Bash tool.
+Optimizely does not publish a Claude MCP server, so the migration reads
+Optimizely data through one of two **input methods** — pick per the
+user's access:
 
-### Required
+| Method | Use when | How Step 1 reads data |
+|--------|----------|------------------------|
+| **A — Live REST API** (default) | The user has (or can create) an API token | `curl` against `api.optimizely.com` |
+| **B — Exported JSON files** | The user's account can't produce a working API token (older/legacy Optimizely product, a token scoped to summary-only exports, no self-serve API access, etc.) | Read local files with the Read tool — no network calls |
+
+Both methods feed the **same extraction step** (Step 1c/1d below) with
+the same field names; only the data source differs. Ask the user which
+they have; don't assume.
+
+### ASK the user (only if not already provided)
+
+> To read your Optimizely flags, rollouts, and experiments, I need
+> either:
+> 1. An Optimizely **API token** (Account Settings > API Access — a
+>    Personal Access Token is fine, with read access) plus your
+>    **Project ID** (the number in the app URL, e.g.
+>    `app.optimizely.com/v2/projects/<PROJECT_ID>/flags/list`), **or**
+> 2. If you can't generate a working token (e.g. an older Optimizely
+>    product, or your export tool only gives summary data): a path to
+>    exported flag/experiment JSON file(s) instead.
+>
+> Paste the token here, or set it in your shell as `OPTIMIZELY_API_TOKEN`
+> before continuing, and tell me the project ID — or tell me where the
+> exported file(s) are.
+
+### Option A: Live REST API
 
 1. An **Optimizely API token** (a Personal Access Token, or a Service
    Account token). Created in the Optimizely app under **Account
@@ -217,30 +243,17 @@ to Optimizely's **REST API** directly using `curl` from the Bash tool.
 **Authentication header (both APIs):**
 - `Authorization: Bearer <api-token>`
 
-### ASK the user (only if not already provided)
+**Storing the token.** Once provided, store the token for the session in
+the environment variable `OPTIMIZELY_API_TOKEN` (export it in the Bash
+session the agent uses) and reference it via `$OPTIMIZELY_API_TOKEN` in
+every `curl` call — never hardcode the token into the plan file, the
+conversation output, or any committed file. If the user pastes a token
+inline, scrub it from the plan file and only keep a placeholder like
+`<your-optimizely-api-token>`. (See also the "never echo secrets" rule in
+the User-Facing Communication Rules above.) The project ID is not a
+secret and may be written to the plan.
 
-> To read your Optimizely flags, rollouts, and experiments, I need:
-> 1. An Optimizely **API token** (Account Settings > API Access — a
->    Personal Access Token is fine, with read access).
-> 2. Your **Project ID** (the number in the app URL, e.g.
->    `app.optimizely.com/v2/projects/<PROJECT_ID>/flags/list`).
->
-> Paste the token here, or set it in your shell as `OPTIMIZELY_API_TOKEN`
-> before continuing, and tell me the project ID.
-
-### Storing the token
-
-Once provided, store the token for the session in the environment
-variable `OPTIMIZELY_API_TOKEN` (export it in the Bash session the agent
-uses) and reference it via `$OPTIMIZELY_API_TOKEN` in every `curl` call —
-never hardcode the token into the plan file, the conversation output, or
-any committed file. If the user pastes a token inline, scrub it from the
-plan file and only keep a placeholder like `<your-optimizely-api-token>`.
-(See also the "never echo secrets" rule in the User-Facing Communication
-Rules above.) The project ID is not a secret and may be written to the
-plan.
-
-### Smoke test before scanning
+**Smoke test before scanning:**
 
 ```bash
 curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
@@ -251,16 +264,90 @@ curl -sS -H "Authorization: Bearer $OPTIMIZELY_API_TOKEN" \
 If this returns a `401`/`403` or an HTML error page, stop and surface
 the error to the user — do not start scanning.
 
+### Option B: Exported JSON files
+
+Ask the user for a **file path or directory**. Read files with the Read
+tool (never `curl`, never guess at data). Two shapes are recognized —
+detect which one you have by inspecting the JSON, and say which you
+detected before proceeding:
+
+**B1 — Raw API response dumps (preferred, full fidelity).** One or more
+files that are verbatim saves of the endpoints in "Optimizely REST API
+Reference" below (e.g. `flags.json` = the List Flags response,
+`ruleset-<flag>-<env>.json` = a Get Ruleset response, `audiences.json` =
+List Audiences, etc.). These carry every field Step 1c/1d expects
+(variation-level `percentage_included`, full `audience_conditions`), so
+migration proceeds with **no fidelity loss** versus Option A — just
+substitute "read this file" for the matching `curl` call in Step 1.
+
+**B2 — Flattened per-flag summary export.** A single JSON array, one
+entry per `(flag, environment)`:
+
+```json
+{
+  "name": "<flag name>", "key": "<flag key>", "description": "<...>",
+  "environment": "<env key>",
+  "config": {
+    "enabled": <bool>, "default_variation_key": "<key>",
+    "default_variation_name": "<name>",
+    "rules_detail": [
+      {
+        "key": "<rule key>", "type": "a/b" | "targeted_delivery" | "...",
+        "enabled": <bool>, "traffic_allocation": <basis points>,
+        "variation_names": ["<arm1>", "<arm2>", ...],
+        "audience_ids": [<id>, ...]
+      }
+    ]
+  }
+}
+```
+
+This is what a restricted/summary-only export token typically produces
+(look for `has_restricted_permissions: true` in the payload as a tell).
+Map it onto the same internal model Step 1c/1d builds, with these
+**known gaps** — call each one out explicitly in the plan as a note next
+to the affected flag, don't silently guess and stay silent about it:
+
+- **No flag `variable_definitions`.** Treat the flag as variable-less;
+  each `variation_names` entry becomes a bare Confidence variant (not a
+  struct property). If the customer's code reads variable values (not
+  just the variation key) for these flags, ASK — Option B2 can't tell
+  you either way.
+- **No per-variation split**, only the rule-level `traffic_allocation`.
+  Default to an **even split** across `variation_names` (remainder to
+  the last variant) and flag it in the plan: "Split not in the export —
+  assumed even; confirm against Optimizely before executing." Prefer
+  asking the customer for the fuller `/ruleset` response (Option B1) if
+  exact splits matter.
+- **No audience conditions**, only `audience_ids`. If a rule's
+  `audience_ids` is empty, it targets everyone (no gap). If non-empty,
+  the plan **cannot** express that targeting — mark the rule BLOCKED
+  pending the audience detail and ask the user for the `/v2/audiences`
+  export (or a live token) to resolve it rather than guessing "everyone."
+- **Ignore** experiment-reporting metadata that isn't part of the flag
+  model: `layer_experiment_id`, `primary_metric`, `days_running`,
+  `fetch_results_ui_url`, `created_by_user_email`,
+  `has_restricted_permissions`, `custom_fields`. None of it affects the
+  Confidence targeting rule.
+- A `config.enabled: false` (or rule `enabled: false`) means the exact
+  same thing as the live-API case: migrate the flag, keep it OFF.
+
 ### Local testing (no Optimizely account needed)
 
 For development and CI smoke tests, this skill ships with a fake
 Optimizely REST API server under
 `skills/migrate-optimizely/test-fixtures/`. It implements the read
 endpoints with curated fixtures that exercise every operator-mapping
-branch. See that directory's `README.md` for usage — short version is
-`python3 server.py`, then point this skill at `http://127.0.0.1:4100`
-when prompted for the base URL (the fake server serves both the
-`/flags/v1` and `/v2` routes on one port).
+branch, plus a second (synthetic) project modeling the Option-B2
+(summary-export) pattern. See that directory's `README.md` for usage —
+short version is `python3 server.py`, then point this skill at
+`http://127.0.0.1:4100` when prompted for the base URL (the fake server
+serves both the `/flags/v1` and `/v2` routes on one port).
+
+To exercise **Option B** specifically without a live account, point the
+skill at
+`skills/migrate-optimizely/test-fixtures/summary-export-sample.json`
+(a synthetic B2-shaped export) when it asks for a file path.
 
 ---
 
@@ -269,7 +356,8 @@ when prompted for the base URL (the fake server serves both the
 The migration uses these endpoints. All require
 `-H "Authorization: Bearer $OPTIMIZELY_API_TOKEN"`. `PROJECT_ID` is the
 project being migrated; `ENV_KEY` is an environment key (e.g.
-`production`).
+`production`). **Option B1 files** are verbatim saves of these same
+response bodies — the field names and shapes below apply unchanged.
 
 > **Source of truth.** Field names and shapes here are taken from
 > Optimizely's published API docs at
@@ -542,6 +630,14 @@ bucketing ID, Step 4 generate the MCP commands.
 `.claude/plans/optimizely-flag-migration-<date>.md`
 
 ### Step 1: Scan Optimizely
+
+**If using Option B (exported files):** every `curl` call below is
+replaced by reading the matching local file with the Read tool — same
+field names, same extraction logic. For B2 (flattened summary export),
+`environment` is already given per entry (skip 1a's environment listing
+if every entry names one), and 1c/1d's fetches collapse into "read the
+one file and extract the fields listed", applying the Option B2 gap
+handling above.
 
 **Step 1a — pick the environment.** Optimizely keeps a separate ruleset
 per environment (e.g. `development`, `production`). List environments and

--- a/skills/migrate-optimizely/test-fixtures/README.md
+++ b/skills/migrate-optimizely/test-fixtures/README.md
@@ -38,9 +38,15 @@ Python 3.10+ stdlib, no dependencies.
 ```bash
 python3 server.py
 # Fake Optimizely REST API listening on http://127.0.0.1:4100
-#   14 flags (13 non-archived), 11 audiences, 2 environments
-#   Project ID: 4100100100
+#   Project 4100100100 (curated operator-mapping fixtures): 14 flags (13 non-archived), 11 audiences, 2 environments
+#   Project 5551000001 (summary export scenario): 6 flags (6 non-archived), 0 audiences, 1 environment
 ```
+
+The server hosts **two Optimizely projects** on one port, selected by the
+project id in each request: the curated operator-mapping fixtures
+(`4100100100`) and a synthetic summary-export scenario (`5551000001`, see
+[Summary export scenario](#summary-export-scenario-option-b2-flattened-export)
+below).
 
 Override the port if 4100 is taken:
 
@@ -111,6 +117,66 @@ Pick a throwaway Confidence client and map the Optimizely user ID to a
 | 9 `Internal staff` | `is_internal exact true` | used NEGATED in a combo |
 | 10 `Has plan` | `plan exists` | BLOCKED — no working presence operator |
 | 11 `Chrome users` | `browser exact gc` | non-custom_attribute → BLOCKED |
+
+## Summary export scenario (Option B2: flattened export)
+
+Project `5551000001` is a **synthetic** account modeling a real-world
+support pattern: an account whose export tool/token could only produce
+rule *summaries* (`has_restricted_permissions: true`, no full rulesets).
+All flag names, keys, and ids in this scenario are made up — this is not
+any real account's data. A matching synthetic export file is checked in
+at [`summary-export-sample.json`](./summary-export-sample.json). This is
+the reference example for the skill's **Option B2** input method (see
+`SKILL.md` → "Prerequisites: Optimizely Side" → "Option B: Exported JSON
+files").
+
+**Test the file-input path directly (Option B):** run
+`/migrate-optimizely plan flags` and, when asked for an input method,
+point it at `summary-export-sample.json` — no server, no token needed.
+This exercises the skill's B2 detection and gap-filling logic.
+
+**Test the same data via the live-API path (Option A) for comparison:**
+run the fake server and drive the skill against project `5551000001` over
+HTTP instead:
+
+```
+export OPTIMIZELY_API_TOKEN=fake-token-for-testing
+```
+
+Then run `/migrate-optimizely plan flags`, answer `http://127.0.0.1:4100`
+for the base URL, project id `5551000001`, and the `production`
+environment. (The server reconstructs full rulesets for this project —
+see "Reconstruction assumptions" below — so this path exercises normal
+Step 1c/1d extraction rather than the B2 gap-filling logic itself.)
+
+### What this scenario exercises
+
+| Trait | In the export | Why it matters for the migration |
+|---|---|---|
+| `type: a/b` with **no flag variables** | variations are bare names (`control`/`treatment`, `layout_a`/`layout_b`, `variation_1`/`variation_2`, etc.) | Code branches on the **variation key**, not on flag variables — the a/b rule still folds into one Confidence targeting rule with a bare variant per arm (no separate "experiment" migration path; see SKILL.md "Optimizely's flag model") |
+| Every experiment **paused / disabled** | `enabled: false`, `status: paused` | Flags migrate **OFF** (rules created but not live) |
+| **No audiences** | `audience_ids: []` | Each rule targets everyone (no gap) |
+| `has_restricted_permissions: true` | present on every config | The tell for Option B2: a restricted token could only export rule **summaries** — no per-variation split, variable values, or audience conditions |
+
+### Reconstruction assumptions (fake-server / Option A comparison path only)
+
+The export only carries rule *summaries* (`traffic_allocation` +
+`variation_names`). For the **Option A comparison path** above, `server.py`
+fills the gaps with Optimizely's documented defaults to serve a complete
+ruleset over HTTP (the skill's own **Option B2 gap-filling** — used when
+you point it at `summary-export-sample.json` directly — makes and
+documents the same assumptions in the generated plan instead):
+
+- **Split:** `distribution_mode: manual` with N arms → an even split
+  (2 arms = 50/50). The real live split isn't in the export.
+- **Variables:** none — each arm becomes a bare Confidence variant. The
+  arm identity (the variation key) is what code reads.
+- **`off` variation:** `default_variation_key: "off"` implies an implicit
+  `off` variation served when the (disabled) rule doesn't apply.
+
+If a real account later shares the full `/ruleset` and `/variations`
+responses (Option B1), the skill uses those directly with no fidelity
+loss — see "Option B: Exported JSON files" in `SKILL.md`.
 
 ## What a successful test looks like
 

--- a/skills/migrate-optimizely/test-fixtures/server.py
+++ b/skills/migrate-optimizely/test-fixtures/server.py
@@ -31,8 +31,15 @@ Notable conventions:
     live in each AUDIENCE's `conditions` (a JSON-encoded string)
   * List endpoints wrap results under `items` with `page`/`total_pages`
 
-Fixtures are curated to exercise every branch of the skill's
-operator-mapping table and BLOCKED markers — see README.md.
+The server hosts two Optimizely projects on one port, selected by the
+project id in the request:
+
+  * {PROJECT_ID} — curated fixtures that exercise every branch of the
+    skill's operator-mapping table and BLOCKED markers (see README.md)
+  * {SUMMARY_EXPORT_PROJECT_ID} — a synthetic account modeling the
+    Option B2 flattened-summary-export pattern: legacy variable-less
+    a/b tests, all paused, no audiences (see README.md → "Summary
+    export scenario")
 
 Run:
     python3 server.py [--port 4100]
@@ -494,10 +501,125 @@ FLAGS_BY_KEY = {f["key"]: f for f in FLAGS}
 
 
 # ---------------------------------------------------------------------------
+# Summary-export scenario dataset (synthetic — models Option B2)
+# ---------------------------------------------------------------------------
+# Models an account whose export tool/token only produces rule *summaries*
+# (`traffic_allocation` + `variation_names` — the same shape a
+# `has_restricted_permissions: true` token returns). It does NOT include
+# per-variation split, flag variables, or audiences. We reconstruct a
+# faithful ruleset using Optimizely's documented defaults so the skill can
+# run end-to-end against a representative account of this shape:
+#   * manual N-way a/b split          → even split (2 arms = 50/50)
+#   * no flag variables               → variable-less flag; the SDK returns
+#                                        the variation KEY (getVariationKey),
+#                                        so each arm is a bare named variation
+#   * empty `audience_ids`            → targets everyone
+#   * every experiment paused         → ruleset disabled → migrate the flag OFF
+#   * `default_variation_key: "off"`  → implicit off variation plus the arms
+#
+# All flag names/keys/ids below are synthetic — this is not any real
+# account's data (see `summary-export-sample.json` for the matching
+# synthetic Option B2 file used to test file-based input directly).
+
+SUMMARY_EXPORT_PROJECT_ID = 5551000001
+SUMMARY_EXPORT_ACCOUNT_ID = 5551000000
+
+SUMMARY_EXPORT_ENVIRONMENTS = [
+    {"key": "production", "name": "Production", "id": 5551000002, "archived": False, "priority": 1},
+]
+
+
+def _bare_ab_variations(arms: list[str]) -> list[dict[str, Any]]:
+    """An `off` variation plus one bare (variable-less) variation per arm."""
+    variations = [{"key": "off", "name": "Off", "variables": {}}]
+    variations.extend({"key": arm, "name": arm, "variables": {}} for arm in arms)
+    return variations
+
+
+def _summary_export_ab_flag(flag_key: str, exp_name: str, exp_key: str, arms: list[str]) -> dict[str, Any]:
+    """A paused, variable-less a/b experiment targeting everyone, split evenly."""
+    n = len(arms)
+    base = 10000 // n
+    split = {arm: base for arm in arms}
+    split[arms[-1]] += 10000 - base * n  # give rounding remainder to the last arm
+    return {
+        "key": flag_key,
+        "name": exp_name,
+        "description": "",
+        "archived": False,
+        "variable_definitions": {},
+        "_variations": _bare_ab_variations(arms),
+        "_enabled": False,
+        "_default_variation_key": "off",
+        "_rule_priorities": [exp_key],
+        "_rules": {
+            exp_key: _rule(exp_key, exp_name, "a/b", variations=split, enabled=False),
+        },
+    }
+
+
+SUMMARY_EXPORT_FLAGS: list[dict[str, Any]] = [
+    _summary_export_ab_flag(
+        "flag-sample-checkout-btn", "Checkout Button Color",
+        "checkout_button_color", ["control", "treatment"],
+    ),
+    _summary_export_ab_flag(
+        "flag-sample-homepage-hero", "Homepage Hero Layout",
+        "homepage_hero_layout", ["layout_a", "layout_b"],
+    ),
+    _summary_export_ab_flag(
+        "flag-sample-search-rank", "Search Result Ranking",
+        "search_result_ranking", ["variation_1", "variation_2"],
+    ),
+    _summary_export_ab_flag(
+        "flag-sample-onboarding", "Onboarding Flow Steps",
+        "onboarding_flow_steps", ["three_step", "five_step"],
+    ),
+    _summary_export_ab_flag(
+        "flag-sample-pricing-copy", "Pricing Page Copy",
+        "pricing_page_copy", ["original", "variation"],
+    ),
+    _summary_export_ab_flag(
+        "flag-sample-email-subject", "Email Subject Line",
+        "email_subject_line", ["subject_a", "subject_b"],
+    ),
+]
+SUMMARY_EXPORT_FLAGS_BY_KEY = {f["key"]: f for f in SUMMARY_EXPORT_FLAGS}
+SUMMARY_EXPORT_AUDIENCES: list[dict[str, Any]] = []
+
+
+# ---------------------------------------------------------------------------
+# Datasets — the server serves one dataset per Optimizely project id, so both
+# the curated operator-mapping fixtures and the summary-export scenario are
+# reachable on the same port. The curated dataset stays the module-level
+# default so `verify_migration.py` / `seed_optimizely.py` keep importing
+# FLAGS/AUDIENCES.
+# ---------------------------------------------------------------------------
+
+class Dataset:
+    def __init__(self, project_id, account_id, flags, audiences, environments):
+        self.project_id = project_id
+        self.account_id = account_id
+        self.flags = flags
+        self.flags_by_key = {f["key"]: f for f in flags}
+        self.audiences = audiences
+        self.audiences_by_id = {a["id"]: a for a in audiences}
+        self.environments = environments
+
+
+DEFAULT_DATASET = Dataset(PROJECT_ID, ACCOUNT_ID, FLAGS, AUDIENCES, ENVIRONMENTS)
+SUMMARY_EXPORT_DATASET = Dataset(
+    SUMMARY_EXPORT_PROJECT_ID, SUMMARY_EXPORT_ACCOUNT_ID,
+    SUMMARY_EXPORT_FLAGS, SUMMARY_EXPORT_AUDIENCES, SUMMARY_EXPORT_ENVIRONMENTS,
+)
+DATASETS = {ds.project_id: ds for ds in (DEFAULT_DATASET, SUMMARY_EXPORT_DATASET)}
+
+
+# ---------------------------------------------------------------------------
 # Response shaping
 # ---------------------------------------------------------------------------
 
-def _flag_public(f: dict[str, Any], env_key: str = "production") -> dict[str, Any]:
+def _flag_public(ds: Dataset, f: dict[str, Any], env_key: str = "production") -> dict[str, Any]:
     """The flag object as the List/Fetch Flags endpoints return it."""
     rules_detail = [
         {
@@ -519,8 +641,8 @@ def _flag_public(f: dict[str, Any], env_key: str = "production") -> dict[str, An
         "variable_definitions": f["variable_definitions"],
         "id": abs(hash(f["key"])) % 10_000_000,
         "urn": f"flags.flags.optimizely.com::{f['key']}",
-        "project_id": PROJECT_ID,
-        "account_id": ACCOUNT_ID,
+        "project_id": ds.project_id,
+        "account_id": ds.account_id,
         "environments": {
             env["key"]: {
                 "key": env["key"],
@@ -532,17 +654,17 @@ def _flag_public(f: dict[str, Any], env_key: str = "production") -> dict[str, An
                 "rules_detail": rules_detail if env["key"] == "production" else [],
                 "id": env["id"],
             }
-            for env in ENVIRONMENTS
+            for env in ds.environments
         },
     }
 
 
-def _ruleset_public(f: dict[str, Any], env_key: str) -> dict[str, Any]:
+def _ruleset_public(ds: Dataset, f: dict[str, Any], env_key: str) -> dict[str, Any]:
     enabled = f["_enabled"] if env_key == "production" else False
     rules = f["_rules"] if env_key == "production" else {}
     priorities = f["_rule_priorities"] if env_key == "production" else []
     return {
-        "url": f"/projects/{PROJECT_ID}/flags/{f['key']}/environments/{env_key}/ruleset",
+        "url": f"/projects/{ds.project_id}/flags/{f['key']}/environments/{env_key}/ruleset",
         "rules": rules,
         "rule_priorities": priorities,
         "id": abs(hash(f["key"] + env_key)) % 10_000_000,
@@ -556,7 +678,7 @@ def _ruleset_public(f: dict[str, Any], env_key: str) -> dict[str, Any]:
     }
 
 
-def _audience_public(a: dict[str, Any]) -> dict[str, Any]:
+def _audience_public(ds: Dataset, a: dict[str, Any]) -> dict[str, Any]:
     return {
         "id": a["id"],
         "name": a["name"],
@@ -564,7 +686,7 @@ def _audience_public(a: dict[str, Any]) -> dict[str, Any]:
         "conditions": a["conditions"],
         "archived": False,
         "is_classic": False,
-        "project_id": PROJECT_ID,
+        "project_id": ds.project_id,
     }
 
 
@@ -610,6 +732,18 @@ class Handler(BaseHTTPRequestHandler):
     def _bool_param(self, query: dict[str, list[str]], name: str) -> bool:
         return name in query and query[name][0].lower() in ("true", "1", "yes")
 
+    def _dataset_for_pid(self, pid: str) -> "Dataset | None":
+        """Resolve the dataset for a path project id, 404-ing if unknown."""
+        ds = DATASETS.get(int(pid))
+        if ds is None:
+            self._send(404, {"message": f"project {pid} not found"})
+        return ds
+
+    def _dataset_for_query_pid(self, query: dict[str, list[str]]) -> "Dataset":
+        """Resolve the dataset for a `project_id` query param (v2 endpoints)."""
+        raw = query.get("project_id", [str(PROJECT_ID)])[0]
+        return DATASETS.get(int(raw), DEFAULT_DATASET)
+
     def _paginate(self, items: list, query: dict[str, list[str]], url: str) -> dict:
         per_page = int(query.get("per_page", [str(self.per_page_default)])[0])
         page = int(query.get("page", ["1"])[0])
@@ -635,16 +769,22 @@ class Handler(BaseHTTPRequestHandler):
 
         m = R_RULESET.match(path)
         if m:
-            f = FLAGS_BY_KEY.get(m["key"])
+            ds = self._dataset_for_pid(m["pid"])
+            if ds is None:
+                return
+            f = ds.flags_by_key.get(m["key"])
             if f is None:
                 self._send(404, {"message": f"flag {m['key']} not found"})
                 return
-            self._send(200, _ruleset_public(f, m["env"]))
+            self._send(200, _ruleset_public(ds, f, m["env"]))
             return
 
         m = R_FLAG_VARIATIONS.match(path)
         if m:
-            f = FLAGS_BY_KEY.get(m["key"])
+            ds = self._dataset_for_pid(m["pid"])
+            if ds is None:
+                return
+            f = ds.flags_by_key.get(m["key"])
             if f is None:
                 self._send(404, {"message": f"flag {m['key']} not found"})
                 return
@@ -653,42 +793,55 @@ class Handler(BaseHTTPRequestHandler):
 
         m = R_FLAG_ONE.match(path)
         if m and not path.rstrip("/").endswith("/flags"):
-            f = FLAGS_BY_KEY.get(m["key"])
+            ds = self._dataset_for_pid(m["pid"])
+            if ds is None:
+                return
+            f = ds.flags_by_key.get(m["key"])
             if f is None:
                 self._send(404, {"message": f"flag {m['key']} not found"})
                 return
-            self._send(200, _flag_public(f))
+            self._send(200, _flag_public(ds, f))
             return
 
         m = R_FLAGS_LIST.match(path)
         if m:
+            ds = self._dataset_for_pid(m["pid"])
+            if ds is None:
+                return
             include_archived = self._bool_param(query, "archived")
-            visible = [f for f in FLAGS if include_archived or not f["archived"]]
-            self._send(200, self._paginate([_flag_public(f) for f in visible], query, path))
+            visible = [f for f in ds.flags if include_archived or not f["archived"]]
+            self._send(200, self._paginate([_flag_public(ds, f) for f in visible], query, path))
             return
 
         m = R_AUDIENCE_ONE.match(path)
         if m:
-            a = AUDIENCES_BY_ID.get(int(m["id"]))
-            if a is None:
-                self._send(404, {"message": f"audience {m['id']} not found"})
-                return
-            self._send(200, _audience_public(a))
+            aid = int(m["id"])
+            for ds in DATASETS.values():
+                a = ds.audiences_by_id.get(aid)
+                if a is not None:
+                    self._send(200, _audience_public(ds, a))
+                    return
+            self._send(404, {"message": f"audience {m['id']} not found"})
             return
 
         m = R_AUDIENCES_LIST.match(path)
         if m:
-            self._send(200, self._paginate([_audience_public(a) for a in AUDIENCES], query, path))
+            ds = self._dataset_for_query_pid(query)
+            self._send(200, self._paginate([_audience_public(ds, a) for a in ds.audiences], query, path))
             return
 
         m = R_ENVIRONMENTS.match(path)
         if m:
-            self._send(200, {"items": ENVIRONMENTS, "count": len(ENVIRONMENTS)})
+            ds = self._dataset_for_query_pid(query)
+            self._send(200, {"items": ds.environments, "count": len(ds.environments)})
             return
 
         m = R_PROJECTS.match(path)
         if m:
-            self._send(200, {"items": [{"id": PROJECT_ID, "name": "Fixture project", "status": "active"}]})
+            self._send(200, {"items": [
+                {"id": ds.project_id, "name": f"Fixture project {ds.project_id}", "status": "active"}
+                for ds in DATASETS.values()
+            ]})
             return
 
         self._send(404, {"message": f"No route for {path}"})
@@ -706,11 +859,13 @@ def main() -> None:
 
     server = HTTPServer(("127.0.0.1", args.port), Handler)
     base = f"http://127.0.0.1:{args.port}"
-    n_active = sum(1 for f in FLAGS if not f["archived"])
     print(f"Fake Optimizely REST API listening on {base}")
-    print(f"  {len(FLAGS)} flags ({n_active} non-archived), {len(AUDIENCES)} audiences, "
-          f"{len(ENVIRONMENTS)} environments")
-    print(f"  Project ID: {PROJECT_ID}")
+    for ds in DATASETS.values():
+        n_active = sum(1 for f in ds.flags if not f["archived"])
+        label = "curated operator-mapping fixtures" if ds is DEFAULT_DATASET else "summary export scenario"
+        print(f"  Project {ds.project_id} ({label}): "
+              f"{len(ds.flags)} flags ({n_active} non-archived), "
+              f"{len(ds.audiences)} audiences, {len(ds.environments)} environments")
     print("  Point the migrate-optimizely skill at this base URL when prompted.")
     print("  Set OPTIMIZELY_API_TOKEN to anything (any Bearer value passes).")
     print("  Press Ctrl+C to stop.")

--- a/skills/migrate-optimizely/test-fixtures/summary-export-sample.json
+++ b/skills/migrate-optimizely/test-fixtures/summary-export-sample.json
@@ -1,0 +1,254 @@
+[
+  {
+    "name": "Checkout Button Color",
+    "key": "flag-sample-checkout-btn",
+    "description": "",
+    "environment": "production",
+    "config": {
+      "key": "production",
+      "name": "Production",
+      "enabled": false,
+      "has_restricted_permissions": true,
+      "priority": 1,
+      "status": "paused",
+      "rules_summary": { "a/b": { "keys": ["checkout_button_color"] } },
+      "rules_detail": [
+        {
+          "primary_metric": "conversion_rate",
+          "status": "paused",
+          "enabled": false,
+          "traffic_allocation": 10000,
+          "key": "checkout_button_color",
+          "fetch_results_ui_url": null,
+          "days_running": null,
+          "layer_experiment_id": 10000000001,
+          "id": 20000001,
+          "variation_names": ["control", "treatment"],
+          "distribution_mode": "manual",
+          "created_time": "2023-04-25T04:59:36.925716Z",
+          "type": "a/b",
+          "name": "Checkout Button Color",
+          "created_by_user_email": "example@example.com",
+          "audience_ids": [],
+          "custom_fields": null,
+          "updated_time": "2024-09-04T22:49:43.832309Z"
+        }
+      ],
+      "default_variation_key": "off",
+      "default_variation_name": "Off",
+      "id": 5551000002,
+      "enable_url": "/projects/5551000001/flags/flag-sample-checkout-btn/environments/production/ruleset/enabled",
+      "created_time": "2018-04-18T15:56:19.000000Z"
+    }
+  },
+  {
+    "name": "Homepage Hero Layout",
+    "key": "flag-sample-homepage-hero",
+    "description": "Compare hero layout A with layout B for logged-out visitors",
+    "environment": "production",
+    "config": {
+      "key": "production",
+      "name": "Production",
+      "enabled": false,
+      "has_restricted_permissions": true,
+      "priority": 1,
+      "status": "paused",
+      "rules_summary": { "a/b": { "keys": ["homepage_hero_layout"] } },
+      "rules_detail": [
+        {
+          "primary_metric": "click_through_rate",
+          "status": "paused",
+          "enabled": false,
+          "traffic_allocation": 10000,
+          "key": "homepage_hero_layout",
+          "fetch_results_ui_url": null,
+          "days_running": null,
+          "layer_experiment_id": 10000000002,
+          "id": 20000002,
+          "variation_names": ["layout_a", "layout_b"],
+          "distribution_mode": "manual",
+          "created_time": "2023-02-22T13:24:13.084634Z",
+          "type": "a/b",
+          "name": "Homepage Hero Layout",
+          "created_by_user_email": "example@example.com",
+          "audience_ids": [],
+          "custom_fields": null,
+          "updated_time": "2024-09-04T22:49:39.485032Z"
+        }
+      ],
+      "default_variation_key": "off",
+      "default_variation_name": "Off",
+      "id": 5551000002,
+      "enable_url": "/projects/5551000001/flags/flag-sample-homepage-hero/environments/production/ruleset/enabled",
+      "created_time": "2018-04-18T15:56:19.000000Z"
+    }
+  },
+  {
+    "name": "Search Result Ranking",
+    "key": "flag-sample-search-rank",
+    "description": "",
+    "environment": "production",
+    "config": {
+      "key": "production",
+      "name": "Production",
+      "enabled": false,
+      "has_restricted_permissions": true,
+      "priority": 1,
+      "status": "paused",
+      "rules_summary": { "a/b": { "keys": ["search_result_ranking"] } },
+      "rules_detail": [
+        {
+          "primary_metric": null,
+          "status": "paused",
+          "enabled": false,
+          "traffic_allocation": 10000,
+          "key": "search_result_ranking",
+          "fetch_results_ui_url": null,
+          "days_running": null,
+          "layer_experiment_id": 10000000003,
+          "id": 20000003,
+          "variation_names": ["variation_1", "variation_2"],
+          "distribution_mode": "manual",
+          "created_time": "2021-04-14T00:13:51.959953Z",
+          "type": "a/b",
+          "name": "Search Result Ranking",
+          "created_by_user_email": "example@example.com",
+          "audience_ids": [],
+          "custom_fields": null,
+          "updated_time": "2024-09-04T22:49:35.101401Z"
+        }
+      ],
+      "default_variation_key": "off",
+      "default_variation_name": "Off",
+      "id": 5551000002,
+      "enable_url": "/projects/5551000001/flags/flag-sample-search-rank/environments/production/ruleset/enabled",
+      "created_time": "2018-04-18T15:56:19.000000Z"
+    }
+  },
+  {
+    "name": "Onboarding Flow Steps",
+    "key": "flag-sample-onboarding",
+    "description": "",
+    "environment": "production",
+    "config": {
+      "key": "production",
+      "name": "Production",
+      "enabled": false,
+      "has_restricted_permissions": true,
+      "priority": 1,
+      "status": "paused",
+      "rules_summary": { "a/b": { "keys": ["onboarding_flow_steps"] } },
+      "rules_detail": [
+        {
+          "primary_metric": "onboarding_completion_rate",
+          "status": "paused",
+          "enabled": false,
+          "traffic_allocation": 10000,
+          "key": "onboarding_flow_steps",
+          "fetch_results_ui_url": null,
+          "days_running": null,
+          "layer_experiment_id": 10000000004,
+          "id": 20000004,
+          "variation_names": ["three_step", "five_step"],
+          "distribution_mode": "manual",
+          "created_time": "2020-03-25T11:35:12.459501Z",
+          "type": "a/b",
+          "name": "Onboarding Flow Steps",
+          "created_by_user_email": "example@example.com",
+          "audience_ids": [],
+          "custom_fields": null,
+          "updated_time": "2024-09-04T22:49:30.716049Z"
+        }
+      ],
+      "default_variation_key": "off",
+      "default_variation_name": "Off",
+      "id": 5551000002,
+      "enable_url": "/projects/5551000001/flags/flag-sample-onboarding/environments/production/ruleset/enabled",
+      "created_time": "2018-04-18T15:56:19.000000Z"
+    }
+  },
+  {
+    "name": "Pricing Page Copy",
+    "key": "flag-sample-pricing-copy",
+    "description": "",
+    "environment": "production",
+    "config": {
+      "key": "production",
+      "name": "Production",
+      "enabled": false,
+      "has_restricted_permissions": true,
+      "priority": 1,
+      "status": "paused",
+      "rules_summary": { "a/b": { "keys": ["pricing_page_copy"] } },
+      "rules_detail": [
+        {
+          "primary_metric": null,
+          "status": "paused",
+          "enabled": false,
+          "traffic_allocation": 10000,
+          "key": "pricing_page_copy",
+          "fetch_results_ui_url": null,
+          "days_running": null,
+          "layer_experiment_id": 10000000005,
+          "id": 20000005,
+          "variation_names": ["variation_1", "variation_2"],
+          "distribution_mode": "manual",
+          "created_time": "2020-02-06T11:03:46.643255Z",
+          "type": "a/b",
+          "name": "Pricing Page Copy",
+          "created_by_user_email": "example@example.com",
+          "audience_ids": [],
+          "custom_fields": null,
+          "updated_time": "2024-09-04T22:49:26.311500Z"
+        }
+      ],
+      "default_variation_key": "off",
+      "default_variation_name": "Off",
+      "id": 5551000002,
+      "enable_url": "/projects/5551000001/flags/flag-sample-pricing-copy/environments/production/ruleset/enabled",
+      "created_time": "2018-04-18T15:56:19.000000Z"
+    }
+  },
+  {
+    "name": "Email Subject Line",
+    "key": "flag-sample-email-subject",
+    "description": "",
+    "environment": "production",
+    "config": {
+      "key": "production",
+      "name": "Production",
+      "enabled": false,
+      "has_restricted_permissions": true,
+      "priority": 1,
+      "status": "paused",
+      "rules_summary": { "a/b": { "keys": ["email_subject_line"] } },
+      "rules_detail": [
+        {
+          "primary_metric": "open_rate",
+          "status": "paused",
+          "enabled": false,
+          "traffic_allocation": 10000,
+          "key": "email_subject_line",
+          "fetch_results_ui_url": null,
+          "days_running": null,
+          "layer_experiment_id": 10000000006,
+          "id": 20000006,
+          "variation_names": ["subject_a", "subject_b"],
+          "distribution_mode": "manual",
+          "created_time": "2020-01-10T13:21:13.416624Z",
+          "type": "a/b",
+          "name": "Email Subject Line",
+          "created_by_user_email": "example@example.com",
+          "audience_ids": [],
+          "custom_fields": null,
+          "updated_time": "2024-09-04T22:49:21.551783Z"
+        }
+      ],
+      "default_variation_key": "off",
+      "default_variation_name": "Off",
+      "id": 5551000002,
+      "enable_url": "/projects/5551000001/flags/flag-sample-email-subject/environments/production/ruleset/enabled",
+      "created_time": "2018-04-18T15:56:19.000000Z"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Adds a file-based input path to the Optimizely migration kit for accounts that can't produce a working live API token (older Optimizely products, or tokens restricted to summary-only exports). Two shapes are supported: raw API response dumps (full fidelity, no gaps) and a flattened per-flag summary export (with explicit, plan-visible gap-filling for split/variables/audiences when only summaries are available).
- Live REST API remains the default input method; file input is offered as an alternative, selected per the user's access.
- Extends the test fixtures with a second, synthetic project modeling the flattened-summary-export shape, exercised both via the fake server (Option A comparison) and directly as a file (Option B), so the new path has end-to-end coverage without needing a live Optimizely account.

## Test plan
- [x] `python3 verify_migration.py` still passes (curated fixtures unaffected)
- [x] Fake server smoke-tested over HTTP for both projects (flags list, ruleset, variations, audiences, unknown-project 404)
- [x] Shape checks confirming the summary-export dataset and its matching JSON file agree (same flag keys, correct split/defaults)
- [ ] End-to-end `/migrate-optimizely plan flags` run pointed at `summary-export-sample.json` (Option B) in an interactive session
- [ ] End-to-end run against a live account using Option B1 (raw API dumps) to confirm no fidelity loss

Made with [Cursor](https://cursor.com)