### PR TITLE
feat: onboarding skill evals — single-turn + multi-turn with mocked tools

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,10 +1,12 @@
 # Skill Evals
 
 Automated quality evaluation for the migration skills (`migrate-optimizely`,
-`migrate-posthog`, `migrate-eppo`, `migrate-statsig`). Each eval sends a
-skill's full `SKILL.md` as the system prompt plus a source-platform flag
-definition, and scores the model's response on 8 dimensions. Results are
-logged to Braintrust (project **Confidence ai plugins** on
+`migrate-posthog`, `migrate-eppo`, `migrate-statsig`) and the onboarding
+skills (`onboard-confidence`, `setup-warehouse`, `setup-warehouse-bigquery`).
+Each single-turn eval sends a skill's full `SKILL.md` as the system prompt
+plus one case message and scores the model's response; multi-turn evals run
+scripted conversations against mocked tools. Results are logged to
+Braintrust (project **Confidence ai plugins** on
 `braintrust.spotifyinternal.com`).
 
 ## Run it with a Hendrix key (recommended)
@@ -84,6 +86,72 @@ To add a case, drop a YAML file in the skill's directory — the loader picks
 it up automatically. Ground truth is hand-written; if the model disagrees
 with a case, check whether the case (or the skill) is wrong before assuming
 the model is.
+
+## Onboarding evals
+
+The onboarding skill acts through Bash (bundled `auth.py`, curl to REST
+endpoints), AskUserQuestion, and MCP tools — so its evals mock all three.
+
+### Single-turn (`onboard-confidence.eval.ts`, cases in `cases/onboard/`)
+
+Each case is one message (optionally with an `input.context` block holding a
+prior-state summary or a raw API error) answered with no tools. A footer
+(`lib/onboard-footer.ts`) forces a `Next step: <sub-command>.<step>` verdict
+line. Case schema:
+
+```yaml
+name: error-under-review-fraud
+tags: [error-interpretation]
+input:
+  context: |
+    (Conversation so far: ... the API responded: {"code":9,"message":"...flagged as suspicious."})
+  user_message: "So, is my account ready?"
+expected:
+  next_step_pattern: "^create-account"   # regex on the verdict line
+  response_includes: ["confidence-support@spotify.com"]  # all must appear
+  response_includes_any: ["flagged", "review"]           # at least one
+  response_excludes: ["verify your email", "code 9"]     # none in prose
+```
+
+| Scorer | Type | What it checks |
+|--------|------|----------------|
+| NextStep | deterministic | verdict line matches `next_step_pattern` |
+| ResponseContent | deterministic | includes / includes_any / excludes |
+| NoInternalLeak | deterministic | no Auth0 client IDs, JWTs, `Bearer`, org IDs, curl, telemetry mention (binary: any leak = 0) |
+| OnboardCommunication | LLM judge | plain-English status, no payloads/codes/internals |
+| OnboardEducateFirst | LLM judge | concept explained before asking for input |
+| OnboardStepTracker | LLM judge | step tracker present (cases tagged `interactive`) |
+
+### Multi-turn (`multi-turn/onboard-confidence.eval.ts`, cases in `cases/multi-turn/onboard/`)
+
+Scripted conversations against a mock harness (`multi-turn/onboard-tools.ts`):
+
+- **Bash** is regex-routed to canned outputs (auth script → mock JWT,
+  availability checks, account creation, telemetry endpoints, gcloud/bq).
+  Scenarios override per-command with `bash_responses` (consumed in order —
+  e.g. a 409 then a 200).
+- **AskUserQuestion** answers come from `ask_answers` — each entry's `match`
+  regex is tested against the question text, header, and option labels;
+  unmatched questions fall back to the first option with a warning.
+- **MCP tools** are mocked with in-memory state (clients, flags, warehouse);
+  `tool_responses` overrides any tool's results in order (e.g. a failing
+  `getIdentityInfo` before the user authenticates).
+- `skill:` selects the SKILL.md to load (`onboard-confidence`,
+  `setup-warehouse`, `setup-warehouse-bigquery`); `skills:` can list several
+  to concatenate (dispatcher + hand-off target).
+
+Telemetry is asserted, not skipped: happy-path scenarios check the telemetry
+key is acquired and events are published, and that telemetry is never
+mentioned in user-visible text. Scoring is `AssertionsPassed` (declarative
+assertions, including the new `tool_call_arg_not_contains`) plus a
+conversation-level `NoInternalLeak` LLM judge over all user-visible text.
+
+```bash
+npm run eval:onboard:local              # single-turn, Hendrix, no upload
+npm run eval:multi-turn:onboard:local   # multi-turn, Hendrix, no upload
+npm run eval:onboard                    # single-turn → Braintrust (onboard-single-turn-v1)
+npm run eval:multi-turn:onboard         # multi-turn → Braintrust (onboard-multi-turn-v1)
+```
 
 ## CI
 

--- a/evals/cases/multi-turn/onboard/create-account-happy.yaml
+++ b/evals/cases/multi-turn/onboard/create-account-happy.yaml
@@ -1,0 +1,80 @@
+name: create-account-happy-path
+description: >
+  Full create-account flow: signup auth with the signup client ID, workspace
+  name suggestions derived from the signup email, region/auth choices via
+  AskUserQuestion, admin email pre-filled from signup (not re-asked), account
+  created, then re-auth with the regular client ID + org. Telemetry runs
+  silently; the token never appears in user-visible text.
+skill: onboard-confidence
+tags: [multi-turn, create-account, telemetry, happy-path]
+
+conversation:
+  - "I'd like to create a new Confidence account for my company."
+  - "Let's use the workspace name acme."
+  - "Display name: Acme Inc"
+  - "The suggested admin email is fine, and no login domain restrictions."
+  - "Great, that's all — thanks!"
+
+ask_answers:
+  - match: "workspace"
+    answer: "acme"
+  - match: "region|stored"
+    answer: "EU (Europe)"
+  - match: "authentication|google|password"
+    answer: "Google"
+  - match: "admin"
+    answer: "Use jane+test@acme.com"
+  - match: "domain"
+    answer: "No restrictions"
+
+assertions:
+  # Telemetry contract: key acquired, events published, never mentioned.
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "agentTelemetryKey"
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "events:publish"
+  - type: text_not_contains
+    pattern: "telemetry"
+    case_sensitive: false
+  # Signup auth with the signup client, then userinfo for the email.
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "82qMvwZvqd3t3S0gRDvs8R53TehQXSJY"
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "userinfo"
+  # Workspace suggestions derived from jane+test@acme.com.
+  - type: text_contains
+    pattern: "jane"
+    case_sensitive: false
+  # Availability checked before creation.
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "loginIdAvailability"
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "/v1/accounts"
+  # Admin email pre-filled from the signup email.
+  - type: text_contains
+    pattern: "jane+test@acme.com"
+  # Re-auth with the regular client for the org-scoped token.
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w"
+  # Workspace confirmed to the user; no internals leaked.
+  - type: text_contains
+    pattern: "acme"
+    case_sensitive: false
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"
+  - type: text_not_contains
+    pattern: "org_mock123"

--- a/evals/cases/multi-turn/onboard/create-account-name-taken.yaml
+++ b/evals/cases/multi-turn/onboard/create-account-name-taken.yaml
@@ -1,0 +1,43 @@
+name: create-account-name-taken
+description: >
+  The chosen workspace name is taken (availability check returns false).
+  The skill must say so in plain English, suggest alternatives, re-check
+  the new name, and complete account creation.
+skill: onboard-confidence
+tags: [multi-turn, create-account, error-recovery]
+
+bash_responses:
+  - match: "loginIdAvailability"
+    responses:
+      - '{"available": false}'
+      - '{"available": true}'
+
+conversation:
+  - >
+    Create a Confidence account. Workspace name: acme. Display name:
+    Acme Inc. Region: EU. Login with Google. Admin email: jane+test@acme.com.
+    No domain restrictions.
+  - "OK, let's use acme-hq instead."
+  - "Yes, go ahead."
+
+ask_answers:
+  - match: "region|stored"
+    answer: "EU (Europe)"
+  - match: "authentication|google|password"
+    answer: "Google"
+
+assertions:
+  - type: text_contains
+    pattern: "taken|not available|unavailable|already in use"
+    regex: true
+    case_sensitive: false
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "acme-hq"
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "/v1/accounts"
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/create-account-under-review-fraud.yaml
+++ b/evals/cases/multi-turn/onboard/create-account-under-review-fraud.yaml
@@ -1,0 +1,49 @@
+name: create-account-under-review-fraud
+description: >
+  Account creation returns code 9 with a "flagged as suspicious" message.
+  The skill must NOT assume email verification — it must parse the actual
+  message, point the user to support, and not auto-retry.
+skill: onboard-confidence
+tags: [multi-turn, create-account, error-recovery, under-review, fraud]
+
+bash_responses:
+  - match: "/v1/accounts"
+    responses:
+      - |-
+        {"code":9,"message":"Account creation is under review: your account has been flagged as suspicious."}
+        400
+
+conversation:
+  - >
+    Create a Confidence account. Workspace name: acme. Display name:
+    Acme Inc. Region: EU. Login with Google. Admin email: jane+test@acme.com.
+    No domain restrictions.
+  - "Hmm, okay. What should I do now?"
+
+ask_answers:
+  - match: "region|stored"
+    answer: "EU (Europe)"
+  - match: "authentication|google|password"
+    answer: "Google"
+  - match: "proceed|retry|try again|support"
+    answer: "Not right now — I'll wait"
+
+assertions:
+  - type: text_contains
+    pattern: "confidence-support@spotify.com"
+  - type: text_contains
+    pattern: "flagged|review"
+    regex: true
+    case_sensitive: false
+  # Must not misdiagnose as the email-verification case.
+  - type: text_not_contains
+    pattern: "verify your email"
+    case_sensitive: false
+  - type: text_not_contains
+    pattern: "verification link"
+    case_sensitive: false
+  - type: text_not_contains
+    pattern: "code 9"
+    case_sensitive: false
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/create-account-under-review-verify.yaml
+++ b/evals/cases/multi-turn/onboard/create-account-under-review-verify.yaml
@@ -1,0 +1,49 @@
+name: create-account-under-review-verify
+description: >
+  Account creation returns code 9 with a "verify your email" message. The
+  skill must ask the user to verify (this IS the email-verification case),
+  wait for confirmation, then run the retry loop and succeed. No error
+  codes shown to the user.
+skill: onboard-confidence
+tags: [multi-turn, create-account, error-recovery, under-review]
+
+bash_responses:
+  - match: "/v1/accounts"
+    responses:
+      - |-
+        {"code":9,"message":"Account is under review: please verify your email address before continuing."}
+        400
+      - |-
+        ATTEMPT 1: HTTP=200
+        {"name":"accounts/acme-mock","externalId":"ext-123","loginId":"acme","displayName":"Acme Inc"}
+        SUCCESS
+
+conversation:
+  - >
+    Create a Confidence account. Workspace name: acme. Display name:
+    Acme Inc. Region: EU. Login with Google. Admin email: jane+test@acme.com.
+    No domain restrictions.
+  - "Done — I clicked the verification link in my email."
+  - "Thanks!"
+
+ask_answers:
+  - match: "region|stored"
+    answer: "EU (Europe)"
+  - match: "authentication|google|password"
+    answer: "Google"
+
+assertions:
+  - type: text_contains
+    pattern: "verif"
+    case_sensitive: false
+  - type: text_contains
+    pattern: "acme"
+    case_sensitive: false
+  - type: tool_called_count
+    tool_name: Bash
+    min_count: 2
+  - type: text_not_contains
+    pattern: "code 9"
+    case_sensitive: false
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/create-account-work-email.yaml
+++ b/evals/cases/multi-turn/onboard/create-account-work-email.yaml
@@ -1,0 +1,48 @@
+name: create-account-work-email-rejected
+description: >
+  The user supplies a free-provider admin email. Whether the skill catches
+  it upfront (the skill documents the work-email rule) or the API rejects
+  it, the user must get a plain-English explanation and the account must be
+  created once a work email is provided. No HTTP codes in prose.
+skill: onboard-confidence
+tags: [multi-turn, create-account, error-recovery]
+
+# Only reject requests that actually carry the free-provider email — a model
+# that catches the rule upfront and never sends it gets the default 200.
+bash_responses:
+  - match: 'jane@gmail\.com'
+    responses:
+      - |-
+        {"code":3,"message":"adminEmail must be a work email address; free email providers are not allowed"}
+        400
+
+conversation:
+  - >
+    Create a Confidence account. Workspace name: acme. Display name:
+    Acme Inc. Region: EU. Login with Google. Admin email: jane@gmail.com.
+    No domain restrictions.
+  - "Ah right — use jane@acme.com instead."
+  - "Perfect, thanks!"
+
+ask_answers:
+  - match: "region|stored"
+    answer: "EU (Europe)"
+  - match: "authentication|google|password"
+    answer: "Google"
+  # If the model catches the gmail address upfront and asks for a
+  # replacement before the user's second turn arrives:
+  - match: "admin|gmail|work email"
+    answer: "Use jane@acme.com"
+
+assertions:
+  - type: text_contains
+    pattern: "work email"
+    case_sensitive: false
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "jane@acme.com"
+  - type: text_not_contains
+    pattern: "400"
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/invite-user-batch.yaml
+++ b/evals/cases/multi-turn/onboard/invite-user-batch.yaml
@@ -1,0 +1,34 @@
+name: invite-user-batch
+description: >
+  Batch invitation with one invalid address. Valid emails get invited via
+  MCP; the invalid one is flagged in a summary. MCP is verified first.
+skill: onboard-confidence
+tags: [multi-turn, invite-user]
+
+conversation:
+  - "Invite alice@acme.com, bob@acme.com and charlie@invalid to my Confidence workspace."
+  - "Yes, send invitation emails."
+
+ask_answers:
+  - match: "invitation email|send"
+    answer: "Yes, send invitation emails"
+
+assertions:
+  - type: tool_called
+    tool_name: mcp__confidence_flags__getIdentityInfo
+  - type: tool_call_arg_contains
+    tool_name: mcp__confidence_flags__inviteUser
+    arg_name: email
+    pattern: "alice@acme.com"
+  - type: tool_call_arg_contains
+    tool_name: mcp__confidence_flags__inviteUser
+    arg_name: email
+    pattern: "bob@acme.com"
+  - type: text_contains
+    pattern: "alice@acme.com"
+  - type: text_contains
+    pattern: "bob@acme.com"
+  # The invalid address is surfaced (either caught locally or via the tool error).
+  - type: text_contains
+    pattern: "invalid"
+    case_sensitive: false

