### PR TITLE
feat: enrich telemetry with progress fields, honest sentiment, and error tracking

### DIFF
--- a/skills/analyze-project/SKILL.md
+++ b/skills/analyze-project/SKILL.md
@@ -46,7 +46,12 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "step": "<PHASE>.<STEP_TITLE>",
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
-        "completion": "<COMPLETION>"
+        "completion": "<COMPLETION>",
+        "candidates_found": "<NUMBER>",
+        "flags_proposed": "<NUMBER>",
+        "flags_implemented": "<NUMBER>",
+        "existing_provider": "<PROVIDER_NAME_OR_EMPTY>",
+        "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
       "event_time": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     }],
@@ -60,8 +65,13 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `step`       | `<phase>.<step-title>`, e.g. `analyze.scan-project`, `analyze.check-providers`, `analyze.identify-candidates`, `analyze.lookup-docs`, `propose.present-flags`, `implement.setup-sdk`, `implement.create-flag`, `implement.integrate-code`, `implement.verify-build`, `implement.generate-report` |
 | `action`     | Verb describing the operation: `scan_project`, `detect_framework`, `check_providers`, `scan_codebase`, `identify_candidates`, `lookup_docs`, `present_proposal`, `setup_client`, `create_flag`, `add_targeting`, `install_sdk`, `integrate_code`, `verify_build`, `generate_report`              |
-| `sentiment`  | Assess the conversation: `positive` (smooth, engaged), `neutral` (normal), `confused` (retries, questions, errors), `frustrated` (repeated failures, complaints)                                                                                                                                 |
+| `sentiment`  | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished)                                                                                                                                                                                  |
+| `candidates_found` | Number of flag candidate insertion points identified in the codebase |
+| `flags_proposed` | Number of flag proposals presented to the user |
+| `flags_implemented` | Cumulative count of flags the user accepted and that were implemented |
+| `existing_provider` | Name of existing flag provider found (e.g. `posthog`, `statsig`, `optimizely`, `eppo`), or empty if none |
+| `errors` | Comma-separated summary of recent errors (e.g. `mcp_unavailable,build_failed`), or empty if none |
 
 **Rules:**
 
@@ -71,6 +81,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - Always use `eu` as the region for events:publish (no token-based region detection)
 - Never re-try failed telemetry calls
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
+- **Sentiment must be honest** — if the user hit build failures, if MCP tools weren't available, if there were retries, reflect that. A static "positive" on every event is useless telemetry
 
 ---
 

--- a/skills/analyze-project/SKILL.md
+++ b/skills/analyze-project/SKILL.md
@@ -21,8 +21,9 @@ The skill sends telemetry events to track progress, user sentiment, and completi
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -30,6 +31,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after each significant step** (or batched at the end of each step), send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 
@@ -47,6 +55,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "candidates_found": "<NUMBER>",
         "flags_proposed": "<NUMBER>",
         "flags_implemented": "<NUMBER>",
@@ -67,6 +76,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 | `action`     | Verb describing the operation: `scan_project`, `detect_framework`, `check_providers`, `scan_codebase`, `identify_candidates`, `lookup_docs`, `present_proposal`, `setup_client`, `create_flag`, `add_targeting`, `install_sdk`, `integrate_code`, `verify_build`, `generate_report`              |
 | `sentiment`  | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished)                                                                                                                                                                                  |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `candidates_found` | Number of flag candidate insertion points identified in the codebase |
 | `flags_proposed` | Number of flag proposals presented to the user |
 | `flags_implemented` | Cumulative count of flags the user accepted and that were implemented |
@@ -76,6 +86,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 **Rules:**
 
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - Use `&` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Always use `eu` as the region for events:publish (no token-based region detection)

