### PR TITLE
feat: add Codex marketplace.json for OpenAI plugin distribution

### DIFF
--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "confidence",
+  "version": "0.7.0",
+  "owner": {
+    "name": "Spotify Confidence"
+  },
+  "plugins": [
+    {
+      "name": "confidence",
+      "version": "0.7.0",
+      "description": "Access Confidence feature flags, experiments, and migration tools directly from Codex.",
+      "homepage": "https://confidence.spotify.com",
+      "repository": "https://github.com/spotify/confidence-ai-plugins",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/spotify/confidence-ai-plugins.git"
+      }
+    }
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -42,6 +42,16 @@
         },
         {
           "type": "json",
+          "path": ".codex-plugin/marketplace.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
+        },
+        {
+          "type": "json",
           "path": "gemini-extension.json",
           "jsonpath": "$.version"
         }


### PR DESCRIPTION
## Summary
- The `.codex-plugin/plugin.json` was already compatible with the OpenAI plugin spec (skills, mcpServers, interface metadata all present)
- **Missing piece:** no `marketplace.json` for Codex directory distribution — Claude and Cursor plugins both had one, Codex did not
- Adds `.codex-plugin/marketplace.json` matching the pattern from the other two clients
- Wires it into `release-please-config.json` so version bumps are automatic

## Test plan
- [ ] Verify `marketplace.json` schema matches Claude/Cursor equivalents
- [ ] Confirm release-please picks up the new version paths on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)