--- a/evals/cases/multi-turn/onboard/onboard-default-entry.yaml
+++ b/evals/cases/multi-turn/onboard/onboard-default-entry.yaml
@@ -1,0 +1,44 @@
+name: onboard-default-entry
+description: >
+  "Onboard me" must go straight to the create-vs-sign-in question via
+  AskUserQuestion — no menu of sub-commands, no "Setup Wizard" option —
+  and telemetry must be set up before the first user-visible action.
+skill: onboard-confidence
+tags: [multi-turn, routing, telemetry]
+
+conversation:
+  - "I want to get started with Confidence — onboard me."
+
+ask_answers:
+  - match: "create a new account|existing account"
+    answer: "Create a new account"
+
+assertions:
+  - type: tool_called
+    tool_name: AskUserQuestion
+  - type: tool_call_arg_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "create a new account"
+  - type: tool_call_arg_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "existing account"
+  - type: tool_call_arg_not_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "setup wizard"
+  - type: tool_call_arg_not_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "warehouse"
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "agentTelemetryKey"
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "82qMvwZvqd3t3S0gRDvs8R53TehQXSJY"
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/setup-warehouse-bigquery-happy.yaml
+++ b/evals/cases/multi-turn/onboard/setup-warehouse-bigquery-happy.yaml
@@ -1,0 +1,53 @@
+name: setup-warehouse-bigquery-happy
+description: >
+  BigQuery warehouse setup happy path: collect project/dataset/service
+  account, validate the config BEFORE creating, then create the warehouse,
+  both connectors, and the assignment table, in order. Telemetry runs
+  silently and nothing internal is shown.
+skill: setup-warehouse-bigquery
+tags: [multi-turn, setup-warehouse, bigquery, happy-path, telemetry]
+
+conversation:
+  - >
+    Set up BigQuery as my Confidence data warehouse. GCP project ID:
+    acme-data-prod. Dataset: confidence. Service account:
+    confidence-connector@acme-data-prod.iam.gserviceaccount.com.
+  - "Yes, proceed."
+  - "Looks good — you can skip the pipeline verification, finish up."
+
+ask_answers:
+  - match: "proceed|continue|create"
+    answer: "Yes, proceed"
+  - match: "verify|pipeline|skip"
+    answer: "Skip verification"
+
+assertions:
+  - type: tool_called
+    tool_name: mcp__confidence_flags__validateWarehouseConfig
+  - type: tool_call_arg_contains
+    tool_name: mcp__confidence_flags__validateWarehouseConfig
+    arg_name: configJson
+    pattern: "acme-data-prod"
+  - type: tool_called_before
+    first: mcp__confidence_flags__validateWarehouseConfig
+    second: mcp__confidence_flags__createWarehouse
+  - type: tool_called
+    tool_name: mcp__confidence_flags__createWarehouse
+  - type: tool_called
+    tool_name: mcp__confidence_flags__createFlagAppliedConnection
+  - type: tool_called
+    tool_name: mcp__confidence_flags__createEventConnection
+  - type: tool_called
+    tool_name: mcp__confidence_flags__createAssignmentTable
+  - type: tool_called_before
+    first: mcp__confidence_flags__createWarehouse
+    second: mcp__confidence_flags__createAssignmentTable
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "agentTelemetryKey"
+  - type: text_not_contains
+    pattern: "telemetry"
+    case_sensitive: false
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/setup-warehouse-dispatch.yaml
+++ b/evals/cases/multi-turn/onboard/setup-warehouse-dispatch.yaml
@@ -1,0 +1,45 @@
+name: setup-warehouse-dispatch
+description: >
+  The setup-warehouse dispatcher: verify MCP first, present the four
+  warehouse types via AskUserQuestion, and hand off to the BigQuery skill
+  when chosen. Telemetry runs silently.
+skill: setup-warehouse
+tags: [multi-turn, setup-warehouse, routing, telemetry]
+
+conversation:
+  - "I want to set up a data warehouse for Confidence."
+
+ask_answers:
+  - match: "warehouse|bigquery"
+    answer: "BigQuery"
+
+assertions:
+  - type: tool_called
+    tool_name: mcp__confidence_flags__getIdentityInfo
+  - type: tool_call_arg_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "BigQuery"
+  - type: tool_call_arg_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "Snowflake"
+  - type: tool_call_arg_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "Databricks"
+  - type: tool_call_arg_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "Redshift"
+  - type: text_contains
+    pattern: "starting bigquery|bigquery setup|set(ting)? up bigquery"
+    regex: true
+    case_sensitive: false
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "agentTelemetryKey"
+  - type: text_not_contains
+    pattern: "telemetry"
+    case_sensitive: false

--- a/evals/cases/multi-turn/onboard/setup-wizard-existing-account.yaml
+++ b/evals/cases/multi-turn/onboard/setup-wizard-existing-account.yaml
@@ -1,0 +1,75 @@
+name: setup-wizard-existing-account
+description: >
+  Full setup wizard with an existing account: sign-in via valid token, MCP
+  verified, client created with secret, flag created, context schema checked
+  BEFORE targeting (must use visitor_id, not assume user_id), flag resolved
+  to test it, summary shown, SDK integration offered via docs MCP.
+skill: onboard-confidence
+tags: [multi-turn, setup-wizard, happy-path, telemetry]
+
+conversation:
+  - "Run the Confidence setup wizard. I already have an account — I'm signed in."
+  - "done"
+  - "Call the client Web App."
+  - "Name the flag new-checkout-flow."
+  - "Thanks, that's everything!"
+
+ask_answers:
+  - match: "sign in|create a new account"
+    answer: "Sign in to an existing account"
+  - match: "client type|frontend|backend"
+    answer: "Frontend"
+  - match: "on/off|boolean|custom variant"
+    answer: "Simple on/off (boolean)"
+  - match: "default variant|which variant"
+    answer: "off"
+  - match: "integrate|invite|next step|more flags"
+    answer: "Integrate the SDK"
+  - match: "platform|javascript|python|swift"
+    answer: "JavaScript"
+
+assertions:
+  - type: tool_called
+    tool_name: mcp__confidence_flags__getIdentityInfo
+  - type: tool_called
+    tool_name: mcp__confidence_flags__listClients
+  - type: tool_called
+    tool_name: mcp__confidence_flags__createClient
+  - type: tool_called
+    tool_name: mcp__confidence_flags__getClientSecret
+  - type: tool_called
+    tool_name: mcp__confidence_flags__createFlag
+  - type: tool_call_arg_contains
+    tool_name: mcp__confidence_flags__createFlag
+    arg_name: flagName
+    pattern: "new-checkout-flow"
+  # The context schema must be consulted before targeting — and the rule must
+  # use the account's actual entity field (visitor_id), not an assumed user_id.
+  - type: tool_called_before
+    first: mcp__confidence_flags__getContextSchema
+    second: mcp__confidence_flags__addTargetingRule
+  - type: tool_call_arg_contains
+    tool_name: mcp__confidence_flags__addTargetingRule
+    arg_name: targetingKey
+    pattern: "visitor_id"
+  - type: tool_call_arg_not_contains
+    tool_name: mcp__confidence_flags__addTargetingRule
+    arg_name: targetingKey
+    pattern: "user_id"
+  - type: tool_called
+    tool_name: mcp__confidence_flags__resolveFlag
+  # The secret is expected in the final summary; the wizard offers SDK docs.
+  - type: text_contains
+    pattern: "mock-client-secret-abc123"
+  - type: tool_called
+    tool_name: mcp__confidence_docs__getCodeSnippetAndSdkIntegrationTips
+  # Telemetry runs silently.
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "agentTelemetryKey"
+  - type: text_not_contains
+    pattern: "telemetry"
+    case_sensitive: false
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/setup-wizard-mcp-not-connected.yaml
+++ b/evals/cases/multi-turn/onboard/setup-wizard-mcp-not-connected.yaml
@@ -1,0 +1,37 @@
+name: setup-wizard-mcp-not-connected
+description: >
+  The confidence-flags MCP is not authenticated at wizard step 2. The skill
+  must instruct the user to run /mcp, treat the user's next message as
+  confirmation (no extra questions), retry getIdentityInfo, and proceed.
+skill: onboard-confidence
+tags: [multi-turn, setup-wizard, error-recovery, mcp]
+
+tool_responses:
+  - tool: getIdentityInfo
+    responses:
+      - "Error: MCP server confidence-flags is not authenticated. The user must run /mcp and authenticate the server."
+      - '{"user":{"name":"users/mock-user","fullName":"Jane Doe","email":"jane+test@acme.com"},"account":"accounts/acme-mock","accountMemberships":[{"account":"accounts/acme-mock","displayName":"Acme Inc","loginId":"acme","region":"EU"}]}'
+
+conversation:
+  - "Run the Confidence setup wizard. I already have an account and I'm signed in."
+  - "done"
+  - "Call the client Web App, frontend type."
+
+ask_answers:
+  - match: "sign in|create a new account"
+    answer: "Sign in to an existing account"
+  - match: "client type|frontend|backend"
+    answer: "Frontend"
+  - match: "on/off|boolean|custom variant"
+    answer: "Simple on/off (boolean)"
+
+assertions:
+  - type: text_contains
+    pattern: "/mcp"
+  - type: tool_called_count
+    tool_name: mcp__confidence_flags__getIdentityInfo
+    min_count: 2
+  - type: tool_called
+    tool_name: mcp__confidence_flags__createClient
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/status-check.yaml
+++ b/evals/cases/multi-turn/onboard/status-check.yaml
@@ -1,0 +1,24 @@
+name: status-check
+description: >
+  Status is a lightweight command: it must use MCP (getIdentityInfo +
+  listClients) and display identity and account in a readable summary,
+  without leaking org IDs or tokens.
+skill: onboard-confidence
+tags: [multi-turn, status]
+
+conversation:
+  - "What's my Confidence account status?"
+
+assertions:
+  - type: tool_called
+    tool_name: mcp__confidence_flags__getIdentityInfo
+  - type: tool_called
+    tool_name: mcp__confidence_flags__listClients
+  - type: text_contains
+    pattern: "Acme Inc"
+  - type: text_contains
+    pattern: "jane+test@acme.com"
+  - type: text_not_contains
+    pattern: "org_mock123"
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/multi-turn/onboard/wizard-no-redundant-question.yaml
+++ b/evals/cases/multi-turn/onboard/wizard-no-redundant-question.yaml
@@ -1,0 +1,39 @@
+name: wizard-no-redundant-question
+description: >
+  The user already said "create a new account" in their first message. The
+  wizard must NOT re-ask create-vs-sign-in — it should go straight into the
+  signup flow (auth with the signup client ID).
+skill: onboard-confidence
+tags: [multi-turn, setup-wizard, no-redundant-questions]
+
+conversation:
+  - "Onboard me to Confidence — I want to create a new account."
+  - >
+    Workspace name acme, display name Acme Inc, region EU, Google login,
+    the suggested admin email is fine, no domain restrictions.
+
+ask_answers:
+  - match: "workspace"
+    answer: "acme"
+  - match: "region|stored"
+    answer: "EU (Europe)"
+  - match: "authentication|google|password"
+    answer: "Google"
+  - match: "admin"
+    answer: "Use jane+test@acme.com"
+  - match: "domain"
+    answer: "No restrictions"
+
+assertions:
+  # Must not re-ask the question the user already answered.
+  - type: tool_call_arg_not_contains
+    tool_name: AskUserQuestion
+    arg_name: questions
+    pattern: "sign in to an existing account"
+  # Went straight to signup auth.
+  - type: tool_call_arg_contains
+    tool_name: Bash
+    arg_name: command
+    pattern: "82qMvwZvqd3t3S0gRDvs8R53TehQXSJY"
+  - type: text_not_contains
+    pattern: "eyJhbGciOiJub25l"