--- a/skills/migrate-eppo/SKILL.md
+++ b/skills/migrate-eppo/SKILL.md
@@ -48,8 +48,9 @@ The skill sends telemetry events to track migration progress, user sentiment, an
 
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -57,6 +58,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after EVERY batch, step, or user interaction**, send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
@@ -73,6 +81,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "flags_created": "<NUMBER>",
         "flags_remaining": "<NUMBER>",
         "flags_failed": "<NUMBER>",
@@ -93,6 +102,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 | `action` | Verb describing the operation: `scan_flags`, `generate_plan`, `scan_codebase`, `fetch_sdk_guide`, `create_flag`, `add_targeting`, `transform_code`, `create_pr` |
 | `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, mapping errors, unexpected responses), `frustrated` (user expressed frustration, repeated failures, user corrections). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `flags_created` | Cumulative count of flags successfully created so far in this execution |
 | `flags_remaining` | How many flags are left to process |
 | `flags_failed` | Cumulative count of flags that failed during this execution |
@@ -101,6 +111,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - **Send telemetry after EVERY batch** — every flag creation, every targeting rule addition, every project completion. Not just "significant steps"
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends

--- a/skills/migrate-eppo/SKILL.md
+++ b/skills/migrate-eppo/SKILL.md
@@ -58,7 +58,7 @@ d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
 
-**Sending events — after each significant step** (or batched at the end of each step), send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
+**Sending events — after EVERY batch, step, or user interaction**, send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
 curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
   -H "Content-Type: application/json" \
@@ -72,7 +72,12 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "step": "<PHASE>.<STEP_TITLE>",
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
-        "completion": "<COMPLETION>"
+        "completion": "<COMPLETION>",
+        "flags_created": "<NUMBER>",
+        "flags_remaining": "<NUMBER>",
+        "flags_failed": "<NUMBER>",
+        "batch_size": "<NUMBER>",
+        "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
       "event_time": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     }],
@@ -86,14 +91,23 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 |-------|--------------|
 | `step` | `<phase>.<step-title>`, e.g. `plan-flags.scan-source`, `plan-flags.generate-plan`, `plan-code.scan-codebase`, `plan-code.fetch-sdk-guide`, `execute.create-flag`, `execute.transform-code` |
 | `action` | Verb describing the operation: `scan_flags`, `generate_plan`, `scan_codebase`, `fetch_sdk_guide`, `create_flag`, `add_targeting`, `transform_code`, `create_pr` |
-| `sentiment` | Assess the conversation: `positive` (smooth, engaged), `neutral` (normal), `confused` (retries, questions, errors), `frustrated` (repeated failures, complaints) |
+| `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, mapping errors, unexpected responses), `frustrated` (user expressed frustration, repeated failures, user corrections). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `flags_created` | Cumulative count of flags successfully created so far in this execution |
+| `flags_remaining` | How many flags are left to process |
+| `flags_failed` | Cumulative count of flags that failed during this execution |
+| `batch_size` | Number of items in the current batch operation |
+| `errors` | Comma-separated summary of recent errors (e.g. `quota_exceeded,variant_mismatch`), or empty if none |
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Send telemetry after EVERY batch** — every flag creation, every targeting rule addition, every project completion. Not just "significant steps"
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Migration skills always use `eu` as the region for events:publish (no token-based region detection)
+- Never re-try failed telemetry calls
+- Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
+- **Sentiment must be honest** — if the user said something frustrated, if there were errors, if you had to retry, reflect that. A static "positive" on every event is useless telemetry
 - Never re-try failed telemetry calls
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -48,8 +48,9 @@ The skill sends telemetry events to track migration progress, user sentiment, an
 
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -57,6 +58,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after EVERY batch, step, or user interaction**, send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
@@ -73,6 +81,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "flags_created": "<NUMBER>",
         "flags_remaining": "<NUMBER>",
         "flags_failed": "<NUMBER>",
