### PR TITLE
fix(skills): improve instrument-events and explore-metric interactivity and reliability

### DIFF
--- a/skills/explore-metric/SKILL.md
+++ b/skills/explore-metric/SKILL.md
@@ -118,21 +118,18 @@ Mark the recommended kind based on context:
 
 If the user picks consumption, average, or a kind that needs a measure column, ask which measure to use (from the fact table's measures list) with the most relevant one marked "(Recommended)".
 
-### 5. Find exposure tables
+### 5. Exposure table handling
 
-Call `mcp__confidence-flags__listExposureTables` and filter to:
-- Same entity as the fact table
-- State is `TABLE_STATE_ACTIVE`
-- Has `exposureDataDeliveredUntilTime` (meaning data exists)
+**Do NOT include the `exposure` parameter in the generated URL.**
 
-Sort by most recent data delivery time. Pick the best match.
+The Metric Explorer requires the fact table's data partitions to overlap with the exposure table's data partitions. There is no MCP tool to verify this overlap (it requires the `QueryAvailableTimeRange` gRPC endpoint). Picking an exposure table blindly causes "No available time range for this metric" errors when the data doesn't overlap.
 
-If no matching exposure tables exist:
-> No active experiments found for this entity. The Metric Explorer
-> requires an experiment to be running. You can still create the metric
-> manually in the UI, or start an experiment first.
+Instead, let the user select the experiment in the Metric Explorer UI, where the dropdown only shows experiments with valid data ranges.
 
-Generate the URL without the `exposure` param — the user can select one in the UI.
+Tell the user:
+> The link opens the Metric Explorer with your fact table and metric kind
+> pre-filled. Select an experiment from the dropdown in the UI — it only
+> shows experiments with overlapping data, so you won't hit time range errors.
 
 ### 6. Generate the Metric Explorer URL
 
@@ -144,7 +141,6 @@ Generate the URL without the `exposure` param — the user can select one in the
 |-------|---------|-------|
 | Fact table | `factTable` | `factTables/{id}` (URL-encoded) |
 | Entity | `entity` | `entities/{id}` (URL-encoded) |
-| Exposure table | `exposure` | `exposureTables/{id}` (URL-encoded) |
 | Metric kind | `kind` | `conversion`, `consumption`, `average`, `ratio`, `ctr` |
 | Measure column | `measurement` | column name (for consumption/average) |
 | Aggregation | `agg` | `count`, `sum`, `avg`, `min`, `max`, `countDistinct` |
@@ -165,13 +161,14 @@ Generate the URL without the `exposure` param — the user can select one in the
 Examples of CORRECT encoding:
 - `factTable=factTables%2Fpurchase-completed` ✓
 - `entity=entities%2Fenk6xv5ido8wqotjxkcz` ✓
-- `exposure=exposureTables%2Fbed86624e687c05638a42199c4344b7b` ✓
 
 Examples of WRONG encoding (will break the UI):
 - `factTable=factTables/purchase-completed` ✗
 - `entity=entities/visitor` ✗
 
 Always include these required params: `factTable`, `entity`, `kind`, `agg`, `aggOp=none`.
+
+**Do NOT include `exposure` in the URL.** The Metric Explorer requires the fact table and exposure table data partitions to overlap, and there is no MCP tool or public API to verify this overlap (`QueryAvailableTimeRange` is behind an internal GraphQL BFF). Including an exposure table blindly causes "No available time range" errors. Let the user select the experiment in the UI dropdown, which only shows valid options.
 
 **Present the link:**
 
@@ -181,17 +178,13 @@ Always include these required params: `factTable`, `entity`, `kind`, `agg`, `agg
   📊 Revenue per visitor
      Kind: consumption  │  Measure: amount  │  Agg: SUM
 
-  https://app.confidence.spotify.com/metrics/explorer?factTable=factTables%2Fpurchase-completed&entity=entities%2Fvisitor&exposure=exposureTables%2Fabc123&kind=consumption&measurement=amount&agg=sum&aggOp=none
+  https://app.confidence.spotify.com/metrics/explorer?factTable=factTables%2Fpurchase-completed&entity=entities%2Fvisitor&kind=consumption&measurement=amount&agg=sum&aggOp=none
 
   In the Metric Explorer:
-    1. Click "Calculate" to preview the metric
-    2. Review the chart and diagnostics
-    3. Click "Create" to save it as a real metric
-
-  Note: If you see "No available time range", check that
-  the exposure table's data range overlaps with the fact
-  table's data. Try selecting a different experiment in
-  the dropdown — each experiment has its own time range.
+    1. Select an experiment from the dropdown
+    2. Click "Calculate" to preview the metric
+    3. Review the chart and diagnostics
+    4. Click "Create" to save it as a real metric
 
 ────────────────────────────────────────────────────────────
 ```
@@ -214,9 +207,8 @@ Options:
 - **Never run metric calculations in the terminal** — the Metric Explorer UI handles calculation, timing, and visualization. This skill only generates the URL.
 - **Always URL-encode resource names** — `factTables/x` becomes `factTables%2Fx`
 - **The URL must be on a SINGLE LINE** — never split across multiple lines. The user must be able to click it directly.
-- **Pick the most recent exposure table** matching the entity — sorted by `exposureDataDeliveredUntilTime` descending
+- **NEVER include `exposure` in the URL** — there is no MCP tool or public API to verify that the exposure table's data partitions overlap with the fact table's data (`QueryAvailableTimeRange` is behind an internal GraphQL BFF at `graphql-konfidens.spotify.com`). Including an exposure table blindly causes "No available time range for this metric" errors. Let the user select the experiment in the Metric Explorer UI dropdown.
 - **If multiple entities** exist on the fact table, ask the user which one to use
-- **Handle missing data gracefully** — if no fact table, no exposure table, or no measures exist, explain what's missing and what the user can do
+- **Handle missing data gracefully** — if no fact table or no measures exist, explain what's missing and what the user can do
 - **Every AskUserQuestion MUST have a recommended default** — analyze context and suggest the best option first with "(Recommended)" in the label
 - **Start from the business question** — don't force the user to think in terms of fact tables and aggregation types. Translate their intent into the right configuration.
-- **"No available time range" troubleshooting** — if the user reports this error, suggest: (1) try a different exposure table/experiment with a longer data range, (2) check the exposure table's `exposureDataDeliveredUntilTime` overlaps with fact table data, (3) for newly instrumented events, data lands in the warehouse within ~1 hour.

--- a/skills/explore-metric/SKILL.md
+++ b/skills/explore-metric/SKILL.md
@@ -14,6 +14,14 @@ Bridge the gap between raw event data and actionable experiment metrics. The use
 
 ---
 
+## User-Facing Communication Rules
+
+- **Use AskUserQuestion for all choices** — never numbered lists in plain text
+- **Every question MUST have a recommended default.** Analyze the available data and make an informed suggestion. Put the recommended option first with "(Recommended)" appended to its label. The user should be able to accept defaults and keep moving without having to think from scratch.
+- **Start from the business question**, not the data model. Ask what the user wants to measure before diving into fact tables and columns.
+
+---
+
 ## Prerequisites
 
 ### Confidence Flags MCP
@@ -30,7 +38,23 @@ claude mcp add confidence-flags --transport http --url https://mcp.confidence.de
 
 ## Flow
 
-### 1. Resolve the fact table
+### 1. Understand what to measure
+
+Before jumping to fact tables, ask the user what they're trying to understand. If the user provided a specific event or fact table as an argument, skip this step.
+
+If no argument was provided, use AskUserQuestion:
+
+> What do you want to measure?
+
+Examine the available fact tables and metrics to suggest the most relevant options. For example:
+- **Checkout conversion** — are users completing purchases? (Recommended if a checkout fact table exists)
+- **Click-through rate** — are users clicking? (Recommended if click/impression measures exist)
+- **Revenue impact** — how much are users spending?
+- **Something else** — describe what you want to measure
+
+Use the answer to guide fact table selection and metric kind in subsequent steps.
+
+### 2. Resolve the fact table
 
 If the user provides an **event name** (e.g., `purchase-completed`):
 - Call `mcp__confidence-flags__listFactTables` and search for a fact table matching that event name
@@ -53,11 +77,12 @@ If the user provides an **event name** (e.g., `purchase-completed`):
 If the user provides a **fact table name** (e.g., `factTables/purchase-completed`):
 - Use it directly
 
-If the user provides **no argument**:
-- Call `mcp__confidence-flags__listFactTables` and `mcp__confidence-flags__listEventDefinitions`
-- Present the available fact tables (filter to event-derived ones — those with `_event_time` as timestamp column) and let the user pick via AskUserQuestion
+If the user answered the business question in Step 1:
+- Call `mcp__confidence-flags__listFactTables`
+- Match the user's intent to the best fact table(s) based on display names, measures, and dimensions
+- Present the top matches via AskUserQuestion with the best match marked as "(Recommended)"
 
-### 2. Inspect the fact table
+### 3. Inspect the fact table
 
 From the fact table, extract:
 - **Entity** and its mapping (e.g., `visitor_id → entities/visitor`)
@@ -75,19 +100,25 @@ Present:
 ────────────────────────────────────────────────────────────
 ```
 
-### 3. Choose metric configuration
+### 4. Choose metric configuration
 
-Use AskUserQuestion to let the user configure the metric:
+Use AskUserQuestion to let the user configure the metric. **Suggest the best default based on the business question and available measures.**
 
 **Metric kind:**
 - **Conversion** — did the entity trigger at least 1 event? (COUNT ≥ 1)
 - **Consumption** — total of a numeric field per entity (SUM)
 - **Average** — mean of a numeric field per entity (AVG)
-- **Count** — number of events per entity (COUNT)
+- **Ratio** — ratio of two measures (e.g., clicks/impressions)
 
-If the user picks consumption, average, or a kind that needs a measure column, ask which measure to use (from the fact table's measures list).
+Mark the recommended kind based on context:
+- If the user asked about conversion/activation → recommend **Conversion**
+- If the fact table has revenue/amount measures → recommend **Consumption**
+- If the fact table has both click and impression measures → recommend **Ratio** (CTR)
+- If unsure → recommend **Conversion** (simplest, always works)
 
-### 4. Find exposure tables
+If the user picks consumption, average, or a kind that needs a measure column, ask which measure to use (from the fact table's measures list) with the most relevant one marked "(Recommended)".
+
+### 5. Find exposure tables
 
 Call `mcp__confidence-flags__listExposureTables` and filter to:
 - Same entity as the fact table
@@ -97,13 +128,13 @@ Call `mcp__confidence-flags__listExposureTables` and filter to:
 Sort by most recent data delivery time. Pick the best match.
 
 If no matching exposure tables exist:
-> No active experiments found for the Visitor entity. The Metric Explorer
+> No active experiments found for this entity. The Metric Explorer
 > requires an experiment to be running. You can still create the metric
 > manually in the UI, or start an experiment first.
 
 Generate the URL without the `exposure` param — the user can select one in the UI.
 
-### 5. Generate the Metric Explorer URL
+### 6. Generate the Metric Explorer URL
 
 **Base URL:** `https://app.confidence.spotify.com/metrics/explorer`
 
@@ -157,23 +188,24 @@ Always include these required params: `factTable`, `entity`, `kind`, `agg`, `agg
     2. Review the chart and diagnostics
     3. Click "Create" to save it as a real metric
 
-  Note: If you see "No available time range", the event
-  data hasn't landed in the warehouse yet. The event
-  connector batches data hourly — wait and retry.
+  Note: If you see "No available time range", check that
+  the exposure table's data range overlaps with the fact
+  table's data. Try selecting a different experiment in
+  the dropdown — each experiment has its own time range.
 
 ────────────────────────────────────────────────────────────
 ```
 
-### 6. Offer additional metrics
+### 7. Offer additional metrics
 
 After presenting the first URL, ask:
 
 > Want to explore another metric on this fact table, or a different event?
 
 Options:
-- **Another metric on this fact table** — go back to step 3
+- **Another metric on this fact table** — go back to step 4
 - **Different event or fact table** — go back to step 1
-- **Done** — end the skill
+- **Done (Recommended)** — end the skill
 
 ---
 
@@ -185,3 +217,6 @@ Options:
 - **Pick the most recent exposure table** matching the entity — sorted by `exposureDataDeliveredUntilTime` descending
 - **If multiple entities** exist on the fact table, ask the user which one to use
 - **Handle missing data gracefully** — if no fact table, no exposure table, or no measures exist, explain what's missing and what the user can do
+- **Every AskUserQuestion MUST have a recommended default** — analyze context and suggest the best option first with "(Recommended)" in the label
+- **Start from the business question** — don't force the user to think in terms of fact tables and aggregation types. Translate their intent into the right configuration.
+- **"No available time range" troubleshooting** — if the user reports this error, suggest: (1) try a different exposure table/experiment with a longer data range, (2) check the exposure table's `exposureDataDeliveredUntilTime` overlaps with fact table data, (3) for newly instrumented events, data lands in the warehouse within ~1 hour.

--- a/skills/instrument-events/SKILL.md
+++ b/skills/instrument-events/SKILL.md
@@ -534,3 +534,4 @@ List every change:
 - **Exposure tables are system-created** from assignment tables when experiments start — the user doesn't create them
 - **Do NOT run metric calculations or generate Metric Explorer URLs** — that's the explore-metric skill's job. This skill focuses on instrumentation only.
 - **Be interactive** — use AskUserQuestion at every decision point (client selection, entity selection, event selection, verification). Never make assumptions the user should confirm.
+- **NEVER delete event definitions** without explicit user confirmation. Deleting an event definition is a soft-delete that permanently blocks the name from being reused, and any events sent to a deleted definition are rejected with `EVENT_DEFINITION_NOT_FOUND`. If a definition needs to be replaced, always ask the user first and explain the consequences.

--- a/skills/instrument-events/SKILL.md
+++ b/skills/instrument-events/SKILL.md
@@ -70,6 +70,7 @@ curl -s -X POST "https://events.eu.confidence.dev/v1/events:publish" \
 - DO show human-readable status updates
 - DO handle all MCP/API complexity silently
 - **Use AskUserQuestion for all choices** — never numbered lists in plain text
+- **Every question MUST have a recommended default.** Analyze the project context and make an informed suggestion. Put the recommended option first with "(Recommended)" appended to its label. The user should be able to accept defaults and keep moving without having to think from scratch.
 
 ### Step Tracker
 

--- a/skills/instrument-events/SKILL.md
+++ b/skills/instrument-events/SKILL.md
@@ -78,11 +78,13 @@ Display at the START and after EACH step completes (updating status):
 ```
 ───── Instrument Events ──────────────────────────────────
   [1] Scan project              ○ pending
-  [2] Discover instrumentation  ○ pending
-  [3] Propose events & metrics  ○ pending
-  [4] Create event definitions  ○ pending
-  [5] Add SDK code              ○ pending
-  [6] Verify pipeline           ○ pending
+  [2] Select client             ○ pending
+  [3] Select entity             ○ pending
+  [4] Discover instrumentation  ○ pending
+  [5] Propose events & metrics  ○ pending
+  [6] Create event definitions  ○ pending
+  [7] Add SDK code              ○ pending
+  [8] Verify pipeline           ○ pending
 ────────────────────────────────────────────────────────────
 ```
 
@@ -97,9 +99,9 @@ Status markers: `○ pending` · `◉ in progress` · `⏸ awaiting user` · `�
 - The event data cannot be used for metrics
 - The entire metric pipeline is broken
 
-When proposing events, ALWAYS identify which field is the entity identifier (user_id, visitor_id, org_id, etc.) and mark it with an entity reference. Call `listEntities` to find available entities.
+When proposing events, ALWAYS use the entity the user selected in Step 3. Call `listEntities` to find available entities.
 
-**NEVER create duplicate event definitions.** In Step 2, cross-reference existing `track()` calls with existing event definitions. If a `track()` call already has a matching event definition with events flowing, do NOT re-create that event definition — acknowledge the existing coverage. You MAY still suggest NEW events for uncovered actions, but never re-create ones that already exist.
+**NEVER create duplicate event definitions.** In Step 4, cross-reference existing `track()` calls with existing event definitions. If a `track()` call already has a matching event definition with events flowing, do NOT re-create that event definition — acknowledge the existing coverage. You MAY still suggest NEW events for uncovered actions, but never re-create ones that already exist.
 
 **ALWAYS mention `/confidence:explore-metric`** in your response as the next step for metric preview and creation, even if you haven't completed all steps yet.
 
@@ -154,23 +156,79 @@ EDUCATE:
 
 **Determine the SDK** — based on tech stack:
 
-| Stack | SDK | Package |
-|-------|-----|---------|
-| JavaScript/TypeScript (browser) | Confidence JS SDK | `@spotify-confidence/sdk` |
-| React | Confidence JS SDK | `@spotify-confidence/sdk` |
-| Node.js | Confidence JS SDK | `@spotify-confidence/sdk` |
-| Java/Kotlin (server) | Confidence Java SDK | `com.spotify.confidence:sdk` |
-| Python | Confidence Python SDK | `spotify-confidence` |
-| Go | Confidence Go SDK | `github.com/spotify/confidence-sdk-go` |
-| Swift/iOS | Confidence Swift SDK | `ConfidenceSDK` |
-| Kotlin/Android | Confidence Kotlin SDK | `com.spotify.confidence:sdk-android` |
-| Flutter/Dart | Confidence Flutter SDK | `confidence_flutter_sdk` |
+| Stack | SDK | Tracking package | Flag evaluation package (if needed) |
+|-------|-----|-----------------|-------------------------------------|
+| JavaScript/TypeScript (browser) | Confidence JS SDK | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-web-provider` |
+| React (client) | Confidence JS SDK | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-web-provider` |
+| Node.js / Next.js (server) | Confidence JS SDK + Local Resolve | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-server-provider-local` |
+| Java/Kotlin (server) | Confidence Java SDK | `com.spotify.confidence:sdk` | `com.spotify.confidence:openfeature-provider-local` |
+| Python | Confidence Python SDK | `spotify-confidence` | `confidence-openfeature-provider` |
+| Go | Confidence Go SDK | `github.com/spotify/confidence-sdk-go` | `github.com/spotify/confidence-resolver/openfeature-provider/go` |
+| Swift/iOS | Confidence Swift SDK | `ConfidenceSDK` | (included) |
+| Kotlin/Android | Confidence Kotlin SDK | `com.spotify.confidence:sdk-android` | (included) |
+| Flutter/Dart | Confidence Flutter SDK | `confidence_flutter_sdk` | (included) |
+
+**Note:** For server-side/backend environments (Node.js, Java, Go, Python), Confidence uses a **local resolver** powered by WebAssembly from [spotify/confidence-resolver](https://github.com/spotify/confidence-resolver). Flags are evaluated locally with microsecond latency — no per-evaluation network calls. Event tracking still uses `confidence.track()` from the SDK, which sends events to the Confidence backend.
 
 Print "Detected <framework> project (<language>) — will use <SDK>"
 
 ---
 
-## Step 2. Discover existing instrumentation
+## Step 2. Select client
+
+EDUCATE:
+
+> **What is a client?**
+> A client represents the application that resolves flags and sends events — your
+> website, backend service, or mobile app. Each client has its own secret for
+> authentication and can be scoped to environments (dev, staging, prod).
+
+**List available clients** by calling `mcp__confidence-flags__listClients`.
+
+**If multiple clients exist**, use `AskUserQuestion` to let the user choose which client to use. Present the client names as options.
+
+**If no clients exist**, create one by calling `mcp__confidence-flags__createClient` with a name based on the project (e.g., `saas-starter-backend`). Confirm the name with the user via `AskUserQuestion` before creating.
+
+**If exactly one client exists**, confirm with the user that it's the right one to use.
+
+**Get the client secret** by calling `mcp__confidence-flags__getClientSecret` for the selected client.
+
+**Write the secret to `.env`:**
+- If `.env` exists, append `CONFIDENCE_CLIENT_SECRET=<secret>` (don't overwrite existing vars)
+- If `.env` doesn't exist, create it with `CONFIDENCE_CLIENT_SECRET=<secret>`
+- If `.env.example` or `.env.template` exists, add a placeholder there too
+- If `.gitignore` exists and doesn't include `.env`, add it
+
+**Important:** The client must be type **Backend** for server-side integrations. If the selected client is not Backend type, warn the user and offer to create a new Backend client. Backend secrets must be kept secure — they can download the resolver state with all flags and rules.
+
+Print "Using client: <client-name>"
+
+---
+
+## Step 3. Select entity
+
+EDUCATE:
+
+> **What is an entity?**
+> An entity represents the unit you're measuring — typically a user, visitor, or
+> organization. Every event needs an entity reference so Confidence knows how to
+> aggregate metrics (e.g., "revenue **per user**" or "clicks **per visitor**").
+
+**List available entities** by calling `mcp__confidence-flags__listEntities`.
+
+**Use `AskUserQuestion`** to let the user choose which entity to use for event tracking. Present entity names and descriptions as options.
+
+If no entities exist, explain that at least one entity is needed and suggest creating one (e.g., `user` or `visitor`).
+
+**Also ask what field name** the app uses to identify this entity (e.g., `user_id`, `visitor_id`, `email`). Examine the codebase for patterns — look at auth/session code, database schemas, API handlers — and suggest the most likely field name. Present suggestions via `AskUserQuestion`.
+
+Store the selected entity and field name for use in Steps 5 and 6.
+
+Print "Using entity: <entity-name> (field: <field-name>)"
+
+---
+
+## Step 4. Discover existing instrumentation
 
 EDUCATE:
 
@@ -208,7 +266,7 @@ Do NOT propose new events just to have something to suggest. If coverage is comp
 
 ---
 
-## Step 3. Propose events AND metrics together
+## Step 5. Propose events AND metrics together
 
 EDUCATE:
 
@@ -228,11 +286,11 @@ EDUCATE:
 **For each candidate, determine:**
 - Event name (kebab-case, 4-63 chars)
 - Schema fields with types
-- Which field is the **entity identifier** (e.g., `visitor_id`, `user_id`) — this gets the entity reference
+- The entity identifier field from Step 3 (e.g., `user_id`) — this gets the entity reference selected by the user
 - Where in the code to add the `track()` call (file:line)
 - Suggested metric: type (conversion/consumption/average/ratio), measure column, aggregation
 
-**Call `mcp__confidence-flags__listEntities`** to find available entities for the entity reference.
+**Use the entity selected in Step 3** for all event proposals. The entity field name and entity reference must match what the user chose.
 
 **Present each candidate as an event+metric pair:**
 
@@ -241,12 +299,12 @@ EDUCATE:
 │  purchase-completed                                     │
 │                                                         │
 │  Event schema:                                          │
-│    visitor_id → string (entity: entities/visitor)       │
+│    user_id    → string (entity: entities/user)          │
 │    amount     → double                                  │
 │    currency   → string                                  │
 │    item_count → int                                     │
 │                                                         │
-│  Suggested metric: Revenue per visitor                  │
+│  Suggested metric: Revenue per user                     │
 │    Kind: consumption  │  Measure: amount  │  Agg: SUM   │
 │                                                         │
 │  Insert at: src/checkout/handler.ts:42                  │
@@ -257,17 +315,17 @@ Use AskUserQuestion with multiSelect to let the user pick which event+metric pai
 
 ---
 
-## Step 4. Create event definitions
+## Step 6. Create event definitions
 
 For each selected event:
 
-1. Call `mcp__confidence-flags__createEventDefinition` with the event ID and schema JSON **including entity references**:
+1. Call `mcp__confidence-flags__createEventDefinition` with the event ID and schema JSON **including entity references using the entity from Step 3**:
 
 ```json
 {
-  "visitor_id": {
+  "user_id": {
     "stringSchema": {},
-    "semanticType": {"entityReference": {"entity": "entities/visitor"}}
+    "semanticType": {"entityReference": {"entity": "entities/user"}}
   },
   "amount": {"doubleSchema": {}},
   "currency": {"stringSchema": {}},
@@ -282,20 +340,67 @@ For each selected event:
 
 Print:
 ```
-Created event definition: purchase-completed (4 fields, entity: visitor)
+Created event definition: purchase-completed (4 fields, entity: user)
 Fact table auto-created: factTables/purchase-completed
-  Entities: visitor_id → entities/visitor
+  Entities: user_id → entities/user
   Measures: amount, item_count
   Dimensions: currency
 ```
 
 ---
 
-## Step 5. Add SDK code
+## Step 7. Add SDK code
 
-**Check if the Confidence SDK is already installed.** If not, provide the install command.
+EDUCATE:
 
-**Detect the analytics pattern** from Step 2:
+> Now I'll install the SDK, initialize it, and add tracking calls at each
+> event location. For server-side apps, Confidence uses a local resolver
+> powered by WebAssembly — flags evaluate locally with microsecond latency.
+> Event tracking sends data to the Confidence backend for metrics.
+
+**Check if the Confidence SDK is already installed.** If not, install the correct packages:
+
+For **Node.js / Next.js (server-side)** — install both the SDK for tracking and the local resolve provider for flag evaluation:
+```bash
+# Tracking (confidence.track())
+yarn add @spotify-confidence/sdk
+
+# Flag evaluation (local resolve via WASM — from spotify/confidence-resolver)
+yarn add @openfeature/server-sdk @spotify-confidence/openfeature-server-provider-local
+```
+
+For **browser / React (client-side)**:
+```bash
+yarn add @spotify-confidence/sdk @openfeature/web-sdk @spotify-confidence/openfeature-web-provider
+```
+
+**Initialize the SDK** at the app's entry point. For server-side Node.js/Next.js:
+
+```typescript
+import { Confidence } from '@spotify-confidence/sdk';
+
+const confidence = Confidence.create({
+  clientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
+  environment: 'backend',
+  timeout: 10000,
+});
+
+export { confidence };
+```
+
+If the app will also use feature flags (not just tracking), add the local resolve provider setup:
+
+```typescript
+import { OpenFeature } from '@openfeature/server-sdk';
+import { createConfidenceServerProvider } from '@spotify-confidence/openfeature-server-provider-local';
+
+const provider = createConfidenceServerProvider({
+  flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
+});
+await OpenFeature.setProviderAndWait(provider);
+```
+
+**Detect the analytics pattern** from Step 4:
 - If the app uses `confidence.track()` directly → add direct track calls
 - If it uses a framework layer (e.g., Backstage `useAnalytics()`) → use that layer
 
@@ -304,7 +409,7 @@ Fact table auto-created: factTables/purchase-completed
 JavaScript/TypeScript (direct):
 ```typescript
 confidence.track('purchase-completed', {
-  visitor_id: user.id,
+  user_id: user.id,
   amount: cart.total,
   currency: 'USD',
   item_count: cart.items.length,
@@ -320,22 +425,39 @@ analytics.captureEvent({
 });
 ```
 
-**Run the project's build/typecheck** to verify the code compiles.
+**Run the project's build/typecheck** to verify the code compiles. Fix any type errors before continuing.
 
 ---
 
-## Step 6. Verify pipeline
+## Step 8. Verify pipeline
 
 EDUCATE:
 
-> I'll verify the event pipeline is set up correctly.
+> I'll verify the full event pipeline — from SDK to warehouse — is working correctly.
 
-**Check:**
+**Check pipeline components:**
 
 1. `mcp__confidence-flags__checkWarehouseExists` — is a warehouse configured?
 2. `mcp__confidence-flags__getEventDefinition` for each created event — does it exist with entity references?
 3. `mcp__confidence-flags__listFactTables` — was the fact table auto-created?
 4. `mcp__confidence-flags__listExposureTables` — are there exposure tables matching the entity? (needed for the metric explorer URL)
+
+**Test events are flowing:**
+
+Ask the user if they want to start the app and verify events end-to-end:
+
+Use `AskUserQuestion`:
+- **Yes, start the app and test** — run the dev server, trigger an action, check publish counts
+- **Skip, I'll test later** — skip verification
+
+If the user wants to test:
+1. Start the dev server using the project's dev command (e.g., `pnpm dev`, `npm run dev`)
+2. Tell the user to trigger an action in the app (e.g., sign up, click a button) that fires one of the instrumented events
+3. Wait a moment, then call `mcp__confidence-flags__getEventDefinition` for the triggered event and check the `publishCount` — if it increased from 0, events are flowing
+4. If events are NOT flowing, troubleshoot:
+   - Is `CONFIDENCE_CLIENT_SECRET` set in `.env`?
+   - Is the SDK initialized correctly?
+   - Are there console errors?
 
 **Print pipeline status:**
 
@@ -344,14 +466,15 @@ Pipeline Status:
   Event definitions:  ✓ 2 created (with entity references)
   Warehouse:          ✓ configured
   Fact tables:        ✓ 2 auto-created
-  Exposure tables:    ✓ 3 found for entity Visitor
+  Events flowing:     ✓ publish count increased (signup-completed: 1)
+  Exposure tables:    — none yet (created when an experiment starts)
 ```
 
 If the warehouse is NOT configured, suggest `/confidence:onboard-confidence setup-warehouse`.
 
 If no fact table was auto-created:
-- Check that the event definition has entity references (Step 4 requirement)
-- Check that auto fact table creation is enabled for this account
+- Check that the event definition has entity references (Step 6 requirement)
+- Check that auto fact table creation is enabled for the account
 - Guide the user to create the fact table manually in the UI
 
 If no exposure tables exist for the entity:
@@ -360,12 +483,14 @@ If no exposure tables exist for the entity:
 
 ---
 
-## Step 7. Summary & next steps
+## Step 9. Summary & next steps
 
 Print what was done:
 
 ```
 ───── Summary ────────────────────────────────────────────
+  Client:     <client-name>
+  Entity:     <entity-name> (field: <field-name>)
   Created:    2 event definitions (with entity references)
   Fact tables: 2 auto-created
   Modified:   3 files with track() calls
@@ -374,8 +499,8 @@ Print what was done:
 ```
 
 List every change:
-- Created event definition `purchase-completed` (4 fields, entity: visitor)
-- Created event definition `signup-completed` (3 fields, entity: visitor)
+- Created event definition `purchase-completed` (4 fields, entity: user)
+- Created event definition `signup-completed` (3 fields, entity: user)
 - Fact table `factTables/purchase-completed` auto-created (measures: amount, item_count)
 - Fact table `factTables/signup-completed` auto-created (measures: —)
 - Modified `src/checkout/handler.ts:42` — added `confidence.track('purchase-completed', ...)`
@@ -401,9 +526,11 @@ List every change:
 - **EDUCATE before each step** — use a blockquote to briefly explain what's happening and why
 - **Never show secrets** in conversation output
 - **Use the Confidence vanilla SDK** `confidence.track()` for event tracking (not OpenFeature `client.track()` — the OpenFeature tracking spec is not yet wired to Confidence providers). Adapt to the app's existing analytics layer if present.
+- **For backend/server-side apps**, recommend the local resolve provider from [spotify/confidence-resolver](https://github.com/spotify/confidence-resolver) for flag evaluation. Event tracking still uses `confidence.track()` from the vanilla SDK.
 - **Handle failures gracefully** — if MCP is unavailable, explain what the user needs to do manually
 - **Proposals must be project-specific** — generic events like "user_action" are not helpful
 - **Entity references are required** — every event definition MUST have at least one string field with `semanticType.entityReference`. Without it, no fact table is auto-created.
 - **Fact tables are auto-created** from event definitions with entity references (when enabled for the account). The fact table definition appears instantly; warehouse data arrives within ~1 hour via the event connector batch.
 - **Exposure tables are system-created** from assignment tables when experiments start — the user doesn't create them
 - **Do NOT run metric calculations or generate Metric Explorer URLs** — that's the explore-metric skill's job. This skill focuses on instrumentation only.
+- **Be interactive** — use AskUserQuestion at every decision point (client selection, entity selection, event selection, verification). Never make assumptions the user should confirm.


### PR DESCRIPTION
## Summary

- **Interactive client selection** — list clients via MCP, let user pick, write secret to `.env`
- **Interactive entity selection** — list entities via MCP, let user choose which entity for event references
- **Local resolve for backend** — SDK table recommends `@spotify-confidence/openfeature-server-provider-local` from [spotify/confidence-resolver](https://github.com/spotify/confidence-resolver) for server-side apps
- **Event verification** — offers to start the app, trigger an action, and check publish counts
- **Recommended defaults** — every `AskUserQuestion` must have a suggested default so the user can accept and keep moving
- **No exposure param in Metric Explorer URL** — omit to avoid "No available time range" errors (no MCP tool to verify partition overlap)
- **Never delete event definitions without asking** — soft-delete permanently blocks the name from reuse

## Test plan

- [ ] Run instrument-events on a Next.js project — verify it asks for client, entity, and events
- [ ] Verify every AskUserQuestion has a "(Recommended)" option
- [ ] Run explore-metric — verify URL omits exposure param
- [ ] Verify Metric Explorer loads without "No available time range" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)