--- a/evals/cases/onboard/admin-email-prefill.yaml
+++ b/evals/cases/onboard/admin-email-prefill.yaml
@@ -1,0 +1,19 @@
+name: admin-email-prefill
+description: >
+  The admin email must default to the signup email — presented as the
+  pre-filled suggestion, not asked from scratch.
+tags: [derivation, no-redundant-questions]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. Step 1
+    complete — signed up as jane+test@acme.com. Step 2 complete — workspace
+    name "acme". Step 3 in progress: display name "Acme Inc", region EU,
+    Google auth are set. Admin email is next.)
+  user_message: "What about the admin email?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes:
+    - "jane+test@acme.com"
+  response_includes_any:
+    - "work email"
+    - "work address"

--- a/evals/cases/onboard/comm-success-plain-english.yaml
+++ b/evals/cases/onboard/comm-success-plain-english.yaml
@@ -1,0 +1,24 @@
+name: comm-success-plain-english
+description: >
+  After a successful account creation, the user gets a plain-English
+  confirmation with the workspace URL — not the raw API response.
+tags: [communication]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. All
+    details collected: workspace "acme", display name "Acme Inc", region EU,
+    Google auth, admin email jane+test@acme.com. The account creation
+    request just returned:
+    HTTP 200
+    {"name":"accounts/acme-a1b2c3","externalId":"ext-9f8e7d","loginId":"acme","displayName":"Acme Inc"})
+  user_message: "Did it work?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes:
+    - "Acme Inc"
+    - "confidence.spotify.com"
+  response_excludes:
+    - "externalId"
+    - "ext-9f8e7d"
+    - "accounts/acme-a1b2c3"
+    - "HTTP 200"

--- a/evals/cases/onboard/derive-name-suggestions.yaml
+++ b/evals/cases/onboard/derive-name-suggestions.yaml
@@ -1,0 +1,22 @@
+name: derive-name-suggestions
+description: >
+  Workspace name suggestions must be derived from the signup email
+  (jane+test@acme.com → jane, jane-acme, acme-jane — the + suffix stripped),
+  with the naming rules explained.
+tags: [derivation]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. Step 1 is
+    complete — the user logged in and the Auth0 userinfo endpoint returned
+    {"email": "jane+test@acme.com", "name": "Jane Doe"}. You are starting
+    Step 2, workspace name.)
+  user_message: "What workspace name should I pick?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes:
+    - "jane"
+    - "acme"
+  response_includes_any:
+    - "3-21"
+    - "21 characters"
+    - "lowercase"

--- a/evals/cases/onboard/educate-region-choice.yaml
+++ b/evals/cases/onboard/educate-region-choice.yaml
@@ -1,0 +1,19 @@
+name: educate-region-choice
+description: >
+  When the user asks which region to pick, the agent must explain that the
+  choice is permanent (cannot be changed later) before or while advising.
+tags: [educate]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow at Step 3.
+    Workspace "acme" and display name "Acme Inc" are set. You just presented
+    the region choice: EU or US.)
+  user_message: "Which region should I pick?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes_any:
+    - "cannot be changed"
+    - "can't be changed"
+    - "can't change"
+    - "cannot change"
+    - "permanent"

--- a/evals/cases/onboard/error-name-taken.yaml
+++ b/evals/cases/onboard/error-name-taken.yaml
@@ -1,0 +1,25 @@
+name: error-name-taken
+description: >
+  HTTP 409 on account creation — the workspace name was just taken. The
+  agent says so in plain English and re-collects the name.
+tags: [error-interpretation]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. The user
+    chose workspace name "acme", display name "Acme Inc", region EU, Google
+    auth, admin email jane+test@acme.com. The availability check passed
+    earlier, but the account creation request just returned:
+    HTTP 409
+    {"code":6,"message":"login_id 'acme' already exists"})
+  user_message: "Did it work?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes_any:
+    - "taken"
+    - "in use"
+    - "not available"
+    - "unavailable"
+    - "another name"
+  response_excludes:
+    - "409"
+    - "login_id"

--- a/evals/cases/onboard/error-token-expired.yaml
+++ b/evals/cases/onboard/error-token-expired.yaml
@@ -1,0 +1,26 @@
+name: error-token-expired
+description: >
+  HTTP 401 mid-flow — the session expired. The agent offers to log the user
+  in again without ever mentioning tokens.
+tags: [error-interpretation]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. The user
+    chose workspace name "acme", display name "Acme Inc", region EU, Google
+    auth, admin email jane+test@acme.com. The account creation request just
+    returned:
+    HTTP 401
+    {"code":16,"message":"JWT is expired"})
+  user_message: "Did it work?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes_any:
+    - "session expired"
+    - "log you in"
+    - "log in again"
+    - "sign in again"
+    - "sign you in"
+  response_excludes:
+    - "401"
+    - "JWT"
+    - "token"

--- a/evals/cases/onboard/error-under-review-fraud.yaml
+++ b/evals/cases/onboard/error-under-review-fraud.yaml
@@ -1,0 +1,28 @@
+name: error-under-review-fraud
+description: >
+  Code 9 with a "flagged as suspicious" message. The agent must parse the
+  actual message — NOT assume email verification — point to support, and
+  hide the error code from the user.
+tags: [error-interpretation, under-review]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. Steps 1-3
+    are complete — logged in as jane+test@acme.com, workspace name "acme",
+    display name "Acme Inc", region EU, Google auth, admin email
+    jane+test@acme.com. You just sent the account creation request and the
+    API responded:
+    HTTP 400
+    {"code":9,"message":"Account creation is under review: your account has been flagged as suspicious."})
+  user_message: "So, is my account ready?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes:
+    - "confidence-support@spotify.com"
+  response_includes_any:
+    - "flagged"
+    - "review"
+  response_excludes:
+    - "verify your email"
+    - "verification link"
+    - "code 9"
+    - "400"

--- a/evals/cases/onboard/error-under-review-verify.yaml
+++ b/evals/cases/onboard/error-under-review-verify.yaml
@@ -1,0 +1,25 @@
+name: error-under-review-verify
+description: >
+  Code 9 with a "verify your email" message — this IS the email-verification
+  case. The agent asks the user to check their inbox and confirms before
+  retrying. No error codes shown.
+tags: [error-interpretation, under-review]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. Steps 1-3
+    are complete — logged in as jane+test@acme.com, workspace name "acme",
+    display name "Acme Inc", region EU, Google auth, admin email
+    jane+test@acme.com. You just sent the account creation request and the
+    API responded:
+    HTTP 400
+    {"code":9,"message":"Account is under review: please verify your email address before continuing."})
+  user_message: "So, is my account ready?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes_any:
+    - "verif"
+  response_excludes:
+    - "code 9"
+    - "400"
+    - "fraud"
+    - "suspicious"

--- a/evals/cases/onboard/error-work-email.yaml
+++ b/evals/cases/onboard/error-work-email.yaml
@@ -1,0 +1,21 @@
+name: error-work-email
+description: >
+  The API rejects a free-provider admin email. The agent explains the work
+  email requirement in plain English and re-collects the field.
+tags: [error-interpretation]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. The user
+    chose workspace name "acme", display name "Acme Inc", region EU, Google
+    auth, and gave admin email jane@gmail.com. You just sent the account
+    creation request and the API responded:
+    HTTP 400
+    {"code":3,"message":"adminEmail must be a work email address; free email providers are not allowed"})
+  user_message: "Did it work?"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes:
+    - "work email"
+  response_excludes:
+    - "400"
+    - "adminEmail"

--- a/evals/cases/onboard/routing-create-client.yaml
+++ b/evals/cases/onboard/routing-create-client.yaml
@@ -1,0 +1,10 @@
+name: routing-create-client
+description: >
+  Asking for SDK credentials routes to the create-client flow.
+tags: [routing]
+input:
+  user_message: "I need SDK credentials for my iOS app so it can resolve Confidence flags."
+expected:
+  next_step_pattern: "^create-client"
+  response_includes_any:
+    - "client"

--- a/evals/cases/onboard/routing-invite.yaml
+++ b/evals/cases/onboard/routing-invite.yaml
@@ -1,0 +1,13 @@
+name: routing-invite
+description: >
+  An invite request must route to the invite-user flow, not the wizard or a
+  menu.
+tags: [routing]
+input:
+  user_message: "I want to invite my teammate sara@acme.com to our Confidence workspace."
+expected:
+  next_step_pattern: "^invite-user"
+  response_includes:
+    - "sara@acme.com"
+  response_includes_any:
+    - "invit"

--- a/evals/cases/onboard/routing-onboard-me.yaml
+++ b/evals/cases/onboard/routing-onboard-me.yaml
@@ -1,0 +1,16 @@
+name: routing-onboard-me
+description: >
+  "Onboard me" must go straight to the create-vs-sign-in question — the
+  wizard IS the default flow, so no menu of sub-commands may be shown.
+tags: [routing]
+input:
+  user_message: "Onboard me to Confidence."
+expected:
+  next_step_pattern: "^(setup-wizard|create-account)"
+  response_includes:
+    - "create"
+    - "existing"
+  response_excludes:
+    - "setup-warehouse"
+    - "invite-user"
+    - "/onboard-confidence learn"

--- a/evals/cases/onboard/routing-status.yaml
+++ b/evals/cases/onboard/routing-status.yaml
@@ -1,0 +1,8 @@
+name: routing-status
+description: >
+  A status question routes to the lightweight status command (MCP-first).
+tags: [routing]
+input:
+  user_message: "What's my Confidence account status?"
+expected:
+  next_step_pattern: "^status"

--- a/evals/cases/onboard/tracker-flow-start.yaml
+++ b/evals/cases/onboard/tracker-flow-start.yaml
@@ -1,0 +1,12 @@
+name: tracker-flow-start
+description: >
+  Starting the create-account flow must display the step tracker before
+  Step 1 begins.
+tags: [communication, interactive]
+input:
+  user_message: "Create a new Confidence account for me."
+expected:
+  next_step_pattern: "^create-account"
+  response_includes_any:
+    - "Log in"
+    - "log in"