@@ -95,6 +104,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 | `action` | Verb describing the operation: `scan_flags`, `generate_plan`, `scan_codebase`, `fetch_sdk_guide`, `batch_create_flags`, `batch_add_targeting`, `resolve_flag`, `transform_code`, `create_pr` |
 | `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, mapping errors, unexpected responses), `frustrated` (user expressed frustration, repeated failures, user corrections like "i am baffled"). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `flags_created` | Cumulative count of flags successfully created so far in this execution |
 | `flags_remaining` | How many flags are left to process |
 | `flags_failed` | Cumulative count of flags that failed during this execution |
@@ -105,6 +115,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - **Send telemetry after EVERY batch** — every `batchCreateFlags` call, every `batchAddTargetingRules` call, every project completion. Not just "significant steps"
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends

--- a/skills/migrate-posthog/SKILL.md
+++ b/skills/migrate-posthog/SKILL.md
@@ -55,7 +55,7 @@ d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
 
-**Sending events — after each significant step** (or batched at the end of each step), send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
+**Sending events — after EVERY batch, step, or user interaction**, send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
 curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
   -H "Content-Type: application/json" \
@@ -69,7 +69,12 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "step": "<PHASE>.<STEP_TITLE>",
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
-        "completion": "<COMPLETION>"
+        "completion": "<COMPLETION>",
+        "flags_created": "<NUMBER>",
+        "flags_remaining": "<NUMBER>",
+        "flags_failed": "<NUMBER>",
+        "batch_size": "<NUMBER>",
+        "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
       "event_time": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     }],
@@ -83,16 +88,23 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 |-------|--------------|
 | `step` | `<phase>.<step-title>`, e.g. `plan-flags.scan-source`, `plan-flags.generate-plan`, `plan-code.scan-codebase`, `plan-code.fetch-sdk-guide`, `execute.create-flag`, `execute.transform-code` |
 | `action` | Verb describing the operation: `scan_flags`, `generate_plan`, `scan_codebase`, `fetch_sdk_guide`, `create_flag`, `add_targeting`, `transform_code`, `create_pr` |
-| `sentiment` | Assess the conversation: `positive` (smooth, engaged), `neutral` (normal), `confused` (retries, questions, errors), `frustrated` (repeated failures, complaints) |
+| `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, mapping errors, unexpected responses), `frustrated` (user expressed frustration, repeated failures, user corrections). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `flags_created` | Cumulative count of flags successfully created so far in this execution |
+| `flags_remaining` | How many flags are left to process |
+| `flags_failed` | Cumulative count of flags that failed during this execution |
+| `batch_size` | Number of items in the current batch operation |
+| `errors` | Comma-separated summary of recent errors (e.g. `quota_exceeded,variant_mismatch`), or empty if none |
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Send telemetry after EVERY batch** — every flag creation, every targeting rule addition, every project completion. Not just "significant steps"
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Migration skills always use `eu` as the region for events:publish (no token-based region detection)
 - Never re-try failed telemetry calls
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
+- **Sentiment must be honest** — if the user said something frustrated, if there were errors, if you had to retry, reflect that. A static "positive" on every event is useless telemetry
 
 ---
 

--- a/skills/migrate-posthog/SKILL.md
+++ b/skills/migrate-posthog/SKILL.md
@@ -45,8 +45,9 @@ The skill sends telemetry events to track migration progress, user sentiment, an
 
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -54,6 +55,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after EVERY batch, step, or user interaction**, send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
@@ -70,6 +78,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "flags_created": "<NUMBER>",
         "flags_remaining": "<NUMBER>",
         "flags_failed": "<NUMBER>",
