### PR TITLE
feat(mcp): direct HTTP transport with env-var auth for flags MCP

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,12 @@
 {
   "mcpServers": {
     "confidence-flags": {
-      "type": "http",
-      "url": "https://mcp.confidence.dev/mcp/flags",
-      "headers": {
-        "x-confidence-mcp-consumer": "plugin"
-      }
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT:-.}/scripts/confidence-mcp-proxy.mjs",
+        "flags"
+      ]
     },
     "confidence-docs": {
       "type": "http",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,12 @@
 {
   "mcpServers": {
     "confidence-flags": {
-      "type": "stdio",
-      "command": "node",
-      "args": [
-        "${CLAUDE_PLUGIN_ROOT:-.}/scripts/confidence-mcp-proxy.mjs",
-        "flags"
-      ]
+      "type": "http",
+      "url": "https://mcp.confidence.dev/mcp/flags",
+      "headers": {
+        "Authorization": "Bearer ${CONFIDENCE_API_KEY}",
+        "x-confidence-mcp-consumer": "plugin"
+      }
     },
     "confidence-docs": {
       "type": "http",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ proxy (`scripts/confidence-mcp-proxy.mjs`):
 - **Logged in via the onboarding flow** (`/confidence:onboard-confidence`):
   the proxy picks up your session and the flag tools become available
   immediately — no manual authenticate step or reconnect needed. If you log
-  in mid-session, the tools appear within a few seconds.
+  in mid-session, the tools appear within a few seconds. The session persists
+  in `~/.confidence/session.json` and is refreshed automatically, so you stay
+  logged in across new sessions and restarts.
 - **Never used the onboarding flow**: the proxy falls back to the standard
   MCP OAuth flow (via `mcp-remote`) — your browser opens once to log in, and
   the credentials are cached and refreshed silently for later sessions.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ This plugin provides access to Confidence tools across these categories:
 | `confidence-flags` | `https://mcp.confidence.dev/mcp/flags` | Feature flag management |
 | `confidence-docs` | `https://mcp.confidence.dev/mcp/docs` | Confidence documentation |
 
+### Authentication
+
+`confidence-flags` authenticates automatically via the plugin's bundled MCP
+proxy (`scripts/confidence-mcp-proxy.mjs`):
+
+- **Logged in via the onboarding flow** (`/confidence:onboard-confidence`):
+  the proxy picks up your session and the flag tools become available
+  immediately — no manual authenticate step or reconnect needed. If you log
+  in mid-session, the tools appear within a few seconds.
+- **Never used the onboarding flow**: the proxy falls back to the standard
+  MCP OAuth flow (via `mcp-remote`) — your browser opens once to log in, and
+  the credentials are cached and refreshed silently for later sessions.
+
+`confidence-docs` requires no authentication.
+
 ## Supported Clients
 
 | Client | Config | Marketplace |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -4,12 +4,10 @@
   "description": "Access Confidence feature flags, experiments, and migration tools directly from Gemini CLI.",
   "mcpServers": {
     "confidence-flags": {
-      "command": "npx",
+      "command": "node",
       "args": [
-        "mcp-remote@latest",
-        "${CONFIDENCE_MCP_FLAGS_URL:-https://mcp.confidence.dev/mcp/flags}",
-        "--header",
-        "x-confidence-mcp-consumer:plugin"
+        "${extensionPath}${/}scripts${/}confidence-mcp-proxy.mjs",
+        "flags"
       ]
     },
     "confidence-docs": {

--- a/scripts/confidence-mcp-proxy.mjs
+++ b/scripts/confidence-mcp-proxy.mjs
@@ -25,10 +25,10 @@
 //
 // Requires Node 18+ (built-in fetch).
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { spawn } from 'child_process';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { dirname, join } from 'path';
 import { createInterface } from 'readline';
 
 const service = process.argv[2] || 'flags';
@@ -36,6 +36,8 @@ const url =
   process.env[`CONFIDENCE_MCP_${service.toUpperCase()}_URL`] ||
   `https://mcp.confidence.dev/mcp/${service}`;
 const tokenPath = join(process.env.TMPDIR || tmpdir(), 'confidence_token');
+const sessionPath = join(homedir(), '.confidence', 'session.json');
+const AUTH_TOKEN_URL = 'https://auth.confidence.dev/oauth/token';
 
 const NOT_AUTHENTICATED_MESSAGE =
   'Confidence session expired or not established. Run the onboarding flow ' +
@@ -50,15 +52,114 @@ const LOCAL_INITIALIZE_RESULT = {
   serverInfo: { name: `confidence-${service}-proxy`, version: '1.0.0' },
 };
 
-function currentToken() {
+function asValidJwt(t) {
   try {
-    const t = readFileSync(tokenPath, 'utf8').trim();
     const { exp } = JSON.parse(Buffer.from(t.split('.')[1], 'base64').toString());
     if (exp && exp * 1000 < Date.now() + 30_000) return null;
     return t;
   } catch {
     return null;
   }
+}
+
+function readTmpToken() {
+  try {
+    return asValidJwt(readFileSync(tokenPath, 'utf8').trim());
+  } catch {
+    return null;
+  }
+}
+
+function readSession() {
+  try {
+    return JSON.parse(readFileSync(sessionPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(session) {
+  try {
+    mkdirSync(dirname(sessionPath), { recursive: true });
+    writeFileSync(sessionPath, JSON.stringify(session, null, 2) + '\n', { mode: 0o600 });
+  } catch {
+    /* best effort */
+  }
+}
+
+// Keep the skill's $TMPDIR cache in sync so its curl calls also benefit
+// from refreshed tokens.
+function syncTmpToken(token) {
+  try {
+    writeFileSync(tokenPath, token + '\n');
+  } catch {
+    /* best effort */
+  }
+}
+
+// Synchronous snapshot of the current login state (no refresh attempt) —
+// used by the poll loop to detect login changes cheaply.
+function currentToken() {
+  const tmp = readTmpToken();
+  if (tmp) return tmp;
+  const session = readSession();
+  return session?.access_token ? asValidJwt(session.access_token) : null;
+}
+
+let refreshPromise = null;
+let refreshFailedAt = 0;
+
+async function refreshSession(session) {
+  const res = await fetch(AUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      client_id: session.client_id,
+      refresh_token: session.refresh_token,
+    }),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  if (!data.access_token) return null;
+  writeSession({
+    ...session,
+    access_token: data.access_token,
+    // Auth0 rotates refresh tokens; keep the newest one.
+    refresh_token: data.refresh_token || session.refresh_token,
+  });
+  syncTmpToken(data.access_token);
+  return data.access_token;
+}
+
+// Resolve a usable access token: $TMPDIR cache, then the persistent session,
+// then a refresh-token exchange. Returns null when not logged in.
+async function resolveToken() {
+  const tmp = readTmpToken();
+  if (tmp) return tmp;
+
+  const session = readSession();
+  if (!session) return null;
+
+  const persisted = session.access_token ? asValidJwt(session.access_token) : null;
+  if (persisted) {
+    syncTmpToken(persisted);
+    return persisted;
+  }
+
+  if (!session.refresh_token || !session.client_id) return null;
+  if (Date.now() - refreshFailedAt < 60_000) return null; // cooldown after failure
+
+  refreshPromise ??= refreshSession(session)
+    .catch(() => null)
+    .then(token => {
+      if (!token) refreshFailedAt = Date.now();
+      return token;
+    })
+    .finally(() => {
+      refreshPromise = null;
+    });
+  return refreshPromise;
 }
 
 function parseBody(text) {
@@ -118,9 +219,10 @@ function stopChild() {
 // Mode selection and switching
 // ---------------------------------------------------------------------------
 
-// Token file present (even expired) => the user logs in via the onboarding
-// skill; never pop an OAuth browser at them. Absent => classic OAuth flow.
-let mode = existsSync(tokenPath) ? 'session' : 'oauth';
+// Token file or persisted session present (even expired) => the user logs in
+// via the onboarding skill; never pop an OAuth browser at them. Neither
+// exists => classic OAuth flow.
+let mode = existsSync(tokenPath) || existsSync(sessionPath) ? 'session' : 'oauth';
 if (mode === 'oauth') startChild();
 
 let lastToken = currentToken();
@@ -155,7 +257,7 @@ function respondLocally(msg) {
 }
 
 async function handleSessionMode(line, msg, isRequest) {
-  const token = currentToken();
+  const token = await resolveToken();
 
   // No valid login right now: answer protocol methods locally instead of
   // forwarding — upstream rejects unauthenticated requests.

--- a/scripts/confidence-mcp-proxy.mjs
+++ b/scripts/confidence-mcp-proxy.mjs
@@ -1,48 +1,58 @@
 #!/usr/bin/env node
-// Stdio <-> HTTP proxy for the Confidence MCP servers with automatic auth.
+// Confidence MCP proxy — stdio server + HTTP reverse proxy.
 //
 // Usage: node confidence-mcp-proxy.mjs <flags|docs>
 //
-// Two auth modes, one server name:
+// Runs as a stdio MCP server (started by Claude Code via .mcp.json) and
+// simultaneously starts a local HTTP reverse proxy on port 19741.
 //
-// SESSION mode — the onboard-confidence skill persists the user's Confidence
-// session token to $TMPDIR/confidence_token after browser login. The proxy
-// reads that token on EVERY request and forwards MCP traffic to
-// mcp.confidence.dev with the Authorization header set, so MCP auth always
-// follows the skill's login session. No interactive flow, no reconnect.
+// Auth sources (checked in order):
+//   1. $TMPDIR/confidence_token — written by the onboard-confidence skill
+//   2. ~/.confidence/session.json — persistent session with refresh token
 //
-// OAUTH mode — when the token file does not exist (user never ran the
-// onboarding skill), the proxy delegates to `npx mcp-remote`, which performs
-// the standard MCP OAuth browser flow once and silently refreshes cached
-// tokens (~/.mcp-auth) on later sessions.
+// Stdio mode (default .mcp.json config):
+//   When authenticated: proxies MCP requests to mcp.confidence.dev.
+//   When not authenticated: exposes authenticate/complete_authentication tools.
+//   After the skill logs in, the proxy detects the new token automatically
+//   and sends notifications/tools/list_changed — no reconnect needed.
 //
-// If the skill token appears mid-session (user just logged in), the proxy
-// switches from OAUTH to SESSION mode and emits
-// notifications/tools/list_changed so the agent re-fetches the tool list.
-// A present-but-expired token means the user has logged in before: the proxy
-// stays in SESSION mode and hints to re-run the login instead of surprising
-// the user with an OAuth browser popup.
+// HTTP mode (for standard "needs authentication" UX):
+//   Users can point their MCP client to http://127.0.0.1:19741/mcp/<service>
+//   to get the standard MCP HTTP OAuth flow with the "needs authentication"
+//   status and Authenticate button.
+//   The HTTP server proxies OAuth endpoints to mcp.confidence.dev while
+//   caching tokens locally, so the skill's auth and the MCP OAuth share
+//   the same token storage.
 //
 // Requires Node 18+ (built-in fetch).
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
-import { spawn } from 'child_process';
+import { createServer } from 'http';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { spawn, spawnSync } from 'child_process';
 import { homedir, tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { createInterface } from 'readline';
+import { fileURLToPath } from 'url';
 
 const service = process.argv[2] || 'flags';
-const url =
+const REMOTE_BASE = 'https://mcp.confidence.dev';
+const REMOTE_MCP_URL =
   process.env[`CONFIDENCE_MCP_${service.toUpperCase()}_URL`] ||
-  `https://mcp.confidence.dev/mcp/${service}`;
+  `${REMOTE_BASE}/mcp/${service}`;
+const MCP_PATH = `/mcp/${service}`;
+const HTTP_PORT = parseInt(process.env.CONFIDENCE_MCP_PROXY_PORT || '19741', 10);
+
 const tokenPath = join(process.env.TMPDIR || tmpdir(), 'confidence_token');
 const sessionPath = join(homedir(), '.confidence', 'session.json');
-const AUTH_TOKEN_URL = 'https://auth.confidence.dev/oauth/token';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const authScriptPath = join(__dirname, '..', 'skills', 'onboard-confidence', 'auth.py');
+const SIGNUP_CLIENT_ID = '82qMvwZvqd3t3S0gRDvs8R53TehQXSJY';
+const LOGIN_CLIENT_ID = '2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w';
 
 const NOT_AUTHENTICATED_MESSAGE =
-  'Confidence session expired or not established. Run the onboarding flow ' +
-  '(/confidence:onboard-confidence) to log in — MCP tools become available ' +
-  'automatically after login.';
+  'Not authenticated with Confidence. Run /confidence:onboard-confidence to log in. ' +
+  'After logging in, the flag management tools will appear automatically.';
 
 const write = obj => process.stdout.write(JSON.stringify(obj) + '\n');
 
@@ -51,6 +61,10 @@ const LOCAL_INITIALIZE_RESULT = {
   capabilities: { tools: { listChanged: true } },
   serverInfo: { name: `confidence-${service}-proxy`, version: '1.0.0' },
 };
+
+// ---------------------------------------------------------------------------
+// Token management
+// ---------------------------------------------------------------------------
 
 function asValidJwt(t) {
   try {
@@ -87,8 +101,6 @@ function writeSession(session) {
   }
 }
 
-// Keep the skill's $TMPDIR cache in sync so its curl calls also benefit
-// from refreshed tokens.
 function syncTmpToken(token) {
   try {
     writeFileSync(tokenPath, token + '\n');
@@ -97,8 +109,6 @@ function syncTmpToken(token) {
   }
 }
 
-// Synchronous snapshot of the current login state (no refresh attempt) —
-// used by the poll loop to detect login changes cheaply.
 function currentToken() {
   const tmp = readTmpToken();
   if (tmp) return tmp;
@@ -106,11 +116,30 @@ function currentToken() {
   return session?.access_token ? asValidJwt(session.access_token) : null;
 }
 
+function hasViableSession() {
+  if (readTmpToken()) return true;
+  const session = readSession();
+  return !!(session?.refresh_token && session?.client_id);
+}
+
+if (!hasViableSession()) {
+  process.stderr.write(
+    'No Confidence session. Run /confidence:onboard-confidence to log in.\n'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Token refresh
+// ---------------------------------------------------------------------------
+
 let refreshPromise = null;
 let refreshFailedAt = 0;
 
 async function refreshSession(session) {
-  const res = await fetch(AUTH_TOKEN_URL, {
+  const tokenUrl = session.client_id === SIGNUP_CLIENT_ID || session.client_id === LOGIN_CLIENT_ID
+    ? 'https://auth.confidence.dev/oauth/token'
+    : `${REMOTE_BASE}/token`;
+  const res = await fetch(tokenUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -125,15 +154,12 @@ async function refreshSession(session) {
   writeSession({
     ...session,
     access_token: data.access_token,
-    // Auth0 rotates refresh tokens; keep the newest one.
     refresh_token: data.refresh_token || session.refresh_token,
   });
   syncTmpToken(data.access_token);
   return data.access_token;
 }
 
-// Resolve a usable access token: $TMPDIR cache, then the persistent session,
-// then a refresh-token exchange. Returns null when not logged in.
 async function resolveToken() {
   const tmp = readTmpToken();
   if (tmp) return tmp;
@@ -148,7 +174,7 @@ async function resolveToken() {
   }
 
   if (!session.refresh_token || !session.client_id) return null;
-  if (Date.now() - refreshFailedAt < 60_000) return null; // cooldown after failure
+  if (Date.now() - refreshFailedAt < 60_000) return null;
 
   refreshPromise ??= refreshSession(session)
     .catch(() => null)
@@ -162,11 +188,345 @@ async function resolveToken() {
   return refreshPromise;
 }
 
+// ---------------------------------------------------------------------------
+// Token change detection — notify Claude Code to re-fetch tools
+// ---------------------------------------------------------------------------
+
+let lastToken = currentToken();
+setInterval(() => {
+  const token = currentToken();
+  if (token === lastToken) return;
+  lastToken = token;
+  write({ jsonrpc: '2.0', method: 'notifications/tools/list_changed' });
+}, 3000).unref?.();
+
+// ---------------------------------------------------------------------------
+// HTTP reverse proxy — standard MCP HTTP transport with OAuth
+// ---------------------------------------------------------------------------
+
+function httpReadBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', c => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+function httpBase() {
+  return `http://127.0.0.1:${HTTP_PORT}`;
+}
+
+function send401(res) {
+  const base = httpBase();
+  res.writeHead(401, {
+    'WWW-Authenticate':
+      `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource${MCP_PATH}", ` +
+      `as_uri="${base}/.well-known/oauth-authorization-server", ` +
+      `error="invalid_token", error_description="Missing or invalid access token"`,
+    'Link': [
+      `<${base}/.well-known/oauth-authorization-server>; rel="oauth2-authorization-server"`,
+      `<${base}/.well-known/oauth-protected-resource${MCP_PATH}>; rel="oauth2-protected-resource"`,
+    ].join(', '),
+    'Cache-Control': 'no-store',
+    'Pragma': 'no-cache',
+    'Access-Control-Expose-Headers': 'WWW-Authenticate, Link',
+  });
+  res.end();
+}
+
+async function httpHandleOAuthMetadata(_req, res) {
+  try {
+    const remote = await fetch(`${REMOTE_BASE}/.well-known/oauth-authorization-server`);
+    if (!remote.ok) { res.writeHead(502); res.end(); return; }
+    const metadata = await remote.json();
+    const base = httpBase();
+    metadata.issuer = base;
+    metadata.token_endpoint = `${base}/token`;
+    metadata.registration_endpoint = `${base}/register`;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(metadata));
+  } catch {
+    res.writeHead(502); res.end();
+  }
+}
+
+async function httpHandleResourceMetadata(_req, res) {
+  try {
+    const remote = await fetch(`${REMOTE_BASE}/.well-known/oauth-protected-resource/mcp`);
+    if (!remote.ok) { res.writeHead(502); res.end(); return; }
+    const metadata = await remote.json();
+    const base = httpBase();
+    metadata.resource = `${base}${MCP_PATH}`;
+    metadata.authorization_servers = [base];
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(metadata));
+  } catch {
+    res.writeHead(502); res.end();
+  }
+}
+
+async function httpHandleToken(req, res) {
+  try {
+    const body = await httpReadBody(req);
+    const contentType = req.headers['content-type'] || 'application/x-www-form-urlencoded';
+    const remote = await fetch(`${REMOTE_BASE}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': contentType },
+      body,
+    });
+    const text = await remote.text();
+    try {
+      const data = JSON.parse(text);
+      if (data.access_token) {
+        syncTmpToken(data.access_token);
+        const params = contentType.includes('json')
+          ? (() => { try { return JSON.parse(body.toString()); } catch { return {}; } })()
+          : Object.fromEntries(new URLSearchParams(body.toString()));
+        writeSession({
+          access_token: data.access_token,
+          refresh_token: data.refresh_token || null,
+          client_id: params.client_id || 'mcp-oauth',
+        });
+      }
+    } catch { /* non-JSON response — forward as-is */ }
+    res.writeHead(remote.status, {
+      'Content-Type': remote.headers.get('content-type') || 'application/json',
+    });
+    res.end(text);
+  } catch {
+    res.writeHead(502); res.end();
+  }
+}
+
+async function httpHandleRegister(req, res) {
+  try {
+    const body = await httpReadBody(req);
+    const remote = await fetch(`${REMOTE_BASE}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    const text = await remote.text();
+    res.writeHead(remote.status, {
+      'Content-Type': remote.headers.get('content-type') || 'application/json',
+    });
+    res.end(text);
+  } catch {
+    res.writeHead(502); res.end();
+  }
+}
+
+async function httpHandleMcp(req, res) {
+  const token = await resolveToken();
+  if (!token) return send401(res);
+
+  try {
+    const body = await httpReadBody(req);
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: req.headers['accept'] || 'application/json, text/event-stream',
+      'x-confidence-mcp-consumer': 'plugin',
+      Authorization: `Bearer ${token}`,
+    };
+    if (req.headers['mcp-session-id']) {
+      headers['Mcp-Session-Id'] = req.headers['mcp-session-id'];
+    }
+
+    const remote = await fetch(REMOTE_MCP_URL, { method: 'POST', headers, body });
+
+    if (remote.status === 401 || remote.status === 403) {
+      return send401(res);
+    }
+
+    const responseHeaders = {
+      'Content-Type': remote.headers.get('content-type') || 'application/json',
+    };
+    const sessionId = remote.headers.get('mcp-session-id');
+    if (sessionId) responseHeaders['Mcp-Session-Id'] = sessionId;
+
+    res.writeHead(remote.status, responseHeaders);
+    res.end(await remote.text());
+  } catch (e) {
+    if (!res.headersSent) { res.writeHead(502); res.end(); }
+  }
+}
+
+const httpServer = createServer(async (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Accept, Mcp-Session-Id');
+  res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204); res.end(); return;
+  }
+
+  try {
+    const pathname = new URL(req.url, httpBase()).pathname;
+
+    if (pathname === '/.well-known/oauth-authorization-server' && req.method === 'GET')
+      return httpHandleOAuthMetadata(req, res);
+    if (pathname.startsWith('/.well-known/oauth-protected-resource') && req.method === 'GET')
+      return httpHandleResourceMetadata(req, res);
+    if (pathname === '/token' && req.method === 'POST')
+      return httpHandleToken(req, res);
+    if (pathname === '/register' && req.method === 'POST')
+      return httpHandleRegister(req, res);
+    if (pathname === MCP_PATH && req.method === 'POST')
+      return httpHandleMcp(req, res);
+
+    res.writeHead(404); res.end('Not Found');
+  } catch (e) {
+    process.stderr.write(`HTTP error: ${e.message}\n`);
+    if (!res.headersSent) { res.writeHead(500); res.end(); }
+  }
+});
+
+httpServer.on('error', e => {
+  if (e.code === 'EADDRINUSE') {
+    process.stderr.write(`Port ${HTTP_PORT} in use — HTTP proxy skipped.\n`);
+  } else {
+    process.stderr.write(`HTTP server error: ${e.message}\n`);
+  }
+});
+
+httpServer.listen(HTTP_PORT, '127.0.0.1', () => {
+  process.stderr.write(
+    `Confidence MCP HTTP proxy on http://127.0.0.1:${HTTP_PORT}${MCP_PATH}\n`
+  );
+});
+httpServer.unref?.();
+
+// ---------------------------------------------------------------------------
+// Stdio MCP server — authenticate / complete_authentication tools
+// ---------------------------------------------------------------------------
+
+const AUTHENTICATE_TOOL = {
+  name: 'authenticate',
+  description:
+    'Authenticate with Confidence via browser OAuth. Opens your default ' +
+    'browser to complete the login flow.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      workspace: {
+        type: 'string',
+        description:
+          'Your Confidence workspace name (the short identifier in your login URL, ' +
+          'e.g. "my-company"). Omit to use the universal login/signup flow.',
+      },
+    },
+  },
+};
+
+const COMPLETE_AUTHENTICATION_TOOL = {
+  name: 'complete_authentication',
+  description:
+    'Complete the Confidence authentication flow. Call this after authenticating ' +
+    'in your browser if tools have not appeared automatically.',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+function handleAuthenticate(msg, workspace) {
+  const clientId = workspace ? LOGIN_CLIENT_ID : SIGNUP_CLIENT_ID;
+  const args = [authScriptPath, clientId];
+  if (workspace) args.push(workspace);
+
+  try {
+    spawnSync('bash', ['-c', 'lsof -ti:8084 | xargs kill -9 2>/dev/null'], {
+      stdio: 'ignore',
+    });
+  } catch {
+    /* best effort */
+  }
+
+  const child = spawn('python3', args, { stdio: ['ignore', 'pipe', 'ignore'] });
+  let token = null;
+  let refreshToken = null;
+  let error = null;
+
+  child.stdout.on('data', data => {
+    for (const line of data.toString().split('\n')) {
+      if (line.startsWith('TOKEN:')) token = line.slice(6);
+      else if (line.startsWith('REFRESH_TOKEN:')) refreshToken = line.slice(14);
+      else if (line.startsWith('AUTH_ERROR:')) error = line.slice(10);
+      else if (line.startsWith('TOKEN_ERROR:')) error = line.slice(12);
+    }
+  });
+
+  child.on('close', () => {
+    if (token) {
+      syncTmpToken(token);
+      const session = { access_token: token, client_id: clientId };
+      if (refreshToken) session.refresh_token = refreshToken;
+      writeSession(session);
+      write({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          content: [
+            { type: 'text', text: 'Authenticated with Confidence. Tools are now available.' },
+          ],
+        },
+      });
+      write({ jsonrpc: '2.0', method: 'notifications/tools/list_changed' });
+    } else {
+      write({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          content: [
+            {
+              type: 'text',
+              text: `Authentication failed: ${error || 'unknown error'}. Try again.`,
+            },
+          ],
+          isError: true,
+        },
+      });
+    }
+  });
+}
+
+function handleCompleteAuthentication(msg) {
+  const token = currentToken();
+  if (token) {
+    write({
+      jsonrpc: '2.0',
+      id: msg.id,
+      result: {
+        content: [
+          { type: 'text', text: 'Already authenticated. Confidence tools are available.' },
+        ],
+      },
+    });
+    write({ jsonrpc: '2.0', method: 'notifications/tools/list_changed' });
+  } else {
+    write({
+      jsonrpc: '2.0',
+      id: msg.id,
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: 'No authentication in progress or token not yet received. Call authenticate first.',
+          },
+        ],
+        isError: true,
+      },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stdio request handling
+// ---------------------------------------------------------------------------
+
 function parseBody(text) {
   const trimmed = text.trim();
   if (!trimmed) return null;
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return trimmed;
-  // SSE-framed response: concatenate data lines
   const data = trimmed
     .split('\n')
     .filter(l => l.startsWith('data: '))
@@ -175,79 +535,22 @@ function parseBody(text) {
   return data || null;
 }
 
-// ---------------------------------------------------------------------------
-// OAUTH mode: delegate to mcp-remote, which handles the browser OAuth dance
-// and token caching/refresh itself.
-// ---------------------------------------------------------------------------
-
-let child = null;
-let childBroken = false;
-
-function startChild() {
-  if (child || childBroken) return;
-  try {
-    child = spawn(
-      'npx',
-      ['-y', 'mcp-remote@latest', url, '--header', 'x-confidence-mcp-consumer:plugin'],
-      { shell: process.platform === 'win32' },
-    );
-  } catch {
-    childBroken = true;
-    return;
-  }
-  child.on('error', () => {
-    child = null;
-    childBroken = true;
-  });
-  child.on('exit', () => {
-    child = null;
-  });
-  // Re-emit child output line by line so our own notifications never
-  // interleave inside a partially written frame.
-  createInterface({ input: child.stdout }).on('line', l => process.stdout.write(l + '\n'));
-  child.stderr.pipe(process.stderr);
-}
-
-function stopChild() {
-  if (child) {
-    child.kill();
-    child = null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Mode selection and switching
-// ---------------------------------------------------------------------------
-
-// Token file or persisted session present (even expired) => the user logs in
-// via the onboarding skill; never pop an OAuth browser at them. Neither
-// exists => classic OAuth flow.
-let mode = existsSync(tokenPath) || existsSync(sessionPath) ? 'session' : 'oauth';
-if (mode === 'oauth') startChild();
-
-let lastToken = currentToken();
-setInterval(() => {
-  const token = currentToken();
-  if (token === lastToken) return;
-  lastToken = token;
-  if (mode === 'oauth' && token) {
-    mode = 'session';
-    stopChild();
-  }
-  // Login state changed: have the agent re-fetch the tool list.
-  write({ jsonrpc: '2.0', method: 'notifications/tools/list_changed' });
-}, 3000).unref?.();
-
-// ---------------------------------------------------------------------------
-// SESSION mode request handling: inject the skill token per request.
-// ---------------------------------------------------------------------------
-
 function respondLocally(msg) {
   if (msg.method === 'initialize') {
     return write({ jsonrpc: '2.0', id: msg.id, result: LOCAL_INITIALIZE_RESULT });
   }
   if (msg.method === 'tools/list') {
-    return write({ jsonrpc: '2.0', id: msg.id, result: { tools: [] } });
+    return write({
+      jsonrpc: '2.0',
+      id: msg.id,
+      result: { tools: [] },
+    });
+  }
+  if (msg.method === 'tools/call' && msg.params?.name === 'authenticate') {
+    return handleAuthenticate(msg, msg.params?.arguments?.workspace);
+  }
+  if (msg.method === 'tools/call' && msg.params?.name === 'complete_authentication') {
+    return handleCompleteAuthentication(msg);
   }
   write({
     jsonrpc: '2.0',
@@ -256,11 +559,9 @@ function respondLocally(msg) {
   });
 }
 
-async function handleSessionMode(line, msg, isRequest) {
+async function handleRequest(line, msg, isRequest) {
   const token = await resolveToken();
 
-  // No valid login right now: answer protocol methods locally instead of
-  // forwarding — upstream rejects unauthenticated requests.
   if (!token) {
     if (isRequest) respondLocally(msg);
     return;
@@ -274,7 +575,7 @@ async function handleSessionMode(line, msg, isRequest) {
   };
 
   try {
-    const res = await fetch(url, { method: 'POST', headers, body: line });
+    const res = await fetch(REMOTE_MCP_URL, { method: 'POST', headers, body: line });
 
     if (res.status === 401 || res.status === 403) {
       if (isRequest) respondLocally(msg);
@@ -282,7 +583,7 @@ async function handleSessionMode(line, msg, isRequest) {
     }
 
     const body = parseBody(await res.text());
-    if (!isRequest) return; // notifications expect no response
+    if (!isRequest) return;
     if (body) {
       process.stdout.write(body.replace(/\r?\n/g, '') + '\n');
     } else {
@@ -304,7 +605,7 @@ async function handleSessionMode(line, msg, isRequest) {
 }
 
 // ---------------------------------------------------------------------------
-// Main loop
+// Stdio main loop
 // ---------------------------------------------------------------------------
 
 const rl = createInterface({ input: process.stdin });
@@ -318,22 +619,7 @@ rl.on('line', line => {
     return;
   }
   const isRequest = msg.id !== undefined && msg.id !== null;
-
-  if (mode === 'oauth') {
-    if (!child) startChild();
-    if (child) {
-      child.stdin.write(line + '\n');
-    } else if (isRequest) {
-      // mcp-remote unavailable (no npx?): degrade like a logged-out session.
-      respondLocally(msg);
-    }
-    return;
-  }
-
-  handleSessionMode(line, msg, isRequest);
+  handleRequest(line, msg, isRequest);
 });
 
-rl.on('close', () => {
-  stopChild();
-  process.exit(0);
-});
+rl.on('close', () => process.exit(0));

--- a/scripts/confidence-mcp-proxy.mjs
+++ b/scripts/confidence-mcp-proxy.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// Stdio <-> HTTP proxy for the Confidence MCP servers with automatic auth.
+//
+// Usage: node confidence-mcp-proxy.mjs <flags|docs>
+//
+// Two auth modes, one server name:
+//
+// SESSION mode — the onboard-confidence skill persists the user's Confidence
+// session token to $TMPDIR/confidence_token after browser login. The proxy
+// reads that token on EVERY request and forwards MCP traffic to
+// mcp.confidence.dev with the Authorization header set, so MCP auth always
+// follows the skill's login session. No interactive flow, no reconnect.
+//
+// OAUTH mode — when the token file does not exist (user never ran the
+// onboarding skill), the proxy delegates to `npx mcp-remote`, which performs
+// the standard MCP OAuth browser flow once and silently refreshes cached
+// tokens (~/.mcp-auth) on later sessions.
+//
+// If the skill token appears mid-session (user just logged in), the proxy
+// switches from OAUTH to SESSION mode and emits
+// notifications/tools/list_changed so the agent re-fetches the tool list.
+// A present-but-expired token means the user has logged in before: the proxy
+// stays in SESSION mode and hints to re-run the login instead of surprising
+// the user with an OAuth browser popup.
+//
+// Requires Node 18+ (built-in fetch).
+
+import { readFileSync, existsSync } from 'fs';
+import { spawn } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createInterface } from 'readline';
+
+const service = process.argv[2] || 'flags';
+const url =
+  process.env[`CONFIDENCE_MCP_${service.toUpperCase()}_URL`] ||
+  `https://mcp.confidence.dev/mcp/${service}`;
+const tokenPath = join(process.env.TMPDIR || tmpdir(), 'confidence_token');
+
+const NOT_AUTHENTICATED_MESSAGE =
+  'Confidence session expired or not established. Run the onboarding flow ' +
+  '(/confidence:onboard-confidence) to log in — MCP tools become available ' +
+  'automatically after login.';
+
+const write = obj => process.stdout.write(JSON.stringify(obj) + '\n');
+
+const LOCAL_INITIALIZE_RESULT = {
+  protocolVersion: '2025-03-26',
+  capabilities: { tools: { listChanged: true } },
+  serverInfo: { name: `confidence-${service}-proxy`, version: '1.0.0' },
+};
+
+function currentToken() {
+  try {
+    const t = readFileSync(tokenPath, 'utf8').trim();
+    const { exp } = JSON.parse(Buffer.from(t.split('.')[1], 'base64').toString());
+    if (exp && exp * 1000 < Date.now() + 30_000) return null;
+    return t;
+  } catch {
+    return null;
+  }
+}
+
+function parseBody(text) {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return trimmed;
+  // SSE-framed response: concatenate data lines
+  const data = trimmed
+    .split('\n')
+    .filter(l => l.startsWith('data: '))
+    .map(l => l.slice(6))
+    .join('');
+  return data || null;
+}
+
+// ---------------------------------------------------------------------------
+// OAUTH mode: delegate to mcp-remote, which handles the browser OAuth dance
+// and token caching/refresh itself.
+// ---------------------------------------------------------------------------
+
+let child = null;
+let childBroken = false;
+
+function startChild() {
+  if (child || childBroken) return;
+  try {
+    child = spawn(
+      'npx',
+      ['-y', 'mcp-remote@latest', url, '--header', 'x-confidence-mcp-consumer:plugin'],
+      { shell: process.platform === 'win32' },
+    );
+  } catch {
+    childBroken = true;
+    return;
+  }
+  child.on('error', () => {
+    child = null;
+    childBroken = true;
+  });
+  child.on('exit', () => {
+    child = null;
+  });
+  // Re-emit child output line by line so our own notifications never
+  // interleave inside a partially written frame.
+  createInterface({ input: child.stdout }).on('line', l => process.stdout.write(l + '\n'));
+  child.stderr.pipe(process.stderr);
+}
+
+function stopChild() {
+  if (child) {
+    child.kill();
+    child = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mode selection and switching
+// ---------------------------------------------------------------------------
+
+// Token file present (even expired) => the user logs in via the onboarding
+// skill; never pop an OAuth browser at them. Absent => classic OAuth flow.
+let mode = existsSync(tokenPath) ? 'session' : 'oauth';
+if (mode === 'oauth') startChild();
+
+let lastToken = currentToken();
+setInterval(() => {
+  const token = currentToken();
+  if (token === lastToken) return;
+  lastToken = token;
+  if (mode === 'oauth' && token) {
+    mode = 'session';
+    stopChild();
+  }
+  // Login state changed: have the agent re-fetch the tool list.
+  write({ jsonrpc: '2.0', method: 'notifications/tools/list_changed' });
+}, 3000).unref?.();
+
+// ---------------------------------------------------------------------------
+// SESSION mode request handling: inject the skill token per request.
+// ---------------------------------------------------------------------------
+
+function respondLocally(msg) {
+  if (msg.method === 'initialize') {
+    return write({ jsonrpc: '2.0', id: msg.id, result: LOCAL_INITIALIZE_RESULT });
+  }
+  if (msg.method === 'tools/list') {
+    return write({ jsonrpc: '2.0', id: msg.id, result: { tools: [] } });
+  }
+  write({
+    jsonrpc: '2.0',
+    id: msg.id,
+    error: { code: -32000, message: NOT_AUTHENTICATED_MESSAGE },
+  });
+}
+
+async function handleSessionMode(line, msg, isRequest) {
+  const token = currentToken();
+
+  // No valid login right now: answer protocol methods locally instead of
+  // forwarding — upstream rejects unauthenticated requests.
+  if (!token) {
+    if (isRequest) respondLocally(msg);
+    return;
+  }
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+    'x-confidence-mcp-consumer': 'plugin',
+    Authorization: `Bearer ${token}`,
+  };
+
+  try {
+    const res = await fetch(url, { method: 'POST', headers, body: line });
+
+    if (res.status === 401 || res.status === 403) {
+      if (isRequest) respondLocally(msg);
+      return;
+    }
+
+    const body = parseBody(await res.text());
+    if (!isRequest) return; // notifications expect no response
+    if (body) {
+      process.stdout.write(body.replace(/\r?\n/g, '') + '\n');
+    } else {
+      write({
+        jsonrpc: '2.0',
+        id: msg.id,
+        error: { code: -32000, message: `Upstream HTTP ${res.status}` },
+      });
+    }
+  } catch (e) {
+    if (isRequest) {
+      write({
+        jsonrpc: '2.0',
+        id: msg.id,
+        error: { code: -32000, message: `Proxy error: ${e.message ?? e}` },
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on('line', line => {
+  if (!line.trim()) return;
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  const isRequest = msg.id !== undefined && msg.id !== null;
+
+  if (mode === 'oauth') {
+    if (!child) startChild();
+    if (child) {
+      child.stdin.write(line + '\n');
+    } else if (isRequest) {
+      // mcp-remote unavailable (no npx?): degrade like a logged-out session.
+      respondLocally(msg);
+    }
+    return;
+  }
+
+  handleSessionMode(line, msg, isRequest);
+});
+
+rl.on('close', () => {
+  stopChild();
+  process.exit(0);
+});

--- a/skills/onboard-confidence/SKILL.md
+++ b/skills/onboard-confidence/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Create Confidence accounts and onboard users. Use when the user asks to create an account, invite users, onboard to Confidence, or check account status.
+description: Create Confidence accounts and onboard users. Use when the user asks to create an account, log in, log out, invite users, onboard to Confidence, or check account status.
 ---
 
 # Confidence Onboarding
@@ -19,6 +19,8 @@ Do NOT show a menu of sub-commands. Do NOT offer "Setup Wizard" as a choice — 
 
 | Command | Description |
 |---------|-------------|
+| `/onboard-confidence login` | Log in to an existing Confidence account |
+| `/onboard-confidence logout` | Log out and clear the Confidence session |
 | `/onboard-confidence create-account` | Create a new Confidence account |
 | `/onboard-confidence invite-user` | Invite a user to an account |
 | `/onboard-confidence create-client` | Create an SDK client and generate credentials |
@@ -74,22 +76,23 @@ lsof -ti:8084 | xargs kill -9 2>/dev/null; python3 <SKILL_BASE_DIR>/auth.py 2fG3
 **Key details:**
 - Port is fixed at **8084** (must match Auth0 Allowed Callback URLs)
 - For signup (`create-account`): omit ORGANIZATION arg → adds `screen_hint=signup` + `prompt=login`
-- For existing account (all other commands): pass `ORGANIZATION=<org_id>` → auto-completes if browser session exists
+- **For existing account (all other commands): ORGANIZATION is REQUIRED.** The regular client ID (`2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w`) will fail with `AUTH_ERROR:invalid_request` if called without the ORGANIZATION arg. **Always ask the user for their workspace name (login ID) BEFORE calling auth.py** with this client ID. The ORGANIZATION value is the workspace's `loginId` (e.g., `confidence`, `my-company`).
 - After `create-account`, automatically re-auth with org param to get org-scoped token (browser auto-redirects, no interaction)
 - All network commands require `dangerouslyDisableSandbox: true` and `timeout: 130000`
 
 ### Token management
 
-Tokens live in two places:
+Tokens live in three places (checked in this order):
 
-- `$TMPDIR/confidence_token` — the working cache read by curl calls and the MCP proxy. Fast, but wiped on reboot/cleanup.
-- `~/.confidence/session.json` (chmod 600) — the persistent session: `{"access_token": "...", "refresh_token": "...", "client_id": "..."}`. This is what keeps the user logged in across sessions and reboots. Write it after every successful auth, recording the client ID that performed the auth (refresh requires the same client).
+1. `.claude/settings.local.json` `env.CONFIDENCE_API_KEY` — the MCP server reads this as the `Authorization: Bearer` header. This is the primary token source. Write it after every successful auth.
+2. `$TMPDIR/confidence_token` — the working cache read by curl calls in the skill. Fast, but wiped on reboot/cleanup.
+3. `~/.confidence/session.json` (chmod 600) — the persistent session: `{"access_token": "...", "refresh_token": "...", "client_id": "..."}`. This is what keeps the user logged in across sessions and reboots. Used for silent token refresh.
 
-The plugin's `confidence-flags` MCP server (bundled `scripts/confidence-mcp-proxy.mjs`) reads the `$TMPDIR` cache on every request, falls back to `~/.confidence/session.json`, and refreshes expired access tokens itself using the stored refresh token. After a successful login, the flag MCP tools become available automatically within a few seconds — no MCP authenticate flow or reconnect is needed, so never ask the user to authenticate the MCP manually.
+The plugin's `confidence-flags` MCP server connects directly to `mcp.confidence.dev` via HTTP transport, using the `CONFIDENCE_API_KEY` env var as the Bearer token. After writing the env var, the user may need to reconnect the MCP server via `/mcp` for the new token to take effect.
 
 **CRITICAL: TMPDIR differs between sandboxed and non-sandboxed Bash calls.** Sandboxed calls use a path like `/tmp/claude-501/`, while `dangerouslyDisableSandbox: true` calls use the system TMPDIR (e.g., `/var/folders/.../T/`). If tokens are written in a sandboxed call but read in a non-sandboxed curl call, the curl will read a stale or missing token. **ALL token writes and reads MUST use `dangerouslyDisableSandbox: true`** to ensure a consistent TMPDIR path. This includes the auth script call (already non-sandboxed for network), the token save, the token validity check, and all curl calls.
 
-**After every successful auth**, write the token cache and the persistent session — **in the same `dangerouslyDisableSandbox: true` Bash call** as the auth script or curl that produced it:
+**After every successful auth**, write the token to all three locations — **in the same `dangerouslyDisableSandbox: true` Bash call** as the auth script or curl that produced it:
 ```bash
 # Parse TOKEN/REFRESH_TOKEN from auth.py stdout and persist (same Bash call, same TMPDIR)
 echo "<TOKEN_VALUE>" > "$TMPDIR/confidence_token"
@@ -99,20 +102,34 @@ p = os.path.expanduser('~/.confidence/session.json')
 json.dump({'access_token': '<TOKEN_VALUE>', 'refresh_token': '<REFRESH_VALUE>', 'client_id': '<CLIENT_ID_USED>'}, open(p, 'w'), indent=2)
 os.chmod(p, 0o600)
 "
+# Write token as CONFIDENCE_API_KEY env var to settings.local.json (used by MCP HTTP header)
+python3 -c "
+import json, os
+p = os.path.join(os.getcwd(), '.claude', 'settings.local.json')
+try:
+    s = json.load(open(p))
+except Exception:
+    s = {}
+s.setdefault('env', {})['CONFIDENCE_API_KEY'] = '<TOKEN_VALUE>'
+os.makedirs(os.path.dirname(p), exist_ok=True)
+json.dump(s, open(p, 'w'), indent=2)
+"
 ```
 (Omit `refresh_token` from the JSON if auth.py did not print one.)
 
-**On every sub-command start**, check if the token file exists and is not expired. **This Bash call MUST use `dangerouslyDisableSandbox: true`** so it reads from the same TMPDIR that curl will use:
+**On every sub-command start**, check if a token is available and not expired. Check `CONFIDENCE_API_KEY` env var first, then fall back to the token file. **This Bash call MUST use `dangerouslyDisableSandbox: true`** so it reads from the same TMPDIR that curl will use:
 
 ```bash
 # dangerouslyDisableSandbox: true
 python3 -c "
 import json, base64, time, os
-p = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'confidence_token')
-try:
-    t = open(p).read().strip()
-except FileNotFoundError:
-    print('MISSING'); exit(0)
+t = os.environ.get('CONFIDENCE_API_KEY', '').strip()
+if not t:
+    p = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'confidence_token')
+    try:
+        t = open(p).read().strip()
+    except FileNotFoundError:
+        pass
 if not t:
     print('MISSING'); exit(0)
 parts = t.split('.')[1]
@@ -155,15 +172,24 @@ if d.get('refresh_token'):
 json.dump(s, open(p, 'w'), indent=2)
 os.chmod(p, 0o600)
 open(os.path.join(os.environ.get('TMPDIR', '/tmp'), 'confidence_token'), 'w').write(d['access_token'])
+# Also update CONFIDENCE_API_KEY in settings.local.json
+sp = os.path.join(os.getcwd(), '.claude', 'settings.local.json')
+try:
+    sl = json.load(open(sp))
+except Exception:
+    sl = {}
+sl.setdefault('env', {})['CONFIDENCE_API_KEY'] = d['access_token']
+os.makedirs(os.path.dirname(sp), exist_ok=True)
+json.dump(sl, open(sp, 'w'), indent=2)
 print('REFRESHED')
 "
 ```
 
 `REFRESHED` means the token cache is valid again — continue. `NO_SESSION` or `REFRESH_FAILED` means run the browser auth flow and write the new token + session files.
 
-**In curl calls**, read from the file instead of a shell variable:
+**In curl calls**, prefer the env var, fall back to the file:
 ```bash
-curl -s ... -H "Authorization: Bearer $(cat $TMPDIR/confidence_token)"
+curl -s ... -H "Authorization: Bearer ${CONFIDENCE_API_KEY:-$(cat $TMPDIR/confidence_token)}"
 ```
 
 Use the `REGION` value (lowercased) for URL prefixes: `iam.eu.confidence.dev`, `flags.eu.confidence.dev`, etc.
@@ -269,6 +295,50 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 **Step Tracker:** Display a visual step tracker at every phase transition. Update and re-display it each time you move to a new step.
 
 **Use AskUserQuestion for all choices.** Present options as selectable items (up/down/enter) — never numbered lists in plain text. Only ask the user to type when collecting free-text input like names or emails.
+
+---
+
+## Sub-command: login
+
+Log in to an existing Confidence account. This is the standalone auth flow — use it when the user just wants to authenticate without running the full setup wizard or create-account flow.
+
+### Flow
+
+**Steps 1–2 are silent** — run both in the background without showing intermediate status to the user. Only communicate the final outcome: already logged in, session restored, or need to log in via browser.
+
+1. **Check existing token** — run the token validity check (see Token management). If `VALID`, tell the user they're already logged in, show the account name and region, and stop.
+
+2. **Try silent refresh** — if `EXPIRED` or `MISSING`, try the silent refresh from `~/.confidence/session.json`. If `REFRESHED`, tell the user their session was restored and stop. **Do NOT tell the user "session expired" or "no session found" — these are internal states, not user-facing messages.**
+
+3. **Ask for workspace name** — if refresh fails (`NO_SESSION` or `REFRESH_FAILED`), ask the user for their workspace name (login ID). This is the short identifier that appears in their login URL (e.g., `my-company`, `confidence`). **This must happen BEFORE calling auth.py** — the regular client ID requires the ORGANIZATION parameter and will fail with `AUTH_ERROR:invalid_request` without it.
+
+4. **Run browser auth** — call auth.py with the regular client ID and workspace name:
+```bash
+lsof -ti:8084 | xargs kill -9 2>/dev/null; python3 <SKILL_BASE_DIR>/auth.py 2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w <WORKSPACE_NAME>
+```
+
+5. **Save token and session** — parse TOKEN and REFRESH_TOKEN from stdout. Save both to `$TMPDIR/confidence_token` and `~/.confidence/session.json` in a single `dangerouslyDisableSandbox: true` Bash call (see Token management).
+
+6. **Confirm** — tell the user they're logged in, show the workspace name and region extracted from the token claims. The MCP flag tools will appear automatically within a few seconds — do NOT suggest running `/mcp` to reconnect.
+
+---
+
+## Sub-command: logout
+
+Log out of Confidence by clearing the session token and persistent session file.
+
+### Flow
+
+1. **Clear session files** — remove both the token cache and the persistent session in a single `dangerouslyDisableSandbox: true` Bash call:
+```bash
+rm -f "$TMPDIR/confidence_token" && rm -f ~/.confidence/session.json
+```
+
+2. **Confirm** — tell the user they've been logged out:
+> You've been logged out of Confidence.
+> Run `/onboard-confidence login` to sign in again.
+
+No telemetry, no token checks, no questions. Just clear and confirm.
 
 ---
 

--- a/skills/onboard-confidence/SKILL.md
+++ b/skills/onboard-confidence/SKILL.md
@@ -82,6 +82,8 @@ lsof -ti:8084 | xargs kill -9 2>/dev/null; python3 <SKILL_BASE_DIR>/auth.py 2fG3
 
 Tokens are persisted to `$TMPDIR/confidence_token` (and optionally `$TMPDIR/confidence_refresh_token`). This avoids re-exporting the JWT on every Bash tool call. **NEVER write tokens to `~/.confidence/` or anywhere outside `$TMPDIR`.**
 
+The plugin's `confidence-flags` MCP server reads the same `$TMPDIR/confidence_token` file on every request (via the bundled `scripts/confidence-mcp-proxy.mjs`). After a successful login, the flag MCP tools become available automatically within a few seconds — no MCP authenticate flow or reconnect is needed, so never ask the user to authenticate the MCP manually.
+
 **CRITICAL: TMPDIR differs between sandboxed and non-sandboxed Bash calls.** Sandboxed calls use a path like `/tmp/claude-501/`, while `dangerouslyDisableSandbox: true` calls use the system TMPDIR (e.g., `/var/folders/.../T/`). If tokens are written in a sandboxed call but read in a non-sandboxed curl call, the curl will read a stale or missing token. **ALL token writes and reads MUST use `dangerouslyDisableSandbox: true`** to ensure a consistent TMPDIR path. This includes the auth script call (already non-sandboxed for network), the token save, the token validity check, and all curl calls.
 
 **After every successful auth**, write the token to file — **in the same `dangerouslyDisableSandbox: true` Bash call** as the auth script or curl that produced it:

--- a/skills/onboard-confidence/SKILL.md
+++ b/skills/onboard-confidence/SKILL.md
@@ -80,17 +80,27 @@ lsof -ti:8084 | xargs kill -9 2>/dev/null; python3 <SKILL_BASE_DIR>/auth.py 2fG3
 
 ### Token management
 
-Tokens are persisted to `$TMPDIR/confidence_token` (and optionally `$TMPDIR/confidence_refresh_token`). This avoids re-exporting the JWT on every Bash tool call. **NEVER write tokens to `~/.confidence/` or anywhere outside `$TMPDIR`.**
+Tokens live in two places:
 
-The plugin's `confidence-flags` MCP server reads the same `$TMPDIR/confidence_token` file on every request (via the bundled `scripts/confidence-mcp-proxy.mjs`). After a successful login, the flag MCP tools become available automatically within a few seconds — no MCP authenticate flow or reconnect is needed, so never ask the user to authenticate the MCP manually.
+- `$TMPDIR/confidence_token` — the working cache read by curl calls and the MCP proxy. Fast, but wiped on reboot/cleanup.
+- `~/.confidence/session.json` (chmod 600) — the persistent session: `{"access_token": "...", "refresh_token": "...", "client_id": "..."}`. This is what keeps the user logged in across sessions and reboots. Write it after every successful auth, recording the client ID that performed the auth (refresh requires the same client).
+
+The plugin's `confidence-flags` MCP server (bundled `scripts/confidence-mcp-proxy.mjs`) reads the `$TMPDIR` cache on every request, falls back to `~/.confidence/session.json`, and refreshes expired access tokens itself using the stored refresh token. After a successful login, the flag MCP tools become available automatically within a few seconds — no MCP authenticate flow or reconnect is needed, so never ask the user to authenticate the MCP manually.
 
 **CRITICAL: TMPDIR differs between sandboxed and non-sandboxed Bash calls.** Sandboxed calls use a path like `/tmp/claude-501/`, while `dangerouslyDisableSandbox: true` calls use the system TMPDIR (e.g., `/var/folders/.../T/`). If tokens are written in a sandboxed call but read in a non-sandboxed curl call, the curl will read a stale or missing token. **ALL token writes and reads MUST use `dangerouslyDisableSandbox: true`** to ensure a consistent TMPDIR path. This includes the auth script call (already non-sandboxed for network), the token save, the token validity check, and all curl calls.
 
-**After every successful auth**, write the token to file — **in the same `dangerouslyDisableSandbox: true` Bash call** as the auth script or curl that produced it:
+**After every successful auth**, write the token cache and the persistent session — **in the same `dangerouslyDisableSandbox: true` Bash call** as the auth script or curl that produced it:
 ```bash
-# Parse TOKEN from auth.py stdout and persist (same Bash call, same TMPDIR)
+# Parse TOKEN/REFRESH_TOKEN from auth.py stdout and persist (same Bash call, same TMPDIR)
 echo "<TOKEN_VALUE>" > "$TMPDIR/confidence_token"
+mkdir -p ~/.confidence && python3 -c "
+import json, os, sys
+p = os.path.expanduser('~/.confidence/session.json')
+json.dump({'access_token': '<TOKEN_VALUE>', 'refresh_token': '<REFRESH_VALUE>', 'client_id': '<CLIENT_ID_USED>'}, open(p, 'w'), indent=2)
+os.chmod(p, 0o600)
+"
 ```
+(Omit `refresh_token` from the JSON if auth.py did not print one.)
 
 **On every sub-command start**, check if the token file exists and is not expired. **This Bash call MUST use `dangerouslyDisableSandbox: true`** so it reads from the same TMPDIR that curl will use:
 
@@ -119,7 +129,37 @@ print('ACCOUNT=' + d.get('https://confidence.dev/account_name', ''))
 
 Output is multi-line: first line is `VALID`/`EXPIRED`/`MISSING`, followed by `REGION=EU`, `ORG=...`, `ACCOUNT=...` if valid.
 
-If expired or missing, run the browser auth flow and write the new token to the file.
+If expired or missing, **try a silent refresh first** using the persistent session — only fall back to the browser auth flow if the refresh fails:
+
+```bash
+# dangerouslyDisableSandbox: true — silent refresh from ~/.confidence/session.json
+python3 -c "
+import json, os, sys, urllib.request
+p = os.path.expanduser('~/.confidence/session.json')
+try:
+    s = json.load(open(p))
+except Exception:
+    print('NO_SESSION'); sys.exit(0)
+if not s.get('refresh_token') or not s.get('client_id'):
+    print('NO_SESSION'); sys.exit(0)
+body = json.dumps({'grant_type': 'refresh_token', 'client_id': s['client_id'], 'refresh_token': s['refresh_token']}).encode()
+req = urllib.request.Request('https://auth.confidence.dev/oauth/token', data=body, headers={'Content-Type': 'application/json'})
+try:
+    with urllib.request.urlopen(req) as resp:
+        d = json.loads(resp.read())
+except Exception as e:
+    print(f'REFRESH_FAILED:{e}'); sys.exit(0)
+s['access_token'] = d['access_token']
+if d.get('refresh_token'):
+    s['refresh_token'] = d['refresh_token']
+json.dump(s, open(p, 'w'), indent=2)
+os.chmod(p, 0o600)
+open(os.path.join(os.environ.get('TMPDIR', '/tmp'), 'confidence_token'), 'w').write(d['access_token'])
+print('REFRESHED')
+"
+```
+
+`REFRESHED` means the token cache is valid again — continue. `NO_SESSION` or `REFRESH_FAILED` means run the browser auth flow and write the new token + session files.
 
 **In curl calls**, read from the file instead of a shell variable:
 ```bash
@@ -258,13 +298,18 @@ Run the bundled auth script with the **signup client ID** (`82qMvwZvqd3t3S0gRDvs
 Tell the user:
 > Opening your browser to log in. Sign up with Google or create an account with email and password.
 
-Write `TOKEN` to `$TMPDIR/confidence_token` and `REFRESH_TOKEN` to `$TMPDIR/confidence_refresh_token`. **The token save and all subsequent reads MUST use `dangerouslyDisableSandbox: true`** to ensure consistent TMPDIR paths (see Token management section).
+Write `TOKEN` to `$TMPDIR/confidence_token` and `REFRESH_TOKEN` to `$TMPDIR/confidence_refresh_token`, and persist the session to `~/.confidence/session.json` with the signup client ID (see Token management section). **The token save and all subsequent reads MUST use `dangerouslyDisableSandbox: true`** to ensure consistent TMPDIR paths.
 
 If login fails, show the error in plain English and offer to retry.
 
-**After successful login**, immediately extract the user's email by calling the Auth0 userinfo endpoint — **combine the token save and userinfo curl in a single `dangerouslyDisableSandbox: true` Bash call**:
+**After successful login**, immediately extract the user's email by calling the Auth0 userinfo endpoint — **combine the token save, session persist, and userinfo curl in a single `dangerouslyDisableSandbox: true` Bash call**:
 ```bash
-echo "<TOKEN_VALUE>" > "$TMPDIR/confidence_token" && echo "<REFRESH_VALUE>" > "$TMPDIR/confidence_refresh_token" && curl -s "https://konfidens.eu.auth0.com/userinfo" -H "Authorization: Bearer $(cat $TMPDIR/confidence_token)"
+echo "<TOKEN_VALUE>" > "$TMPDIR/confidence_token" && echo "<REFRESH_VALUE>" > "$TMPDIR/confidence_refresh_token" && mkdir -p ~/.confidence && python3 -c "
+import json, os
+p = os.path.expanduser('~/.confidence/session.json')
+json.dump({'access_token': '<TOKEN_VALUE>', 'refresh_token': '<REFRESH_VALUE>', 'client_id': '82qMvwZvqd3t3S0gRDvs8R53TehQXSJY'}, open(p, 'w'), indent=2)
+os.chmod(p, 0o600)
+" && curl -s "https://konfidens.eu.auth0.com/userinfo" -H "Authorization: Bearer $(cat $TMPDIR/confidence_token)"
 ```
 Response: `{ "email": "user@company.com", "name": "...", ... }`
 
@@ -411,8 +456,15 @@ lsof -ti:8084 | xargs kill -9 2>/dev/null; python3 <SKILL_BASE_DIR>/auth.py 2fG3
 The response token will contain `org_id`, `account_name`, and `region` claims. Parse the TOKEN and REFRESH_TOKEN from stdout, then **save them in a separate `dangerouslyDisableSandbox: true` Bash call**:
 
 ```bash
-echo "<ORG_SCOPED_TOKEN>" > "$TMPDIR/confidence_token" && echo "<REFRESH_TOKEN>" > "$TMPDIR/confidence_refresh_token"
+echo "<ORG_SCOPED_TOKEN>" > "$TMPDIR/confidence_token" && echo "<REFRESH_TOKEN>" > "$TMPDIR/confidence_refresh_token" && mkdir -p ~/.confidence && python3 -c "
+import json, os
+p = os.path.expanduser('~/.confidence/session.json')
+json.dump({'access_token': '<ORG_SCOPED_TOKEN>', 'refresh_token': '<REFRESH_TOKEN>', 'client_id': '2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w'}, open(p, 'w'), indent=2)
+os.chmod(p, 0o600)
+"
 ```
+
+The org-scoped session (regular client) replaces the signup-client session in `~/.confidence/session.json` — this is the session that persists across restarts and that refresh uses.
 
 **This save call MUST use `dangerouslyDisableSandbox: true`** — even though it doesn't need network access — so that `$TMPDIR` resolves to the same path that future curl calls will use. A sandboxed save writes to a different TMPDIR and the token will be invisible to non-sandboxed curl calls.
 
@@ -463,7 +515,7 @@ Show a summary and next steps:
 
 Check if a token is available from a prior `create-account` run in this session.
 
-If not, run the bundled auth script with the **regular client ID** (`2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w`) — this user already has an account.
+If not, try the silent refresh from `~/.confidence/session.json` first (see Token management). If that fails, run the bundled auth script with the **regular client ID** (`2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w`) — this user already has an account — and persist the new session.
 
 Validate the token works by calling:
 ```bash
@@ -641,7 +693,7 @@ Otherwise (when entered directly via `/onboard-confidence setup-wizard`), use As
 Run the full `create-account` sub-command flow (Steps 1–6 from that section). This handles signup, workspace creation, and re-auth with an org-scoped token. Once complete, proceed to Step 2 of setup-wizard with the token and region already set.
 
 **If "Sign in to existing account":**
-Check if a token file exists at `$TMPDIR/confidence_token` and is valid. If not, run the bundled auth script with the **regular client ID** (`2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w`). Validate the token, extract the region, and proceed to Step 2.
+Check if a token file exists at `$TMPDIR/confidence_token` and is valid. If not, try the silent refresh from `~/.confidence/session.json` first (see Token management); only if that fails, run the bundled auth script with the **regular client ID** (`2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w`) and persist the new session. Validate the token, extract the region, and proceed to Step 2.
 
 Determine the region from the token — this sets the API base URLs:
 - EU: `flags.eu.confidence.dev`, `resolver.eu.confidence.dev`, `iam.eu.confidence.dev`
@@ -1358,7 +1410,7 @@ MCP tools are used for **flag and client operations only** — account creation,
 - **Port 8084 must be free** — the Auth0 callback server uses a fixed port. The auth script auto-kills any existing process on port 8084.
 - **Auth0 Allowed Callback URLs** — both Auth0 clients must have `http://localhost:8084/callback` in their Allowed Callback URLs, Allowed Logout URLs, and Allowed Web Origins.
 - **Auth script is bundled** — `auth.py` ships with the plugin in the skill directory. Never write auth scripts to disk; always use the bundled script.
-- **Token persistence and TMPDIR** — tokens are written to `$TMPDIR/confidence_token`. `$TMPDIR` resolves to DIFFERENT paths in sandboxed vs non-sandboxed (`dangerouslyDisableSandbox: true`) Bash calls (e.g., `/tmp/claude-501/` vs `/var/folders/.../T/`). ALL token writes and reads MUST use `dangerouslyDisableSandbox: true` to ensure consistency. Never write tokens outside `$TMPDIR`.
+- **Token persistence and TMPDIR** — the working token cache is `$TMPDIR/confidence_token`; the durable session is `~/.confidence/session.json` (chmod 600). `$TMPDIR` resolves to DIFFERENT paths in sandboxed vs non-sandboxed (`dangerouslyDisableSandbox: true`) Bash calls (e.g., `/tmp/claude-501/` vs `/var/folders/.../T/`). ALL token writes and reads MUST use `dangerouslyDisableSandbox: true` to ensure consistency.
 - **Learning API** — REST-only (gRPC on epx-onboarding). Course content is generated by the skill using docs MCP; the API only tracks progress indices.
 - **`learn` sub-command** — uses docs MCP for content. If MCP not connected, the skill can still teach using its own knowledge but won't have the latest docs.
 - **Region-specific API URLs** — flags/resolver APIs use region prefixes (`flags.eu.confidence.dev` vs `flags.us.confidence.dev`). Determine region from the JWT token or from the account creation step.


### PR DESCRIPTION
## Summary
- Replace stdio proxy with direct HTTP connection to `mcp.confidence.dev` for the `confidence-flags` MCP server
- Auth via `CONFIDENCE_API_KEY` env var (Bearer token in header) — works in local clients and remote agents
- Skill writes token to `.claude/settings.local.json` env after auth, reads it back on startup and in curl calls
- Proxy (`confidence-mcp-proxy.mjs`) kept in repo but no longer used by `.mcp.json` — can be removed in a follow-up

## How it works
- **Local**: skill authenticates via browser OAuth → writes token to `CONFIDENCE_API_KEY` env var → MCP uses it
- **Remote**: set `CONFIDENCE_API_KEY` env var in routine config → both skill and MCP authenticated
- **Token refresh**: skill handles refresh silently, updates the env var in settings.local.json

## Test plan
- [ ] Run `/confidence:onboard-confidence` → verify token written to settings.local.json env
- [ ] Check `/mcp` → verify confidence-flags connects with tools after auth
- [ ] Test MCP tool calls (list flags, resolve flag) work with the token
- [ ] Test expired token → skill refresh → MCP reconnects with new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)