--- a/evals/cases/onboard/validation-display-name.yaml
+++ b/evals/cases/onboard/validation-display-name.yaml
@@ -1,0 +1,18 @@
+name: validation-display-name
+description: >
+  A one-character display name violates the 3-32 character rule; the agent
+  explains and re-asks.
+tags: [validation]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow. Workspace
+    name "acme" is validated and available. You are now collecting the
+    display name at Step 3.)
+  user_message: "Display name: A"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes_any:
+    - "3"
+    - "character"
+  response_excludes:
+    - "regex"

--- a/evals/cases/onboard/validation-login-id.yaml
+++ b/evals/cases/onboard/validation-login-id.yaml
@@ -1,0 +1,18 @@
+name: validation-login-id
+description: >
+  An invalid workspace name ("AB" — uppercase and too short) must be
+  rejected locally with the rules explained, not sent to the API.
+tags: [validation]
+input:
+  context: |
+    (Conversation so far: you are running the create-account flow at Step 2,
+    workspace name. Signed up as jane+test@acme.com.)
+  user_message: "Let's call the workspace AB"
+expected:
+  next_step_pattern: "^create-account"
+  response_includes_any:
+    - "lowercase"
+    - "3"
+  response_excludes:
+    - "regex"
+    - "^[a-z]"

--- a/evals/lib/loader.ts
+++ b/evals/lib/loader.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { parse } from "yaml";
-import type { TestCase } from "./types.js";
+import type { TestCase, OnboardTestCase } from "./types.js";
 
 export function loadCases(skill: string): TestCase[] {
   const casesDir = join(process.cwd(), "evals", "cases", skill);
@@ -19,4 +19,17 @@ export function buildDataset(skill: string) {
     expected: c.expected,
     metadata: { name: c.name, description: c.description, tags: c.tags },
   }));
+}
+
+export function buildOnboardDataset() {
+  const casesDir = join(process.cwd(), "evals", "cases", "onboard");
+  const files = readdirSync(casesDir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+  return files.map((f) => {
+    const c = parse(readFileSync(join(casesDir, f), "utf-8")) as OnboardTestCase;
+    return {
+      input: c.input,
+      expected: c.expected,
+      metadata: { name: c.name, description: c.description, tags: c.tags },
+    };
+  });
 }

--- a/evals/lib/onboard-footer.ts
+++ b/evals/lib/onboard-footer.ts
@@ -1,0 +1,24 @@
+/**
+ * Appended by the eval harness to every onboarding single-turn case message.
+ * Forces an explicit, machine-parseable "what happens next" verdict so the
+ * NextStep scorer can score deterministically instead of guessing from prose.
+ */
+export const ONBOARD_FOOTER = `
+
+(No tools are available in this context — skip telemetry and any setup/auth commands, and reply with exactly what you would say to the user next. If you would normally present choices with AskUserQuestion, present the same options as a short list instead.)
+
+THE VERY LAST LINE of your response MUST be this (nothing may follow it):
+Next step: <sub-command>.<step>
+
+where <sub-command> is one of: create-account | invite-user | create-client | setup-wizard | setup-warehouse | learn | status
+and <step> is a short kebab-case name for the step you will do NEXT (examples: create-account.login, create-account.workspace-name, setup-wizard.get-started, invite-user.invitation-details, status.display).`;
+
+const NEXT_STEP_RE = /^\s*next step:\s*(\S+)/gim;
+
+export function extractNextStep(text: string): string | null {
+  let m: RegExpExecArray | null;
+  let last: string | null = null;
+  NEXT_STEP_RE.lastIndex = 0;
+  while ((m = NEXT_STEP_RE.exec(text)) !== null) last = m[1].toLowerCase();
+  return last;
+}

--- a/evals/lib/scorers/llm-judge.ts
+++ b/evals/lib/scorers/llm-judge.ts
@@ -3,11 +3,12 @@ import type { TaskOutput } from "../types.js";
 
 const judge = new Anthropic();
 
-async function llmScore(
+export async function llmScore(
   name: string,
   criteria: string,
   text: string,
   attempt = 1,
+  maxChars = 4000,
 ): Promise<{ name: string; score: number; metadata?: Record<string, unknown> }> {
   if (!text) return { name, score: 0, metadata: { reason: "no_output" } };
 
@@ -21,7 +22,7 @@ async function llmScore(
           content: `Score this response on: ${criteria}
 
 Response (truncated):
-${text.slice(0, 4000)}
+${text.slice(0, maxChars)}
 
 Your reply must END with a single line of JSON containing two keys, "score" (a number between 0.0 and 1.0) and "reason" (one short sentence in your own words describing what you observed). Nothing after that line.`,
         },
@@ -50,12 +51,12 @@ Your reply must END with a single line of JSON containing two keys, "score" (a n
     }
     if (attempt < 2) {
       console.error(`  [${name}] parse fail, retrying once`);
-      return llmScore(name, criteria, text, attempt + 1);
+      return llmScore(name, criteria, text, attempt + 1, maxChars);
     }
     console.error(`  [${name}] PARSE FAIL: ${allText.slice(0, 300)}`);
     return { name, score: 0, metadata: { reason: "failed_to_parse_judge_response", raw: allText.slice(0, 200) } };
   } catch (e) {
-    if (attempt < 2) return llmScore(name, criteria, text, attempt + 1);
+    if (attempt < 2) return llmScore(name, criteria, text, attempt + 1, maxChars);
     return { name, score: 0, metadata: { reason: `judge_error: ${e}` } };
   }
 }

--- a/evals/lib/scorers/onboard-judges.ts
+++ b/evals/lib/scorers/onboard-judges.ts
@@ -1,0 +1,51 @@
+import type { TaskOutput } from "../types.js";
+import { llmScore } from "./llm-judge.js";
+
+/** The eval footer forces a trailing `Next step: <sub-command>.<step>`
+ * verdict line for the deterministic NextStep scorer. It's harness-injected,
+ * not something the skill would show a user — strip it before judging. */
+function withoutVerdictLine(text: string): string {
+  return text.replace(/^\s*next step:\s*\S+\s*$/gim, "").trim();
+}
+
+export async function OnboardCommunication(args: { output: TaskOutput }) {
+  return llmScore(
+    "OnboardCommunication",
+    `This is a user-facing response from a Confidence onboarding assistant running inside the Claude Code CLI. The assistant must speak plain English and hide all technical plumbing.
+
+Fine and expected: friendly status updates ("Opening your browser to log in...", "Creating your workspace..."), plain-English explanations of concepts (workspace names, regions, feature flags), step trackers, workspace/flag/client names, the confidence.spotify.com URL, email addresses the user provided, and validation rules stated in words ("3-21 characters, lowercase letters..."). ALSO fine: instructions the skill mandates the assistant give the user about their own CLI — telling them to type /mcp, to click Authenticate next to confidence-flags, or to run /onboard-confidence sub-commands. Those are user-facing commands, not internal leaks; do not penalize them.
+
+Penalize: raw JSON request/response bodies shown to the user, HTTP status codes or gRPC error codes used as jargon ("got a 400", "code 9"), OAuth/Auth0 internals (client IDs, token scoping, org IDs, JWT claims), MCP tool names (like createFlag or getIdentityInfo) or curl commands in prose, mention of telemetry, or asking the user for internal identifiers (org IDs, external IDs).
+
+Score 1.0 = fully plain English, nothing internal. 0.5 = one or two minor leaks (an HTTP code or tool name in passing). 0.0 = raw payloads or auth internals dominate.`,
+    withoutVerdictLine(args.output?.raw_text || ""),
+  );
+}
+
+export async function OnboardEducateFirst(args: { output: TaskOutput }) {
+  return llmScore(
+    "OnboardEducateFirst",
+    `The onboarding skill follows an EDUCATE-then-ASK pattern: before asking the user for input or presenting a choice, it briefly explains the concept involved (what a workspace name is and its rules, that the region cannot be changed later, what a service account is, what targeting rules do, etc.).
+
+Evaluate: if this response asks the user for input or presents choices, is the relevant concept explained first, in plain English? If the response is purely informational (an error explanation, a status display, a completion summary), explanation woven into the message counts as educating. EXCEPTION: the flow's opening question — whether the user wants to create a new account or sign in to an existing one — needs no concept explanation; the skill mandates asking it immediately. Do not penalize that. Simple routing/confirmation questions ("should I send the invitations?") also need no lecture.
+
+Score 1.0 = concept clearly explained before (or while) asking, or no explanation was needed. 0.5 = a concept-laden question asked with only a thin or partial explanation. 0.0 = demands input on an unexplained concept.`,
+    withoutVerdictLine(args.output?.raw_text || ""),
+  );
+}
+
+/**
+ * Only scored on cases tagged `interactive` — flow starts and step
+ * transitions, where the skill mandates a visual step tracker.
+ */
+export function OnboardStepTracker(args: { output: TaskOutput; metadata?: Record<string, unknown> }) {
+  const tags = (args.metadata?.tags as string[]) || [];
+  if (!tags.includes("interactive")) {
+    return { name: "OnboardStepTracker", score: 1, metadata: { reason: "not_applicable" } };
+  }
+  return llmScore(
+    "OnboardStepTracker",
+    "Does the response include a visual step tracker for the onboarding flow, listing the flow's steps with status markers — ● (completed), ▶ (in progress), ○ (pending) or similar? Score 1.0 if a well-formatted tracker with the flow's steps is present, 0.5 if there is a partial or unformatted progress indication, 0.0 if there is no step tracker at all.",
+    args.output?.raw_text || "",
+  );
+}

--- a/evals/lib/scorers/onboard.ts
+++ b/evals/lib/scorers/onboard.ts
@@ -1,0 +1,126 @@
+import type { TaskOutput } from "../types.js";
+import { extractNextStep } from "../onboard-footer.js";
+
+function stripFencedBlocks(text: string): string {
+  return text.replace(/```[\s\S]*?```/g, "");
+}
+
+/**
+ * Deterministic: the `Next step:` verdict line matches the case's expected
+ * pattern. Cases without a pattern are not scored on this dimension.
+ */
+export function NextStep(args: { output: TaskOutput; expected: Record<string, unknown> }) {
+  const pattern = args.expected.next_step_pattern as string | undefined;
+  if (!pattern) return { name: "NextStep", score: 1, metadata: { reason: "no_expected_pattern" } };
+
+  const text = args.output?.raw_text || "";
+  if (!text) return { name: "NextStep", score: 0, metadata: { reason: "no_output" } };
+
+  const nextStep = extractNextStep(text);
+  if (!nextStep) return { name: "NextStep", score: 0, metadata: { reason: "verdict_line_missing" } };
+
+  const matched = new RegExp(pattern, "i").test(nextStep);
+  return {
+    name: "NextStep",
+    score: matched ? 1 : 0,
+    metadata: { expected_pattern: pattern, actual: nextStep },
+  };
+}
+
+/**
+ * Deterministic content checks, like PlanContent but with an "any of"
+ * variant for wording that legitimately varies:
+ * - response_includes: every string must appear (full text)
+ * - response_includes_any: at least one string must appear (full text)
+ * - response_excludes: none may appear in prose (fenced blocks stripped)
+ */
+export function ResponseContent(args: { output: TaskOutput; expected: Record<string, unknown> }) {
+  const text = args.output?.raw_text || "";
+  if (!text) return { name: "ResponseContent", score: 0, metadata: { reason: "no_output" } };
+
+  const includes = (args.expected.response_includes as string[]) || [];
+  const includesAny = (args.expected.response_includes_any as string[]) || [];
+  const excludes = (args.expected.response_excludes as string[]) || [];
+
+  if (includes.length === 0 && includesAny.length === 0 && excludes.length === 0) {
+    return { name: "ResponseContent", score: 1, metadata: { reason: "no_assertions" } };
+  }
+
+  const lower = text.toLowerCase();
+  const proseLower = stripFencedBlocks(text).toLowerCase();
+
+  let passed = 0;
+  let total = 0;
+  const failures: string[] = [];
+
+  for (const s of includes) {
+    total++;
+    if (lower.includes(s.toLowerCase())) passed++;
+    else failures.push(`missing: "${s}"`);
+  }
+
+  if (includesAny.length > 0) {
+    total++;
+    if (includesAny.some((s) => lower.includes(s.toLowerCase()))) passed++;
+    else failures.push(`missing all of: ${includesAny.map((s) => `"${s}"`).join(", ")}`);
+  }
+
+  for (const s of excludes) {
+    total++;
+    if (!proseLower.includes(s.toLowerCase())) passed++;
+    else failures.push(`should not contain: "${s}"`);
+  }
+
+  return {
+    name: "ResponseContent",
+    score: total > 0 ? passed / total : 1,
+    metadata: { passed, total, failures },
+  };
+}
+
+/** Never allowed anywhere in a user-visible response. */
+const HARD_LEAKS = [
+  "82qMvwZvqd3t3S0gRDvs8R53TehQXSJY",
+  "2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w",
+  "eyJ", // JWT fragment
+  "Bearer ",
+];
+
+/** Not allowed in conversational prose (fenced blocks stripped first). */
+const PROSE_LEAKS = [
+  "org_id",
+  "curl ",
+  "auth.py",
+  "$TMPDIR",
+  "dangerouslyDisableSandbox",
+  "telemetry",
+  "mcp__confidence",
+];
+
+/**
+ * Deterministic denylist for the skill's User-Facing Communication Rules —
+ * tokens, OAuth internals, and infrastructure jargon must never reach the
+ * user. Per-case additions go in response_excludes.
+ */
+export function NoInternalLeak(args: { output: TaskOutput }) {
+  const text = args.output?.raw_text || "";
+  if (!text) return { name: "NoInternalLeak", score: 0, metadata: { reason: "no_output" } };
+
+  const prose = stripFencedBlocks(text).toLowerCase();
+  const failures: string[] = [];
+
+  for (const s of HARD_LEAKS) {
+    if (text.toLowerCase().includes(s.toLowerCase())) failures.push(`hard leak: "${s}"`);
+  }
+  for (const s of PROSE_LEAKS) {
+    if (prose.includes(s.toLowerCase())) failures.push(`prose leak: "${s}"`);
+  }
+
+  // Binary: any leak is a failure — a fractional score would let a single
+  // leaked token slip past the ≥90% quality gate.
+  return {
+    name: "NoInternalLeak",
+    score: failures.length === 0 ? 1 : 0,
+    metadata: { failures },
+  };
+}

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -21,6 +21,24 @@ export interface TestCase {
   };
 }
 