@@ -90,6 +99,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 | `action` | Verb describing the operation: `scan_flags`, `generate_plan`, `scan_codebase`, `fetch_sdk_guide`, `create_flag`, `add_targeting`, `transform_code`, `create_pr` |
 | `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, mapping errors, unexpected responses), `frustrated` (user expressed frustration, repeated failures, user corrections). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `flags_created` | Cumulative count of flags successfully created so far in this execution |
 | `flags_remaining` | How many flags are left to process |
 | `flags_failed` | Cumulative count of flags that failed during this execution |
@@ -98,6 +108,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - **Send telemetry after EVERY batch** — every flag creation, every targeting rule addition, every project completion. Not just "significant steps"
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -48,8 +48,9 @@ The skill sends telemetry events to track migration progress, user sentiment, an
 
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -57,6 +58,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after EVERY batch, step, or user interaction**, send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
@@ -73,6 +81,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "flags_created": "<NUMBER>",
         "flags_remaining": "<NUMBER>",
         "flags_failed": "<NUMBER>",
@@ -93,6 +102,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 | `action` | Verb describing the operation: `scan_flags`, `generate_plan`, `scan_codebase`, `fetch_sdk_guide`, `create_flag`, `add_targeting`, `transform_code`, `create_pr` |
 | `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, mapping errors, unexpected responses), `frustrated` (user expressed frustration, repeated failures, user corrections). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `flags_created` | Cumulative count of flags successfully created so far in this execution |
 | `flags_remaining` | How many flags are left to process |
 | `flags_failed` | Cumulative count of flags that failed during this execution |
@@ -101,6 +111,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - **Send telemetry after EVERY batch** — every flag creation, every targeting rule addition, every project completion. Not just "significant steps"
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -58,7 +58,7 @@ d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
 
-**Sending events — after each significant step** (or batched at the end of each step), send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
+**Sending events — after EVERY batch, step, or user interaction**, send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
 curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
   -H "Content-Type: application/json" \
@@ -72,7 +72,12 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "step": "<PHASE>.<STEP_TITLE>",
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
-        "completion": "<COMPLETION>"
+        "completion": "<COMPLETION>",
+        "flags_created": "<NUMBER>",
+        "flags_remaining": "<NUMBER>",
+        "flags_failed": "<NUMBER>",
+        "batch_size": "<NUMBER>",
+        "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
       "event_time": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     }],
@@ -86,14 +91,23 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 |-------|--------------|
 | `step` | `<phase>.<step-title>`, e.g. `plan-flags.scan-source`, `plan-flags.generate-plan`, `plan-code.scan-codebase`, `plan-code.fetch-sdk-guide`, `execute.create-flag`, `execute.transform-code` |
 | `action` | Verb describing the operation: `scan_flags`, `generate_plan`, `scan_codebase`, `fetch_sdk_guide`, `create_flag`, `add_targeting`, `transform_code`, `create_pr` |
-| `sentiment` | Assess the conversation: `positive` (smooth, engaged), `neutral` (normal), `confused` (retries, questions, errors), `frustrated` (repeated failures, complaints) |
+| `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, mapping errors, unexpected responses), `frustrated` (user expressed frustration, repeated failures, user corrections). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `flags_created` | Cumulative count of flags successfully created so far in this execution |
+| `flags_remaining` | How many flags are left to process |
+| `flags_failed` | Cumulative count of flags that failed during this execution |
+| `batch_size` | Number of items in the current batch operation |
+| `errors` | Comma-separated summary of recent errors (e.g. `quota_exceeded,variant_mismatch`), or empty if none |
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Send telemetry after EVERY batch** — every flag creation, every targeting rule addition, every project completion. Not just "significant steps"
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Migration skills always use `eu` as the region for events:publish (no token-based region detection)
+- Never re-try failed telemetry calls
+- Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
+- **Sentiment must be honest** — if the user said something frustrated, if there were errors, if you had to retry, reflect that. A static "positive" on every event is useless telemetry
 - Never re-try failed telemetry calls
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 

--- a/skills/onboard-confidence-dry-run/SKILL.md
+++ b/skills/onboard-confidence-dry-run/SKILL.md
@@ -36,8 +36,9 @@ The skill sends telemetry events to track dry-run usage, user sentiment, and com
 
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -45,6 +46,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after each significant step** (or batched at the end of each step), send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
@@ -61,6 +69,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "accounts_created": "<NUMBER>",
         "clients_created": "<NUMBER>",
         "flags_created": "<NUMBER>",
@@ -80,6 +89,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 | `action` | Verb describing the operation: `login`, `check_availability`, `create_account`, `create_client`, `create_flag`, `add_targeting`, `resolve_flag`, `choose_warehouse`, `collect_config` |
 | `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `accounts_created` | Cumulative count of (dry-run) accounts created in this session |
 | `clients_created` | Cumulative count of (dry-run) SDK clients created |
 | `flags_created` | Cumulative count of (dry-run) flags created |
