### PR TITLE
fix: remove automatic eval run on push to main

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,18 +1,8 @@
 name: Evals
 
-# PR runs are intentionally disabled — each full run costs real model
-# credits. Run evals locally with a Hendrix key (see evals/README.md),
-# or trigger this workflow manually. The push-to-main run keeps a
-# canonical baseline in Braintrust.
+# Run evals locally with a Hendrix key (see evals/README.md),
+# or trigger this workflow manually via workflow_dispatch.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'skills/migrate-optimizely/**'
-      - 'skills/migrate-posthog/**'
-      - 'skills/migrate-eppo/**'
-      - 'skills/migrate-statsig/**'
-      - 'evals/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Remove the `push` trigger from the evals workflow — it runs on every merge to main and fails because required secrets aren't available in this repo context
- Keep `workflow_dispatch` so evals can still be triggered manually when needed

## Test plan
- [ ] Verify the workflow no longer triggers on push to main
- [ ] Verify manual dispatch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)