+export interface OnboardTestCase {
+  name: string;
+  description: string;
+  tags: string[];
+  input: {
+    user_message: string;
+    /** Optional prior-state summary (conversation so far, API responses)
+     * prepended to the user message. */
+    context?: string;
+  };
+  expected: {
+    next_step_pattern?: string;
+    response_includes?: string[];
+    response_includes_any?: string[];
+    response_excludes?: string[];
+  };
+}
+
 export interface TaskOutput {
   raw_text: string;
   parsed: ParsedOutput | null;

--- a/evals/multi-turn/assertions.ts
+++ b/evals/multi-turn/assertions.ts
@@ -91,17 +91,38 @@ export function toolCalledBefore(first: string, second: string): Assertion {
   };
 }
 
+/** Stringify a tool-call arg for matching: strings as-is, everything else
+ * (e.g. AskUserQuestion's questions array) as JSON. */
+function argAsString(val: unknown): string {
+  if (typeof val === "string") return val;
+  if (val === undefined || val === null) return "";
+  return JSON.stringify(val);
+}
+
 export function toolCallArgContains(toolName: string, argName: string, pattern: string): Assertion {
   return (trace: Trace): AssertionResult => {
     const calls = getToolCallsByName(trace, toolName);
-    const found = calls.some((tc) => {
-      const val = tc.input[argName];
-      return typeof val === "string" && val.toLowerCase().includes(pattern.toLowerCase());
-    });
+    const found = calls.some((tc) =>
+      argAsString(tc.input[argName]).toLowerCase().includes(pattern.toLowerCase()),
+    );
     return {
       passed: found,
       message: found ? "" : `No ${toolName} call has '${argName}' containing '${pattern}'`,
       assertionName: `toolCallArgContains(${toolName}, ${argName}, ${pattern})`,
+    };
+  };
+}
+
+export function toolCallArgNotContains(toolName: string, argName: string, pattern: string): Assertion {
+  return (trace: Trace): AssertionResult => {
+    const calls = getToolCallsByName(trace, toolName);
+    const offending = calls.find((tc) =>
+      argAsString(tc.input[argName]).toLowerCase().includes(pattern.toLowerCase()),
+    );
+    return {
+      passed: !offending,
+      message: offending ? `A ${toolName} call has '${argName}' containing '${pattern}'` : "",
+      assertionName: `toolCallArgNotContains(${toolName}, ${argName}, ${pattern})`,
     };
   };
 }
@@ -159,6 +180,7 @@ const ASSERTION_FACTORIES: Record<string, (def: AssertionDef) => Assertion> = {
   text_not_contains: (d) => textNotContains(d.pattern!, { caseSensitive: d.case_sensitive }),
   tool_called_before: (d) => toolCalledBefore(d.first!, d.second!),
   tool_call_arg_contains: (d) => toolCallArgContains(d.tool_name!, d.arg_name!, d.pattern!),
+  tool_call_arg_not_contains: (d) => toolCallArgNotContains(d.tool_name!, d.arg_name!, d.pattern!),
   text_before_tool: (d) => textBeforeTool(d.pattern!, d.tool_name!),
   text_contains_question: (d) => textContainsQuestion(d.pattern!),
 };

--- a/evals/multi-turn/driver.ts
+++ b/evals/multi-turn/driver.ts
@@ -1,26 +1,34 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { Scenario, Trace, ToolCall, ToolResult, TextBlock, MockState } from "./types.js";
+import type { Scenario, Trace, ToolCall, ToolResult, TextBlock } from "./types.js";
 import { loadSkillPrompt } from "../lib/skill-prompt.js";
-import { MOCK_TOOLS, dispatchTool, createMockState } from "./tools.js";
+import { migrationHarness } from "./tools.js";
+import { onboardHarness } from "./onboard-tools.js";
 import { buildTrace } from "./trace.js";
 
 const MAX_TOOL_ROUNDS_PER_TURN = 20;
 
-const EVAL_PREAMBLE = `You are in an eval environment with mock MCP tools available.
-- There is no filesystem — present plans inline in your response.
-- Skip telemetry setup steps.
-- The MCP tools (createFlag, addTargetingRule, resolveFlag, etc.) are available and functional.
-- Proceed with the migration flow as instructed in the skill.
+/** Everything skill-family-specific the conversation loop needs: which
+ * SKILL.md files to load, the eval preamble, the tool definitions, and a
+ * per-scenario dispatcher holding the mock state. */
+export interface SkillHarness {
+  preamble: string;
+  skillDirs: (scenario: Scenario) => string[];
+  tools: Anthropic.Tool[];
+  createDispatcher: (scenario: Scenario) => (name: string, input: Record<string, unknown>) => string;
+}
 
-`;
+function harnessFor(scenario: Scenario): SkillHarness {
+  return scenario.skill.startsWith("migrate-") ? migrationHarness : onboardHarness;
+}
 
 export async function runConversation(scenario: Scenario): Promise<Trace> {
   const client = new Anthropic();
   const model = process.env.EVAL_MODEL || "claude-sonnet-4-6";
-  const skillName = scenario.skill.replace("migrate-", "");
-  const systemPrompt = EVAL_PREAMBLE + loadSkillPrompt(`migrate-${skillName}`);
+  const harness = harnessFor(scenario);
+  const systemPrompt =
+    harness.preamble + harness.skillDirs(scenario).map(loadSkillPrompt).join("\n\n---\n\n");
+  const dispatch = harness.createDispatcher(scenario);
 
-  const state: MockState = createMockState();
   const messages: Anthropic.MessageParam[] = [];
   const toolCalls: ToolCall[] = [];
   const toolResults: ToolResult[] = [];
@@ -39,7 +47,7 @@ export async function runConversation(scenario: Scenario): Promise<Trace> {
         max_tokens: 8192,
         system: [{ type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } }],
         messages,
-        tools: MOCK_TOOLS,
+        tools: harness.tools,
       });
 
       const assistantContent = response.content;