@@ -88,6 +98,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 **Rules:**
 - Telemetry is the ONE exception to the "no real network calls" dry-run rule — it uses `dangerouslyDisableSandbox: true` for telemetry setup and event sends only
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Always use `eu` as the region for events:publish

--- a/skills/onboard-confidence-dry-run/SKILL.md
+++ b/skills/onboard-confidence-dry-run/SKILL.md
@@ -60,7 +60,11 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
         "step": "<SUB_COMMAND>.<STEP_TITLE>",
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
-        "completion": "<COMPLETION>"
+        "completion": "<COMPLETION>",
+        "accounts_created": "<NUMBER>",
+        "clients_created": "<NUMBER>",
+        "flags_created": "<NUMBER>",
+        "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
       "event_time": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     }],
@@ -74,8 +78,12 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 |-------|--------------|
 | `step` | `<sub-command>.<step-title>`, e.g. `create-account.login`, `create-account.workspace-name`, `setup-wizard.create-flag`, `setup-warehouse-bigquery.collect-config` |
 | `action` | Verb describing the operation: `login`, `check_availability`, `create_account`, `create_client`, `create_flag`, `add_targeting`, `resolve_flag`, `choose_warehouse`, `collect_config` |
-| `sentiment` | Assess the conversation: `positive` (smooth, engaged), `neutral` (normal), `confused` (retries, questions, errors), `frustrated` (repeated failures, complaints) |
+| `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `accounts_created` | Cumulative count of (dry-run) accounts created in this session |
+| `clients_created` | Cumulative count of (dry-run) SDK clients created |
+| `flags_created` | Cumulative count of (dry-run) flags created |
+| `errors` | Comma-separated summary of recent errors, or empty if none |
 
 **Rules:**
 - Telemetry is the ONE exception to the "no real network calls" dry-run rule — it uses `dangerouslyDisableSandbox: true` for telemetry setup and event sends only
@@ -85,6 +93,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - Always use `eu` as the region for events:publish
 - Never re-try failed telemetry calls
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
+- **Sentiment must be honest** — if the dry-run surfaced confusion, errors, or retries, reflect that. A static "positive" on every event is useless telemetry
 
 ---
 

--- a/skills/onboard-confidence/SKILL.md
+++ b/skills/onboard-confidence/SKILL.md
@@ -161,8 +161,9 @@ The skill sends telemetry events to track onboarding progress, user sentiment, a
 
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -170,6 +171,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after each API call** (or batched at the end of each step), send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
@@ -186,6 +194,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "accounts_created": "<NUMBER>",
         "clients_created": "<NUMBER>",
         "flags_created": "<NUMBER>",
@@ -206,6 +215,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 | `action` | Verb describing the API call: `login`, `check_availability`, `create_account`, `create_client`, `create_flag`, `add_targeting`, `resolve_flag`, `send_invitation` |
 | `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `accounts_created` | Cumulative count of accounts created in this session |
 | `clients_created` | Cumulative count of SDK clients created |
 | `flags_created` | Cumulative count of flags created during setup wizard |
@@ -214,6 +224,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action (e.g., before the login browser opens)
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default

--- a/skills/onboard-confidence/SKILL.md
+++ b/skills/onboard-confidence/SKILL.md
@@ -185,7 +185,12 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
         "step": "<SUB_COMMAND>.<STEP_TITLE>",
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
-        "completion": "<COMPLETION>"
+        "completion": "<COMPLETION>",
+        "accounts_created": "<NUMBER>",
+        "clients_created": "<NUMBER>",
+        "flags_created": "<NUMBER>",
+        "invitations_sent": "<NUMBER>",
+        "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
       "event_time": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     }],
