### PR TITLE
fix: add name field to SKILL.md frontmatter and link migration guides

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,8 @@
       "name": "confidence",
       "version": "0.6.0",
       "description": "Access Confidence feature flags, experiments, and migration tools directly from Claude Code.",
+      "homepage": "https://confidence.spotify.com",
+      "repository": "https://github.com/spotify/confidence-ai-plugins",
       "source": {
         "source": "url",
         "url": "https://github.com/spotify/confidence-ai-plugins.git"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -7,6 +7,8 @@
     "name": "Spotify Confidence",
     "url": "https://confidence.spotify.com"
   },
+  "homepage": "https://confidence.spotify.com",
+  "repository": "https://github.com/spotify/confidence-ai-plugins",
   "license": "Apache-2.0",
   "keywords": [
     "feature-flags",

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ This plugin provides access to Confidence tools across these categories:
 
 ## Slash Commands
 
-- `/confidence:migrate-posthog` — Migrate feature flags from PostHog to Confidence SDK
-- `/confidence:migrate-eppo` — Migrate feature flags from Eppo to Confidence SDK
-- `/confidence:migrate-statsig` — Migrate feature flags from Statsig to Confidence SDK
-- `/confidence:migrate-optimizely` — Migrate feature flags from Optimizely Feature Experimentation to Confidence SDK
+- `/confidence:migrate-posthog` — [Migrate feature flags from PostHog to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-posthog)
+- `/confidence:migrate-eppo` — [Migrate feature flags from Eppo to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-eppo)
+- `/confidence:migrate-statsig` — [Migrate feature flags from Statsig to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-statsig)
+- `/confidence:migrate-optimizely` — [Migrate feature flags from Optimizely Feature Experimentation to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-optimizely)
 
 ## Example Usage
 
@@ -106,4 +106,5 @@ This plugin provides access to Confidence tools across these categories:
 ## Documentation
 
 - [Confidence documentation](https://confidence.spotify.com/docs)
+- [Migration guides — migrate to Confidence from PostHog, Eppo, Statsig, or Optimizely](https://confidence.spotify.com/docs/migrations/overview)
 - [OpenFeature SDK integration](https://confidence.spotify.com/docs/sdks)

--- a/skills/migrate-eppo/SKILL.md
+++ b/skills/migrate-eppo/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: migrate-eppo
 description: Migrate feature flags from Eppo to Confidence SDK. Use when the user says /migrate-eppo, asks to migrate Eppo flags, or transform SDK code to Confidence.
 ---
 

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: migrate-optimizely
 description: Migrate feature flags from Optimizely to Confidence SDK. Use when the user says /migrate-optimizely, asks to migrate Optimizely flags/rollouts/experiments, or transform Optimizely SDK code to Confidence.
 ---
 

--- a/skills/migrate-posthog/SKILL.md
+++ b/skills/migrate-posthog/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: migrate-posthog
 description: Migrate feature flags from PostHog to Confidence SDK. Use when the user says /migrate-posthog, asks to migrate PostHog flags, or transform SDK code to Confidence.
 ---
 

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: migrate-statsig
 description: Migrate feature flags from Statsig to Confidence SDK. Use when the user says /migrate-statsig, asks to migrate Statsig gates/configs/experiments, or transform SDK code to Confidence.
 ---
 

--- a/skills/onboard-confidence-dry-run/SKILL.md
+++ b/skills/onboard-confidence-dry-run/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: onboard-confidence-dry-run
 description: Dry-run the Confidence onboarding flow to test UX without real API calls. Use when the user says "dry run", "test onboarding", "demo onboarding", or wants to preview the onboarding experience.
 ---
 

--- a/skills/onboard-confidence/SKILL.md
+++ b/skills/onboard-confidence/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: onboard-confidence
 description: Create Confidence accounts and onboard users. Use when the user asks to create an account, invite users, onboard to Confidence, or check account status.
 ---
 

--- a/skills/setup-warehouse-bigquery/SKILL.md
+++ b/skills/setup-warehouse-bigquery/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: setup-warehouse-bigquery
 description: Set up BigQuery as a data warehouse for Confidence. Use when the user chose BigQuery for warehouse setup.
 ---
 

--- a/skills/setup-warehouse-databricks/SKILL.md
+++ b/skills/setup-warehouse-databricks/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: setup-warehouse-databricks
 description: Set up Databricks as a data warehouse for Confidence. Use when the user chose Databricks for warehouse setup.
 ---
 

--- a/skills/setup-warehouse-redshift/SKILL.md
+++ b/skills/setup-warehouse-redshift/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: setup-warehouse-redshift
 description: Set up Redshift as a data warehouse for Confidence. Use when the user chose Redshift for warehouse setup.
 ---
 

--- a/skills/setup-warehouse-snowflake/SKILL.md
+++ b/skills/setup-warehouse-snowflake/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: setup-warehouse-snowflake
 description: Set up Snowflake as a data warehouse for Confidence. Use when the user chose Snowflake for warehouse setup.
 ---
 

--- a/skills/setup-warehouse/SKILL.md
+++ b/skills/setup-warehouse/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: setup-warehouse
 description: Set up a data warehouse for Confidence experimentation analytics. Use when the user asks to connect a warehouse, set up BigQuery/Snowflake/Databricks/Redshift, or configure data connectors.
 ---
 


### PR DESCRIPTION
## Summary

- **SKILL.md frontmatter**: adds `name:` to all 11 skills — required by the open agent-skills CLI ([npx skills](https://github.com/vercel-labs/skills)). Without it, `npx skills add spotify/confidence-ai-plugins` reports "No valid skills found".
- **README backlinks**: each migration slash command now links to its guide on [confidence.spotify.com/docs](https://confidence.spotify.com/docs/migrations/overview), and the Documentation section links the migrations overview.
- **Marketplace manifests**: adds `homepage` and `repository` to the Cursor and Claude manifests so the marketplace listings link back to the product site and repo.

## Verification

Tested locally: `npx skills add ./confidence-as all 11 skills after the `name:` addition.

🤖 Generated with [Claude Code](https://claude