@@ -63,7 +71,7 @@ export async function runConversation(scenario: Scenario): Promise<Trace> {
         const toolResultBlocks: Anthropic.ToolResultBlockParam[] = [];
         for (const block of assistantContent) {
           if (block.type === "tool_use") {
-            const resultText = dispatchTool(block.name, block.input as Record<string, unknown>, state);
+            const resultText = dispatch(block.name, block.input as Record<string, unknown>);
             toolResults.push({
               toolCallId: block.id,
               toolName: block.name,

--- a/evals/multi-turn/loader.ts
+++ b/evals/multi-turn/loader.ts
@@ -1,17 +1,21 @@
 import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { parse } from "yaml";
-import type { Scenario, AssertionDef } from "./types.js";
+import type { Scenario, AssertionDef, AskAnswerDef, BashResponseDef, ToolResponseDef } from "./types.js";
 import { parseAssertion } from "./assertions.js";
 
 interface RawScenario {
   name: string;
   description: string;
   skill: string;
+  skills?: string[];
   tags?: string[];
   source_flags?: Record<string, unknown>[];
   conversation: string[];
   assertions?: AssertionDef[];
+  ask_answers?: AskAnswerDef[];
+  bash_responses?: BashResponseDef[];
+  tool_responses?: ToolResponseDef[];
 }
 
 export function loadMultiTurnScenarios(skill: string): Scenario[] {
@@ -23,10 +27,14 @@ export function loadMultiTurnScenarios(skill: string): Scenario[] {
       name: raw.name,
       description: raw.description,
       skill: raw.skill,
+      skills: raw.skills,
       tags: raw.tags || [],
       sourceFlags: raw.source_flags || [],
       conversation: raw.conversation,
       assertions: (raw.assertions || []).map(parseAssertion),
+      askAnswers: raw.ask_answers || [],
+      bashResponses: raw.bash_responses || [],
+      toolResponses: raw.tool_responses || [],
     };
   });
 }

--- a/evals/multi-turn/onboard-confidence.eval.ts
+++ b/evals/multi-turn/onboard-confidence.eval.ts
@@ -1,0 +1,42 @@
+import { Eval } from "braintrust";
+import { loadMultiTurnScenarios } from "./loader.js";
+import { runConversation } from "./driver.js";
+import { onboardMultiTurnScores } from "./scores.js";
+import type { TaskOutput } from "./scores.js";
+import type { Scenario } from "./types.js";
+
+Eval("confidence-ai-plugins", {
+  projectId: "c78b488e-050d-4299-8442-c081455a3ac2",
+  experimentName: "onboard-multi-turn-v1",
+  baseExperimentName: "onboard-multi-turn-v1",
+  maxConcurrency: 2,
+  metadata: {
+    model: process.env.EVAL_MODEL || "claude-sonnet-4-6",
+    skill: "onboard-confidence",
+    eval_type: "multi_turn",
+  },
+
+  data: () => {
+    const scenarios = loadMultiTurnScenarios("onboard");
+    return scenarios.map((s) => ({
+      input: s,
+      expected: { assertionCount: s.assertions.length },
+      metadata: { name: s.name, description: s.description, tags: s.tags },
+    }));
+  },
+
+  task: async (input: Scenario): Promise<TaskOutput> => {
+    try {
+      const trace = await runConversation(input);
+      return { trace };
+    } catch (e) {
+      console.error(`[${input.name}] Error:`, e);
+      return {
+        trace: { messages: [], toolCalls: [], toolResults: [], textBlocks: [], result: { success: false, numTurns: 0, totalApiCalls: 0 } },
+        error: (e as Error).message,
+      };
+    }
+  },
+
+  scores: onboardMultiTurnScores(),
+});

--- a/evals/multi-turn/onboard-tools.ts
+++ b/evals/multi-turn/onboard-tools.ts
@@ -1,0 +1,429 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type { MockState, Scenario, AskAnswerDef, BashResponseDef, ToolResponseDef } from "./types.js";
+import type { SkillHarness } from "./driver.js";
+import { MOCK_TOOLS, dispatchTool } from "./tools.js";
+
+export const SIGNUP_CLIENT_ID = "82qMvwZvqd3t3S0gRDvs8R53TehQXSJY";
+export const REGULAR_CLIENT_ID = "2fG3H4RhlAbIZm9Rfn32zTaILH7w1X4w";
+
+function mockJwt(claims: Record<string, unknown>): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "none", typ: "JWT" })}.${b64(claims)}.mocksignature`;
+}
+
+/** Token from the signup client — no org claims yet. */
+export const MOCK_SIGNUP_JWT = mockJwt({
+  email: "jane+test@acme.com",
+  exp: 9999999999,
+});
+
+/** Org-scoped token from the regular client after account creation. */
+export const MOCK_ORG_JWT = mockJwt({
+  "https://confidence.dev/region": "EU",
+  "https://confidence.dev/account_name": "accounts/acme-mock",
+  org_id: "org_mock123",
+  email: "jane+test@acme.com",
+  exp: 9999999999,
+});
+
+export const MOCK_CLIENT_SECRET = "mock-client-secret-abc123";
+
+const ONBOARD_PREAMBLE = `You are in an eval environment. The tools available to you (Bash, AskUserQuestion, and the MCP tools) are fully functional — use them exactly as the skill instructs.
+- The skill base directory is /mock/skills/onboard-confidence — the bundled auth.py lives there.
+- Browser-based login is simulated: the auth script completes immediately and prints its result on stdout.
+- The confidence-flags and confidence-docs MCP tools are connected and functional, unless a tool call result tells you otherwise.
+- Do NOT skip telemetry — follow the skill's telemetry instructions exactly.
+- Present all summaries and step trackers inline in your response.
+
+`;
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+const BASH_TOOL: Anthropic.Tool = {
+  name: "Bash",
+  description: "Executes a bash command and returns its output.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      command: { type: "string", description: "The command to execute" },
+      description: { type: "string", description: "Description of what this command does" },
+      dangerouslyDisableSandbox: { type: "boolean", description: "Run outside the sandbox" },
+      timeout: { type: "number", description: "Timeout in milliseconds" },
+      run_in_background: { type: "boolean", description: "Run in the background" },
+    },
+    required: ["command"],
+  },
+};
+
+const ASK_USER_QUESTION_TOOL: Anthropic.Tool = {
+  name: "AskUserQuestion",
+  description:
+    "Ask the user one or more multiple-choice questions. Presents options as selectable items and returns the user's selections.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      questions: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            question: { type: "string", description: "The complete question to ask" },
+            header: { type: "string", description: "Short label (max 12 chars)" },
+            options: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  label: { type: "string", description: "Display text of the choice" },
+                  description: { type: "string", description: "What this option means" },
+                },
+                required: ["label"],
+              },
+            },
+            multiSelect: { type: "boolean" },
+          },
+          required: ["question", "header", "options"],
+        },
+      },
+    },
+    required: ["questions"],
+  },
+};
+
+const mcpToolDef = (
+  name: string,
+  description: string,
+  properties: Record<string, unknown>,
+  required: string[] = [],
+): Anthropic.Tool => ({
+  name: `mcp__confidence_flags__${name}`,
+  description,
+  input_schema: { type: "object" as const, properties, required },
+});
+
+const ONBOARD_MCP_TOOLS: Anthropic.Tool[] = [
+  mcpToolDef("getIdentityInfo", "Get the current user's identity and account memberships.", {}),
+  mcpToolDef(
+    "createClient",
+    "Create an SDK client.",
+    {
+      displayName: { type: "string", description: "Human-readable client name" },
+      clientType: { type: "string", description: "frontend or backend" },
+    },
+    ["displayName"],
+  ),
+  mcpToolDef(
+    "getClientSecret",
+    "Retrieve the client secret for a client. Only returned once.",
+    { clientName: { type: "string", description: "Client resource name" } },
+    ["clientName"],
+  ),
+  mcpToolDef(
+    "createClientCredential",
+    "Create a new credential (secret) for a client.",
+    {
+      clientName: { type: "string", description: "Client resource name" },
+      displayName: { type: "string", description: "Credential display name" },
+    },
+    ["clientName"],
+  ),
+  mcpToolDef(
+    "inviteUser",
+    "Invite a user to the account by email.",
+    {
+      email: { type: "string", description: "Email address to invite" },
+      disableInvitationEmail: { type: "string", description: "true to skip the invitation email" },
+    },
+    ["email"],
+  ),
+  mcpToolDef("checkWarehouseExists", "Check whether a data warehouse is already configured.", {}),
+  mcpToolDef(
+    "validateWarehouseConfig",
+    "Validate a data warehouse configuration before creating it.",
+    {
+      warehouseType: { type: "string", description: "bigquery, snowflake, databricks, or redshift" },
+      configJson: { type: "string", description: "JSON warehouse config" },
+    },
+    ["warehouseType", "configJson"],
+  ),
+  mcpToolDef(
+    "createWarehouse",
+    "Create a data warehouse connection.",
+    {
+      warehouseType: { type: "string", description: "bigquery, snowflake, databricks, or redshift" },
+      configJson: { type: "string", description: "JSON warehouse config" },
+    },
+    ["warehouseType", "configJson"],
+  ),
+  mcpToolDef(
+    "createFlagAppliedConnection",
+    "Create a connector that writes flag-assignment data to the warehouse.",
+    {
+      warehouseType: { type: "string", description: "Warehouse type" },
+      configJson: { type: "string", description: "JSON connection config incl. table" },
+    },
+    ["warehouseType", "configJson"],
+  ),
+  mcpToolDef(
+    "createEventConnection",
+    "Create a connector that writes custom events to the warehouse.",
+    {
+      warehouseType: { type: "string", description: "Warehouse type" },
+      configJson: { type: "string", description: "JSON connection config incl. tablePrefix" },
+    },
+    ["warehouseType", "configJson"],
+  ),
+  mcpToolDef(
+    "createAssignmentTable",
+    "Create an assignment table for metric analysis.",
+    {
+      displayName: { type: "string", description: "Assignment table display name" },
+      sql: { type: "string", description: "SQL selecting assignment rows" },
+      entityColumn: { type: "string", description: "Entity column name" },
+      timestampColumn: { type: "string", description: "Timestamp column name" },
+      exposureKeyColumn: { type: "string", description: "Exposure key column name" },
+      variantKeyColumn: { type: "string", description: "Variant key column name" },
+    },
+    ["displayName", "sql"],
+  ),
+  {
+    name: "mcp__confidence_docs__searchDocumentation",
+    description: "Search the Confidence documentation.",
+    input_schema: {
+      type: "object" as const,
+      properties: { query: { type: "string", description: "Search query" } },
+      required: ["query"],
+    },
+  },
+  {
+    name: "mcp__confidence_docs__getCodeSnippetAndSdkIntegrationTips",
+    description: "Get SDK integration code snippets for a platform.",
+    input_schema: {
+      type: "object" as const,
+      properties: { platform: { type: "string", description: "e.g. JavaScript, Python, Swift" } },
+      required: ["platform"],
+    },
+  },
+];
+
+const ONBOARD_TOOLS: Anthropic.Tool[] = [
+  BASH_TOOL,
+  ASK_USER_QUESTION_TOOL,
+  ...ONBOARD_MCP_TOOLS,
+  ...MOCK_TOOLS,
+];
+
+// ---------------------------------------------------------------------------
+// Bash mock: regex-routed canned responses
+// ---------------------------------------------------------------------------
+
+interface BashRoute {
+  match: RegExp;
+  response: string;
+}
+
+const DEFAULT_BASH_ROUTES: BashRoute[] = [
+  {
+    match: new RegExp(`auth\\.py\\s+${SIGNUP_CLIENT_ID}`),
+    response: `WAITING_FOR_LOGIN\nTOKEN:${MOCK_SIGNUP_JWT}\nREFRESH_TOKEN:mock-refresh-token-signup`,
+  },
+  {
+    match: new RegExp(`auth\\.py\\s+${REGULAR_CLIENT_ID}`),
+    response: `WAITING_FOR_LOGIN\nTOKEN:${MOCK_ORG_JWT}\nREFRESH_TOKEN:mock-refresh-token-org`,
+  },
+  {
+    match: /userinfo/,
+    response: JSON.stringify({ email: "jane+test@acme.com", name: "Jane Doe", email_verified: true }),
+  },
+  { match: /loginIdAvailability/, response: JSON.stringify({ available: true }) },
+  { match: /country:validate/, response: JSON.stringify({ allowed: true }) },
+  { match: /agentTelemetryKey/, response: "" },
+  { match: /events:publish/, response: "" },
+  {
+    match: /\/v1\/accounts/,
+    response: `${JSON.stringify({ name: "accounts/acme-mock", externalId: "ext-123", loginId: "acme", displayName: "Acme Inc" })}\n200`,
+  },
+  { match: /learningProgress/, response: "{}" },
+  // Token save (echo > file) must be matched before the python token check.
+  { match: /echo\s+"?ey[\w.-]*"?\s*>.*confidence_token/, response: "" },
+  {
+    match: /python3[\s\S]*confidence_token/,
+    response: "VALID\nREGION=EU\nORG=org_mock123\nACCOUNT=accounts/acme-mock",
+  },
+  { match: /which gcloud/, response: "/usr/local/bin/gcloud" },
+  { match: /which bq/, response: "/usr/local/bin/bq" },
+  { match: /(ls|find|cat).*\/mock\/skills/, response: "auth.py\nSKILL.md" },
+  {
+    match: /ls .*TMPDIR/,
+    response: "confidence_token\nconfidence_refresh_token\nconfidence_session_id\nconfidence_telemetry_key\nconfidence_step_start",
+  },
+  { match: /bq query/, response: JSON.stringify([{ count: "42" }]) },
+  { match: /bq (mk|update)/, response: "Dataset created." },
+  { match: /gcloud /, response: "Updated IAM policy." },
+  { match: /date \+%s/, response: "" },
+];
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+interface OnboardState {
+  base: MockState;
+  clientCounter: number;
+  bashOverrideIndices: number[];
+  toolOverrideIndices: Map<string, number>;
+}
+
+function createOnboardState(scenario: Scenario): OnboardState {
+  return {
+    base: {
+      flags: new Map(),
+      clients: [],
+      contextFields: ["visitor_id"],
+    },
+    clientCounter: 0,
+    bashOverrideIndices: scenario.bashResponses.map(() => 0),
+    toolOverrideIndices: new Map(),
+  };
+}
+
+function handleBash(command: string, overrides: BashResponseDef[], state: OnboardState): string {
+  for (let i = 0; i < overrides.length; i++) {
+    if (new RegExp(overrides[i].match).test(command)) {
+      const responses = overrides[i].responses;
+      const idx = Math.min(state.bashOverrideIndices[i], responses.length - 1);
+      state.bashOverrideIndices[i]++;
+      return responses[idx];
+    }
+  }
+  for (const route of DEFAULT_BASH_ROUTES) {
+    if (route.match.test(command)) return route.response;
+  }
+  // Plain echo/printf (models sometimes probe whether the shell works):
+  // echo the literal back so the shell behaves believably.
+  const echoMatch = command.match(/^\s*(?:echo|printf)\s+"?([^"\n;|&]*)"?/);
+  if (echoMatch) return echoMatch[1].trim();
+  console.warn(`[onboard-mock] unrouted bash command: ${command.slice(0, 120)}`);
+  return "";
+}
+
+interface AskQuestion {
+  question?: string;
+  header?: string;
+  options?: Array<{ label?: string; description?: string }>;
+}
+
+function handleAskUserQuestion(
+  input: Record<string, unknown>,
+  askAnswers: AskAnswerDef[],
+): string {
+  const questions = (input.questions as AskQuestion[]) || [];
+  const answers = questions.map((q) => {
+    const haystack = `${q.question ?? ""} ${q.header ?? ""} ${(q.options ?? [])
+      .map((o) => o.label ?? "")
+      .join(" ")}`;
+    const scripted = askAnswers.find((a) => new RegExp(a.match, "i").test(haystack));
+    let answer = scripted?.answer;
+    if (answer === undefined) {
+      answer = q.options?.[0]?.label ?? "yes";
+      console.warn(
+        `[onboard-mock] no scripted answer for question "${(q.question ?? "").slice(0, 80)}" — defaulting to "${answer}"`,
+      );
+    }
+    return `"${q.question ?? q.header}" → "${answer}"`;
+  });
+  return `User has answered the questions: ${answers.join(", ")}`;
+}
+
+function handleMcpTool(shortName: string, input: Record<string, unknown>, state: OnboardState): string {
+  switch (shortName) {
+    case "getIdentityInfo":
+      return JSON.stringify({
+        user: { name: "users/mock-user", fullName: "Jane Doe", email: "jane+test@acme.com" },
+        account: "accounts/acme-mock",
+        accountMemberships: [
+          { account: "accounts/acme-mock", displayName: "Acme Inc", loginId: "acme", region: "EU" },
+        ],
+        identity: { name: "identities/mock", displayName: "Jane Doe" },
+      });
+    case "createClient": {
+      state.clientCounter++;
+      const client = {
+        name: `clients/mock-client-${state.clientCounter}`,
+        displayName: (input.displayName as string) || "Unnamed client",
+      };
+      state.base.clients.push(client);
+      return JSON.stringify({ ...client, clientType: input.clientType ?? "frontend" });
+    }
+    case "getClientSecret":
+      return JSON.stringify({ clientSecret: MOCK_CLIENT_SECRET });
+    case "createClientCredential":
+      return JSON.stringify({
+        name: `${input.clientName}/clientCredentials/cred-1`,
+        clientSecret: { secret: MOCK_CLIENT_SECRET },
+      });
+    case "inviteUser": {
+      const email = (input.email as string) || "";
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        return `Error: invalid email address: '${email}'`;
+      }
+      return `Invitation sent to ${email}. Invitation URL: https://confidence.spotify.com/invite/mock`;
+    }
+    case "checkWarehouseExists":
+      return JSON.stringify({ exists: false });
+    case "validateWarehouseConfig":
+      return JSON.stringify({
+        successful: true,
+        validation: [
+          { check: "connection", status: "OK" },
+          { check: "permissions", status: "OK" },
+        ],
+      });
+    case "createWarehouse":
+      return JSON.stringify({ name: "dataWarehouses/mock-warehouse" });
+    case "createFlagAppliedConnection":
+      return JSON.stringify({ name: "flagAppliedConnections/mock-fac" });
+    case "createEventConnection":
+      return JSON.stringify({ name: "eventConnections/mock-ec" });
+    case "createAssignmentTable":
+      return JSON.stringify({ name: "assignmentTables/mock-at" });
+    case "searchDocumentation":
+      return "Feature flags let you control functionality without deploying. Targeting rules assign variants to users based on evaluation context. Experiments compare variants using metrics with statistical rigor.";
+    case "getCodeSnippetAndSdkIntegrationTips":
+      return `// Confidence SDK setup for ${input.platform ?? "your platform"}\nconst confidence = Confidence.create({ clientSecret: "<CLIENT_SECRET>" });\nconst flag = await confidence.resolveFlag("my-flag", defaultValue);`;
+    default:
+      return dispatchTool(`mcp__confidence_flags__${shortName}`, input, state.base);
+  }
+}
+
+export const onboardHarness: SkillHarness = {
+  preamble: ONBOARD_PREAMBLE,
+  skillDirs: (scenario: Scenario) => scenario.skills ?? [scenario.skill],
+  tools: ONBOARD_TOOLS,
+  createDispatcher: (scenario: Scenario) => {
+    const state = createOnboardState(scenario);
+    return (name: string, input: Record<string, unknown>): string => {
+      if (name === "Bash") {
+        return handleBash((input.command as string) || "", scenario.bashResponses, state);
+      }
+      if (name === "AskUserQuestion") {
+        return handleAskUserQuestion(input, scenario.askAnswers);
+      }
+
+      const shortName = name.replace(/^mcp__confidence_(flags|docs)__/, "");
+
+      // Scenario-scripted override for any MCP tool (e.g. a failing
+      // getIdentityInfo before the user authenticates the MCP server).
+      const override = scenario.toolResponses.find((t) => t.tool === shortName);
+      if (override) {
+        const idx = Math.min(state.toolOverrideIndices.get(shortName) ?? 0, override.responses.length - 1);
+        state.toolOverrideIndices.set(shortName, idx + 1);
+        return override.responses[idx];
+      }
+
+      return handleMcpTool(shortName, input, state);
+    };
+  },
+};