@@ -199,8 +204,13 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 |-------|--------------|
 | `step` | `<sub-command>.<step-title>`, e.g. `create-account.login`, `setup-wizard.create-flag`, `setup-wizard.test-resolve` |
 | `action` | Verb describing the API call: `login`, `check_availability`, `create_account`, `create_client`, `create_flag`, `add_targeting`, `resolve_flag`, `send_invitation` |
-| `sentiment` | Assess the conversation: `positive` (smooth, engaged), `neutral` (normal), `confused` (retries, questions, errors), `frustrated` (repeated failures, complaints) |
+| `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `accounts_created` | Cumulative count of accounts created in this session |
+| `clients_created` | Cumulative count of SDK clients created |
+| `flags_created` | Cumulative count of flags created during setup wizard |
+| `invitations_sent` | Cumulative count of user invitations sent |
+| `errors` | Comma-separated summary of recent errors (e.g. `account_exists,email_unverified,token_expired`), or empty if none |
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action (e.g., before the login browser opens)
@@ -209,6 +219,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default
 - Never re-try failed telemetry calls
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
+- **Sentiment must be honest** — if the user hit login issues, if account creation failed, if there were retries, reflect that. A static "positive" on every event is useless telemetry
 
 ---
 

--- a/skills/setup-warehouse/SKILL.md
+++ b/skills/setup-warehouse/SKILL.md
@@ -43,8 +43,9 @@ The skill sends telemetry events to track warehouse setup progress, user sentime
 
 **Setup — at the very start of every skill invocation**, in a single `dangerouslyDisableSandbox: true` Bash call:
 ```bash
-# Generate session ID and acquire telemetry key
+# Generate session ID, acquire telemetry key, and initialize step timer
 SID=$(uuidgen) && echo "$SID" > "$TMPDIR/confidence_session_id" && \
+date +%s > "$TMPDIR/confidence_step_start" && \
 curl -s -X POST "https://onboarding.confidence.dev/v1/agentTelemetryKey:acquire" \
   -H "Content-Type: application/json" \
   -d '{"session_id": "'$SID'"}' | python3 -c "
@@ -52,6 +53,13 @@ import sys, json
 d = json.loads(sys.stdin.read())
 print(d.get('clientSecret', d.get('client_secret', '')))" > "$TMPDIR/confidence_telemetry_key"
 ```
+
+**Step timing — at the START of each new step**, reset the timer:
+```bash
+date +%s > "$TMPDIR/confidence_step_start"
+```
+
+Combine this with the first action of the step (e.g. a curl or MCP call) to avoid an extra tool call.
 
 **Sending events — after each significant step** (or batched at the end of each step), send a telemetry event. Combine with other curl calls in the same Bash invocation when possible to avoid extra tool calls:
 ```bash
@@ -68,6 +76,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
         "completion": "<COMPLETION>",
+        "step_duration_s": "'$(( $(date +%s) - $(cat $TMPDIR/confidence_step_start) ))'",
         "warehouse_type": "<WAREHOUSE_TYPE_OR_EMPTY>",
         "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
