### PR TITLE
docs: improve README structure and cover onboarding command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
-# Confidence AI Plugin
+<p align="center">
+  <img src="assets/logo.svg" alt="Confidence" width="120" />
+</p>
 
-Official Confidence plugin for AI coding tools. Access feature flags, experiments, and migration tools directly from Claude Code, Cursor, Codex, and Gemini CLI.
+<h1 align="center">Confidence AI Plugin</h1>
 
-## Installation
+<p align="center">
+  Official Confidence plugin for AI coding tools. Manage feature flags, experiments, onboarding, and migrations right from your agent.
+</p>
+
+<p align="center">
+  <a href="https://confidence.spotify.com/docs/introduction"><img alt="Docs" src="https://img.shields.io/badge/docs-confidence.spotify.com-6E56CF"></a>
+  <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
+  <a href="./CHANGELOG.md"><img alt="Version" src="https://img.shields.io/badge/version-0.6.0-informational"></a>
+</p>
+
+## ✨ Highlights
+
+- **Manage feature flags without leaving your editor**: create, list, update, target, resolve, and archive flags from Claude Code, Cursor, Codex, or Gemini CLI
+- **One-command migrations** from PostHog, Eppo, Statsig, or Optimizely, covering flags *and* SDK code
+- **Guided onboarding**: spin up a Confidence account, invite teammates, create SDK clients, and connect a warehouse without reading a setup doc
+- **Docs on tap**: search Confidence documentation and SDK integration guides inline while you code
+- Works with every major AI coding assistant through the same MCP servers
+
+## ℹ️ Overview
+
+[Confidence](https://confidence.spotify.com) is Spotify's feature flagging and experimentation platform, built on the [OpenFeature](https://openfeature.dev) standard. This plugin exposes Confidence's flag management, documentation, and migration tooling as MCP servers and slash commands, so you can create a flag, plan a migration off another platform, or onboard a new workspace directly from your AI coding assistant's chat.
+
+## ⬇️ Installation
 
 ### Claude Code
 
@@ -12,15 +36,9 @@ claude plugin install confidence
 
 ### Cursor
 
-#### From the Marketplace
+**From the Marketplace:** open **Cursor Settings** → **Plugins**, search for **Confidence**, and click **Install**.
 
-1. Open **Cursor Settings** > **Plugins**
-2. Search for **Confidence**
-3. Click **Install**
-
-#### Manual setup
-
-Add the MCP servers to `.cursor/mcp.json` in your project (or `~/.cursor/mcp.json` globally):
+**Manual setup**: add the MCP servers to `.cursor/mcp.json` in your project (or `~/.cursor/mcp.json` globally):
 
 ```json
 {
@@ -57,26 +75,24 @@ git clone https://github.com/spotify/confidence-ai-plugins.git
 claude --plugin-dir ./confidence-ai-plugins
 ```
 
-## Features
+### Skills only, any agent
 
-This plugin provides access to Confidence tools across these categories:
+The migration and onboarding **skills** can also be installed individually via the [skills CLI](https://github.com/vercel-labs/skills), which supports Claude Code, Cursor, Codex, Gemini CLI, and 70+ other agents:
 
-- **Feature flags** — Create, list, update, archive, resolve, and target feature flags
-- **Documentation** — Search Confidence docs and SDK integration guides
-- **Migration** — Migrate feature flags from PostHog, Eppo, Statsig, or Optimizely to Confidence
+```bash
+npx skills add spotify/confidence-ai-plugins
+```
 
-## Slash Commands
+This installs only the skill logic (auto-triggering guidance for migrations and onboarding). It does **not** configure the `confidence-flags`/`confidence-docs` MCP servers or the `/confidence:*` slash commands, even when targeting one of the four clients above. Since several skills call into those MCP servers to manage flags, use one of the full installs above for complete functionality; use this only if you want the skill guidance on an agent the full installs don't support.
 
-- `/confidence:migrate-posthog` — [Migrate feature flags from PostHog to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-posthog)
-- `/confidence:migrate-eppo` — [Migrate feature flags from Eppo to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-eppo)
-- `/confidence:migrate-statsig` — [Migrate feature flags from Statsig to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-statsig)
-- `/confidence:migrate-optimizely` — [Migrate feature flags from Optimizely Feature Experimentation to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-optimizely)
+## 🚀 Usage
 
-## Example Usage
+Once installed, just ask your assistant:
 
 ```
 > List my feature flags
 > Create a flag called new-checkout with a boolean schema
+> /confidence:onboard-confidence create-account
 > /confidence:migrate-posthog plan flag
 > /confidence:migrate-posthog plan code
 > /confidence:migrate-eppo plan flag
@@ -86,6 +102,23 @@ This plugin provides access to Confidence tools across these categories:
 > /confidence:migrate-optimizely plan flags
 > /confidence:migrate-optimizely plan code
 ```
+
+## Features
+
+This plugin provides access to Confidence tools across these categories:
+
+- **Feature flags**: Create, list, update, archive, resolve, and target feature flags
+- **Onboarding**: Create accounts, invite users, set up SDK clients, configure warehouses, and learn experimentation concepts
+- **Documentation**: Search Confidence docs and SDK integration guides
+- **Migration**: Migrate feature flags from PostHog, Eppo, Statsig, or Optimizely to Confidence
+
+## Slash Commands
+
+- `/confidence:onboard-confidence <create-account | invite-user | create-client | setup-wizard | setup-warehouse | learn | status>`: Create accounts, onboard users, set up SDK clients, configure warehouses, and learn experimentation concepts
+- `/confidence:migrate-posthog <plan flag | plan code | execute <plan-file>>`: [Migrate feature flags from PostHog to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-posthog)
+- `/confidence:migrate-eppo <plan flag | plan code | execute <plan-file>>`: [Migrate feature flags from Eppo to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-eppo)
+- `/confidence:migrate-statsig <plan flag | plan code | execute <plan-file>>`: [Migrate feature flags from Statsig to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-statsig)
+- `/confidence:migrate-optimizely <plan flags | plan code | execute <plan-file>>`: [Migrate feature flags from Optimizely Feature Experimentation to Confidence](https://confidence.spotify.com/docs/migrations/migrate-from-optimizely)
 
 ## MCP Servers
 
@@ -105,6 +138,14 @@ This plugin provides access to Confidence tools across these categories:
 
 ## Documentation
 
-- [Confidence documentation](https://confidence.spotify.com/docs)
-- [Migration guides — migrate to Confidence from PostHog, Eppo, Statsig, or Optimizely](https://confidence.spotify.com/docs/migrations/overview)
+- [Confidence documentation](https://confidence.spotify.com/docs/introduction)
+- [Migration guides: migrate to Confidence from PostHog, Eppo, Statsig, or Optimizely](https://confidence.spotify.com/docs/migrations/overview)
 - [OpenFeature SDK integration](https://confidence.spotify.com/docs/sdks)
+
+## 💭 Community & Support
+
+Found a bug or have a feature request? [Open an issue](https://github.com/spotify/confidence-ai-plugins/issues). Changes are tracked in the [changelog](./CHANGELOG.md).
+
+## License
+
+[Apache License 2.0](./LICENSE)


### PR DESCRIPTION
Applies README best-practice guidance (highlights section, visual header, license/community sections), fixes the onboard-confidence command and its whole feature category being missing from Features, Slash Commands, and Example Usage, and documents npx skills add as a skills-only install path (supports the four official clients too, but without MCP servers or slash commands). Links the Confidence introduction page in Documentation.