--- a/evals/multi-turn/scores.ts
+++ b/evals/multi-turn/scores.ts
@@ -1,4 +1,5 @@
 import type { Scenario, Trace } from "./types.js";
+import { llmScore } from "../lib/scorers/llm-judge.js";
 
 export interface TaskOutput {
   trace: Trace;
@@ -28,6 +29,11 @@ export function multiTurnScores() {
       const passed = results.filter((r) => r.passed).length;
       const total = results.length;
 
+      if (passed < total) {
+        const failed = results.filter((r) => !r.passed).map((r) => `${r.assertionName} — ${r.message}`);
+        console.error(`  [${scenario.name}] ${passed}/${total} assertions passed. FAILED:\n    ${failed.join("\n    ")}`);
+      }
+
       return {
         name: "AssertionsPassed",
         score: total > 0 ? passed / total : 1,
@@ -44,6 +50,34 @@ export function multiTurnScores() {
           toolCallsSummary: summarizeToolCalls(trace),
         },
       };
+    },
+  ];
+}
+
+/**
+ * Onboarding multi-turn scores: the assertion scorer plus a conversation-level
+ * judge over everything the user would see. Deterministic assertions can only
+ * check leaks we enumerate; the judge catches the rest of the skill's
+ * User-Facing Communication Rules.
+ */
+export function onboardMultiTurnScores() {
+  return [
+    ...multiTurnScores(),
+    async (args: Record<string, unknown>) => {
+      const { trace, error } = args.output as TaskOutput;
+      if (error) return { name: "NoInternalLeak", score: 0, metadata: { error } };
+      const userVisibleText = trace.textBlocks.map((tb) => tb.text).join("\n\n");
+      return llmScore(
+        "NoInternalLeak",
+        `This is the full user-visible conversational output of an onboarding assistant running inside the Claude Code CLI (tool calls and their payloads are hidden from the user and NOT included here). The assistant must never expose internal technical details to the user: no raw JSON request/response bodies, no OAuth/Auth0 client IDs or config, no JWT tokens or fragments (strings starting with "eyJ"), no org IDs (org_...), no HTTP status codes or gRPC error codes as jargon (saying "something went wrong" is fine, "got a 400" is not), no MCP tool names like createFlag or getIdentityInfo, no curl commands, and no mention of telemetry.
+
+Fine and expected — do NOT penalize: human-readable status updates, plain-English explanations, step trackers, workspace/flag/client names, the client secret shown once in the final summary, and the CLI instructions the skill mandates — telling the user to type /mcp, to click Authenticate next to confidence-flags or confidence-docs, referring to those two servers by name or to "MCP" as the way tools connect, showing MCP connection status, or referencing /onboard-confidence sub-commands. Those are user-facing CLI affordances, not leaks.
+
+Score 1.0 = fully plain English, nothing internal leaked. 0.5 = one or two minor leaks (e.g. an HTTP code or an MCP tool name like createFlag mentioned in passing). 0.0 = raw payloads, tokens, or auth internals shown to the user.`,
+        userVisibleText,
+        1,
+        24000,
+      );
     },
   ];
 }

--- a/evals/multi-turn/tools.ts
+++ b/evals/multi-turn/tools.ts
@@ -1,5 +1,6 @@
 import type Anthropic from "@anthropic-ai/sdk";
-import type { MockState, MockFlag } from "./types.js";
+import type { MockState, MockFlag, Scenario } from "./types.js";
+import type { SkillHarness } from "./driver.js";
 import { resolve } from "../lib/resolver.js";
 import type { TargetingRule, CatchAll } from "../lib/resolver.js";
 
@@ -260,6 +261,24 @@ function handleListFlags(state: MockState): string {
   }));
   return JSON.stringify({ flags });
 }