@@ -85,11 +94,13 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 | `action` | Verb describing the operation: `choose_warehouse`, `handoff`, `validate_config`, `create_warehouse` |
 | `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `step_duration_s` | Automatically calculated: seconds elapsed since the step timer was last reset. Do not set manually — the shell expression in the curl template computes it |
 | `warehouse_type` | Type of warehouse selected: `bigquery`, `snowflake`, `databricks`, `redshift`, or empty if not yet chosen |
 | `errors` | Comma-separated summary of recent errors (e.g. `validation_failed,connection_timeout`), or empty if none |
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
+- **Reset the step timer** (`date +%s > "$TMPDIR/confidence_step_start"`) at the start of each new step — combine with the step's first action to avoid extra tool calls
 - Use `& ` (background) or `> /dev/null 2>&1` on telemetry curls so they never block the flow
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default

--- a/skills/setup-warehouse/SKILL.md
+++ b/skills/setup-warehouse/SKILL.md
@@ -67,7 +67,9 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
         "step": "<SUB_COMMAND>.<STEP_TITLE>",
         "action": "<ACTION_VERB>",
         "sentiment": "<SENTIMENT>",
-        "completion": "<COMPLETION>"
+        "completion": "<COMPLETION>",
+        "warehouse_type": "<WAREHOUSE_TYPE_OR_EMPTY>",
+        "errors": "<COMMA_SEPARATED_ERROR_SUMMARIES_OR_EMPTY>"
       },
       "event_time": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
     }],
@@ -80,9 +82,11 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 | Field | How to set it |
 |-------|--------------|
 | `step` | `<sub-command>.<step-title>`, e.g. `setup.choose-warehouse`, `setup.handoff-bigquery` |
-| `action` | Verb describing the operation: `choose_warehouse`, `handoff` |
-| `sentiment` | Assess the conversation: `positive` (smooth, engaged), `neutral` (normal), `confused` (retries, questions, errors), `frustrated` (repeated failures, complaints) |
+| `action` | Verb describing the operation: `choose_warehouse`, `handoff`, `validate_config`, `create_warehouse` |
+| `sentiment` | **Genuinely assess the conversation tone** — not a static value. `positive` (smooth, user engaged, no issues), `neutral` (normal flow), `confused` (retries, questions, errors), `frustrated` (user expressed frustration, repeated failures, complaints). Read the user's actual words and your own error rate to set this honestly. |
 | `completion` | Progress state: `starting` (first steps), `in_progress` (middle), `completing` (final steps), `done` (finished) |
+| `warehouse_type` | Type of warehouse selected: `bigquery`, `snowflake`, `databricks`, `redshift`, or empty if not yet chosen |
+| `errors` | Comma-separated summary of recent errors (e.g. `validation_failed,connection_timeout`), or empty if none |
 
 **Rules:**
 - Send the telemetry setup call BEFORE the first user-visible action
@@ -91,6 +95,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default
 - Never re-try failed telemetry calls
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
+- **Sentiment must be honest** — if validation failed, if the user was confused about credentials, reflect that. A static "positive" on every event is useless telemetry
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the telemetry gaps identified. All 7 skills now emit richer, more consistent events:

- **Migration skills** (posthog, eppo, statsig) gain progress counters (`flags_created`, `flags_remaining`, `flags_failed`, `batch_size`, `errors`) — matching what migrate-optimizely already had
- **analyze-project** gains `candidates_found`, `flags_proposed`, `flags_implemented`, `existing_provider`, `errors`
- **onboard-confidence** (+ dry-run) gains `accounts_created`, `clients_created`, `flags_created`, `invitations_sent`, `errors`
- **setup-warehouse** gains `warehouse_type`, `errors`
- **All skills** now enforce honest sentiment assessment (explicit instructions that static "positive" is useless telemetry)
- **Migration skills** send events after every batch operation, not just "significant steps"

These fields enable building funnel visualizations, error tracking dashboards, and per-skill conversion analytics in the Confidence warehouse — groundwork for a Braintrust-like observability dashboard in epx-backoffice.

## Test plan

- [ ] Verify event definition `eventDefinitions/agent-telemetry` accepts the new payload fields (flexible schema)
- [ ] Run `/migrate-posthog plan flags` and confirm telemetry events include `flags_created`, `flags_remaining`, etc.
- [ ] Run `/analyze-project` and confirm events include `candidates_found`, `existing_provider`
- [ ] Spot-check sentiment values across a session with errors — should show `confused`/`frustrated`, not static `positive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)