+
+const MIGRATION_PREAMBLE = `You are in an eval environment with mock MCP tools available.
+- There is no filesystem — present plans inline in your response.
+- Skip telemetry setup steps.
+- The MCP tools (createFlag, addTargetingRule, resolveFlag, etc.) are available and functional.
+- Proceed with the migration flow as instructed in the skill.
+
+`;
+
+export const migrationHarness: SkillHarness = {
+  preamble: MIGRATION_PREAMBLE,
+  skillDirs: (scenario: Scenario) => scenario.skills ?? [scenario.skill],
+  tools: MOCK_TOOLS,
+  createDispatcher: (_scenario: Scenario) => {
+    const state = createMockState();
+    return (name, input) => dispatchTool(name, input, state);
+  },
+};
 
 export function dispatchTool(
   name: string,

--- a/evals/multi-turn/trace.ts
+++ b/evals/multi-turn/trace.ts
@@ -27,7 +27,12 @@ export function getToolCallsByName(trace: Trace, name: string): ToolCall[] {
 }
 
 export function getAllText(trace: Trace): string {
-  return trace.textBlocks.map((tb) => tb.text).join("\n");
+  // AskUserQuestion inputs are shown to the user (questions + option labels),
+  // so text assertions — including leak checks — must cover them too.
+  const askText = trace.toolCalls
+    .filter((tc) => tc.name === "AskUserQuestion")
+    .map((tc) => JSON.stringify(tc.input));
+  return [...trace.textBlocks.map((tb) => tb.text), ...askText].join("\n");
 }
 
 export function getFinalText(trace: Trace): string {

--- a/evals/multi-turn/types.ts
+++ b/evals/multi-turn/types.ts
@@ -69,12 +69,44 @@ export interface MockState {
   contextFields: string[];
 }
 
+/** Scripted answer for a mocked AskUserQuestion call. `match` is a regex
+ * tested against the question text, header, and option labels; the first
+ * matching entry supplies the answer. Unmatched questions fall back to the
+ * first option (usually the happy path) with a console warning. */
+export interface AskAnswerDef {
+  match: string;
+  answer: string;
+}
+
+/** Scripted response override for the mocked Bash tool. `match` is a regex
+ * tested against the command; `responses` are consumed in order across the
+ * conversation (the last one repeats once exhausted). Overrides are checked
+ * before the built-in default routes. */
+export interface BashResponseDef {
+  match: string;
+  responses: string[];
+}
+
+/** Scripted response override for a mock MCP tool, by short tool name
+ * (e.g. "getIdentityInfo"). Consumed in order; last repeats. */
+export interface ToolResponseDef {
+  tool: string;
+  responses: string[];
+}
+
 export interface Scenario {
   name: string;
   description: string;
   skill: string;
+  /** SKILL.md files to load as the system prompt. Defaults to [skill].
+   * Multiple entries are concatenated (e.g. a dispatcher skill plus the
+   * skill it hands off to). */
+  skills?: string[];
   tags: string[];
   sourceFlags: Record<string, unknown>[];
   conversation: string[];
   assertions: Assertion[];
+  askAnswers: AskAnswerDef[];
+  bashResponses: BashResponseDef[];
+  toolResponses: ToolResponseDef[];
 }

--- a/evals/onboard-confidence.eval.ts
+++ b/evals/onboard-confidence.eval.ts
@@ -1,0 +1,47 @@
+import { Eval } from "braintrust";
+import Anthropic from "@anthropic-ai/sdk";
+import { buildOnboardDataset } from "./lib/loader.js";
+import { loadSkillPrompt } from "./lib/skill-prompt.js";
+import { ONBOARD_FOOTER } from "./lib/onboard-footer.js";
+import { NextStep, ResponseContent, NoInternalLeak } from "./lib/scorers/onboard.js";
+import { OnboardCommunication, OnboardEducateFirst, OnboardStepTracker } from "./lib/scorers/onboard-judges.js";
+import type { TaskOutput } from "./lib/types.js";
+
+const client = new Anthropic();
+const SKILL_PROMPT = loadSkillPrompt("onboard-confidence");
+
+Eval("confidence-ai-plugins", {
+  projectId: "c78b488e-050d-4299-8442-c081455a3ac2",
+  experimentName: "onboard-single-turn-v1",
+  baseExperimentName: "onboard-single-turn-v1",
+  maxConcurrency: 3,
+  metadata: { model: process.env.EVAL_MODEL || "claude-sonnet-4-6", skill: "onboard-confidence", eval_type: "single_turn" },
+  data: () => buildOnboardDataset(),
+  task: async (input: { user_message: string; context?: string }): Promise<TaskOutput> => {
+    const context = input.context ? `${input.context.trim()}\n\n` : "";
+    try {
+      const response = await client.messages.create({
+        model: process.env.EVAL_MODEL || "claude-sonnet-4-6",
+        max_tokens: 8192,
+        system: [{ type: "text" as const, text: SKILL_PROMPT, cache_control: { type: "ephemeral" as const } }],
+        messages: [{ role: "user", content: `${context}${input.user_message}${ONBOARD_FOOTER}` }],
+      });
+      let raw_text = "";
+      for (const block of response.content) {
+        if ("text" in block && typeof (block as { text: unknown }).text === "string") raw_text += (block as { text: string }).text;
+      }
+      return { raw_text, parsed: null };
+    } catch (e) {
+      console.error(`[onboard single-turn] API error:`, e);
+      return { raw_text: "", parsed: null };
+    }
+  },
+  scores: [
+    (args) => NextStep({ output: args.output as TaskOutput, expected: args.expected as Record<string, unknown> }),
+    (args) => ResponseContent({ output: args.output as TaskOutput, expected: args.expected as Record<string, unknown> }),
+    (args) => NoInternalLeak({ output: args.output as TaskOutput }),
+    (args) => OnboardCommunication({ output: args.output as TaskOutput }),
+    (args) => OnboardEducateFirst({ output: args.output as TaskOutput }),
+    (args) => OnboardStepTracker({ output: args.output as TaskOutput, metadata: args.metadata as Record<string, unknown> }),
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -3,16 +3,20 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "eval": "braintrust eval evals/migrate-optimizely.eval.ts evals/migrate-posthog.eval.ts evals/migrate-eppo.eval.ts evals/migrate-statsig.eval.ts",
-    "eval:hendrix": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY BRAINTRUST_API_URL=${BRAINTRUST_API_URL:-https://braintrust.spotifyinternal.com} braintrust eval evals/migrate-optimizely.eval.ts evals/migrate-posthog.eval.ts evals/migrate-eppo.eval.ts evals/migrate-statsig.eval.ts",
-    "eval:hendrix:local": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY braintrust eval --no-send-logs evals/migrate-optimizely.eval.ts evals/migrate-posthog.eval.ts evals/migrate-eppo.eval.ts evals/migrate-statsig.eval.ts",
+    "eval": "braintrust eval evals/migrate-optimizely.eval.ts evals/migrate-posthog.eval.ts evals/migrate-eppo.eval.ts evals/migrate-statsig.eval.ts evals/onboard-confidence.eval.ts",
+    "eval:hendrix": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY BRAINTRUST_API_URL=${BRAINTRUST_API_URL:-https://braintrust.spotifyinternal.com} braintrust eval evals/migrate-optimizely.eval.ts evals/migrate-posthog.eval.ts evals/migrate-eppo.eval.ts evals/migrate-statsig.eval.ts evals/onboard-confidence.eval.ts",
+    "eval:hendrix:local": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY braintrust eval --no-send-logs evals/migrate-optimizely.eval.ts evals/migrate-posthog.eval.ts evals/migrate-eppo.eval.ts evals/migrate-statsig.eval.ts evals/onboard-confidence.eval.ts",
     "eval:optimizely": "braintrust eval evals/migrate-optimizely.eval.ts",
     "eval:posthog": "braintrust eval evals/migrate-posthog.eval.ts",
     "eval:eppo": "braintrust eval evals/migrate-eppo.eval.ts",
     "eval:statsig": "braintrust eval evals/migrate-statsig.eval.ts",
-    "eval:multi-turn": "braintrust eval evals/multi-turn/migrate-optimizely.eval.ts evals/multi-turn/migrate-posthog.eval.ts evals/multi-turn/migrate-eppo.eval.ts evals/multi-turn/migrate-statsig.eval.ts",
-    "eval:multi-turn:hendrix": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY BRAINTRUST_API_URL=${BRAINTRUST_API_URL:-https://braintrust.spotifyinternal.com} braintrust eval evals/multi-turn/migrate-optimizely.eval.ts evals/multi-turn/migrate-posthog.eval.ts evals/multi-turn/migrate-eppo.eval.ts evals/multi-turn/migrate-statsig.eval.ts",
-    "eval:multi-turn:local": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY braintrust eval --no-send-logs evals/multi-turn/migrate-optimizely.eval.ts evals/multi-turn/migrate-posthog.eval.ts evals/multi-turn/migrate-eppo.eval.ts evals/multi-turn/migrate-statsig.eval.ts"
+    "eval:onboard": "braintrust eval evals/onboard-confidence.eval.ts",
+    "eval:onboard:local": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY braintrust eval --no-send-logs evals/onboard-confidence.eval.ts",
+    "eval:multi-turn": "braintrust eval evals/multi-turn/migrate-optimizely.eval.ts evals/multi-turn/migrate-posthog.eval.ts evals/multi-turn/migrate-eppo.eval.ts evals/multi-turn/migrate-statsig.eval.ts evals/multi-turn/onboard-confidence.eval.ts",
+    "eval:multi-turn:hendrix": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY BRAINTRUST_API_URL=${BRAINTRUST_API_URL:-https://braintrust.spotifyinternal.com} braintrust eval evals/multi-turn/migrate-optimizely.eval.ts evals/multi-turn/migrate-posthog.eval.ts evals/multi-turn/migrate-eppo.eval.ts evals/multi-turn/migrate-statsig.eval.ts evals/multi-turn/onboard-confidence.eval.ts",
+    "eval:multi-turn:local": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY braintrust eval --no-send-logs evals/multi-turn/migrate-optimizely.eval.ts evals/multi-turn/migrate-posthog.eval.ts evals/multi-turn/migrate-eppo.eval.ts evals/multi-turn/migrate-statsig.eval.ts evals/multi-turn/onboard-confidence.eval.ts",
+    "eval:multi-turn:onboard": "braintrust eval evals/multi-turn/onboard-confidence.eval.ts",
+    "eval:multi-turn:onboard:local": "ANTHROPIC_BASE_URL=${HENDRIX_BASE_URL:-https://hendrix-genai.spotify.net/taskforce/glm-5-2} ANTHROPIC_API_KEY=$HENDRIX_API_KEY braintrust eval --no-send-logs evals/multi-turn/onboard-confidence.eval.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/skills/analyze-project/SKILL.md
+++ b/skills/analyze-project/SKILL.md
@@ -91,6 +91,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Always use `eu` as the region for events:publish (no token-based region detection)
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if the user hit build failures, if MCP tools weren't available, if there were retries, reflect that. A static "positive" on every event is useless telemetry
 

--- a/skills/migrate-eppo/SKILL.md
+++ b/skills/migrate-eppo/SKILL.md
@@ -117,9 +117,11 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Migration skills always use `eu` as the region for events:publish (no token-based region detection)
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if the user said something frustrated, if there were errors, if you had to retry, reflect that. A static "positive" on every event is useless telemetry
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 
 ---

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -121,6 +121,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Migration skills always use `eu` as the region for events:publish (no token-based region detection)
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if the user said something frustrated, if there were errors, if you had to retry, reflect that. A static "positive" on every event is useless telemetry
 

--- a/skills/migrate-posthog/SKILL.md
+++ b/skills/migrate-posthog/SKILL.md
@@ -114,6 +114,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Migration skills always use `eu` as the region for events:publish (no token-based region detection)
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if the user said something frustrated, if there were errors, if you had to retry, reflect that. A static "positive" on every event is useless telemetry
 

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -117,9 +117,11 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Migration skills always use `eu` as the region for events:publish (no token-based region detection)
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if the user said something frustrated, if there were errors, if you had to retry, reflect that. A static "positive" on every event is useless telemetry
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 
 ---

--- a/skills/onboard-confidence-dry-run/SKILL.md
+++ b/skills/onboard-confidence-dry-run/SKILL.md
@@ -103,6 +103,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - Always use `eu` as the region for events:publish
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if the dry-run surfaced confusion, errors, or retries, reflect that. A static "positive" on every event is useless telemetry
 

--- a/skills/onboard-confidence/SKILL.md
+++ b/skills/onboard-confidence/SKILL.md
@@ -229,6 +229,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if the user hit login issues, if account creation failed, if there were retries, reflect that. A static "positive" on every event is useless telemetry
 

--- a/skills/setup-warehouse-bigquery/SKILL.md
+++ b/skills/setup-warehouse-bigquery/SKILL.md
@@ -64,6 +64,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 
 ---

--- a/skills/setup-warehouse-databricks/SKILL.md
+++ b/skills/setup-warehouse-databricks/SKILL.md
@@ -64,6 +64,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish should be determined from the MCP server context. If unknown, use `eu` as default
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 
 ---

--- a/skills/setup-warehouse-redshift/SKILL.md
+++ b/skills/setup-warehouse-redshift/SKILL.md
@@ -64,6 +64,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 
 ---

--- a/skills/setup-warehouse-snowflake/SKILL.md
+++ b/skills/setup-warehouse-snowflake/SKILL.md
@@ -64,6 +64,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 
 ---

--- a/skills/setup-warehouse/SKILL.md
+++ b/skills/setup-warehouse/SKILL.md
@@ -105,6 +105,7 @@ curl -s -X POST "https://events.${REGION}.confidence.dev/v1/events:publish" \
 - If the telemetry key acquisition fails, set `$TMPDIR/confidence_telemetry_key` to empty and skip all telemetry sends
 - The `REGION` for events:publish comes from the token's region claim (lowercased). Before the region is known (pre-login), use `eu` as default
 - Never re-try failed telemetry calls
+- **Never narrate telemetry** — do not write transition text like "let me send the telemetry event" or "sending final telemetry". Run telemetry calls without commentary; at the end of a flow, go straight to the user-facing summary
 - Sentiment and completion are cumulative — update them based on the FULL conversation so far, not just the current step
 - **Sentiment must be honest** — if validation failed, if the user was confused about credentials, reflect that. A static "positive" on every event is useless telemetry
 


### PR DESCRIPTION
## What

Adds automated quality evals for the onboarding skills (`onboard-confidence`, `setup-warehouse`, `setup-warehouse-bigquery`), extending the eval stack that already covers the four migration skills. Results log to Braintrust as `onboard-single-turn-v1` / `onboard-multi-turn-v1`.

## How

**Multi-turn harness generalized.** The driver now selects a `SkillHarness` per scenario; migration scenarios are byte-for-byte unchanged. The onboarding harness mocks all three tool surfaces the skill uses:
- **Bash** — regex-routed canned outputs (bundled `auth.py` → mock JWT, userinfo, availability checks, account creation, telemetry endpoints, gcloud/bq)
- **AskUserQuestion** — scripted answers matched by regex against question/header/options, first-option fallback with a warning
- **MCP** — identity, clients/secrets, invites, and the warehouse suite, with in-memory state

Scenarios script failure sequences declaratively: `bash_responses` (e.g. availability false-then-true) and `tool_responses` (e.g. `getIdentityInfo` failing until the user runs `/mcp`).

**Coverage.** 13 multi-turn scenarios (default entry, create-account happy + 4 error paths incl. under-review verify-vs-fraud disambiguation, setup wizard incl. context-schema-before-targeting and MCP retry, invite batch, status, warehouse dispatch + BigQuery end-to-end) and 16 single-turn cases (routing, error interpretation, validation, email-derived name suggestions, communication rules). The telemetry contract is asserted: key acquired, events published, never mentioned to the user.

**Scoring.** Deterministic assertions (incl. new `tool_call_arg_not_contains`) plus a conversation-level internal-leak LLM judge; single-turn adds a forced `Next step:` verdict footer, content checks, a binary leak denylist, and onboarding-tuned judges.

## Findings

The evals caught a real defect on first run: models narrate "let me send the final telemetry" at flow end, violating the telemetry-transparency rule. Fixed by adding a **Never narrate telemetry** rule to every skill's telemetry block (second commit); the BigQuery scenario passes 11/11 with it.

Current scores: single-turn 100% on 5/6 scorers (NextStep 93.75%, one nondeterministic miss); multi-turn AssertionsPassed 99.3% pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)