### PR TITLE
feat: update React guidance according to latest docs

### DIFF
--- a/skills/analyze-project/SKILL.md
+++ b/skills/analyze-project/SKILL.md
@@ -495,7 +495,9 @@ EDUCATE:
 
 **React/Next.js gotchas:**
 
-- Next.js App Router: use `ConfidenceProvider` in the root layout. Server Components use `getFlag('flag.prop', default, context)`; Client Components use the `useFlag('flag.prop', default)` hook. If using the client provider, the rendering file must be a Client Component — extract into `providers.tsx` with `"use client"` if needed.
+- When possible, avoid `@spotify-confidence/react`, `@spotify-confidence/sdk`, or `@openfeature/react-sdk` — these are being phased out. Use `@spotify-confidence/openfeature-server-provider-local` which evaluates flags locally via WebAssembly.
+- Import `ConfidenceProvider` and `getFlag` from `@spotify-confidence/openfeature-server-provider-local/react-server`. Import `useFlag` from `@spotify-confidence/openfeature-server-provider-local/react-client`.
+- Next.js App Router: use `ConfidenceProvider` in the root layout with an evaluation context. Server Components use `getFlag('flag.prop', default, context)` (async). Client Components use the `useFlag('flag.prop', default)` hook and require a `'use client'` directive — extract into `providers.tsx` if needed.
 - Never call `useFlag` in a Server Component — use `getFlag` or wrap in a Client Component.
 - Place the provider above any `<Suspense>` boundary.
 

--- a/skills/instrument-events/SKILL.md
+++ b/skills/instrument-events/SKILL.md
@@ -160,8 +160,8 @@ EDUCATE:
 | Stack | SDK | Tracking package | Flag evaluation package (if needed) |
 |-------|-----|-----------------|-------------------------------------|
 | JavaScript/TypeScript (browser) | Confidence JS SDK | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-web-provider` |
-| React (client) | Confidence JS SDK | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-web-provider` |
-| Node.js / Next.js (server) | Confidence JS SDK + Local Resolve | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-server-provider-local` |
+| React / Next.js | Confidence Server Provider (Local Resolve) | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-server-provider-local` (use `/react-server` for `ConfidenceProvider`/`getFlag`, `/react-client` for `useFlag`) |
+| Node.js (server) | Confidence JS SDK + Local Resolve | `@spotify-confidence/sdk` | `@spotify-confidence/openfeature-server-provider-local` |
 | Java/Kotlin (server) | Confidence Java SDK | `com.spotify.confidence:sdk` | `com.spotify.confidence:openfeature-provider-local` |
 | Python | Confidence Python SDK | `spotify-confidence` | `confidence-openfeature-provider` |
 | Go | Confidence Go SDK | `github.com/spotify/confidence-sdk-go` | `github.com/spotify/confidence-resolver/openfeature-provider/go` |
@@ -370,10 +370,11 @@ yarn add @spotify-confidence/sdk
 yarn add @openfeature/server-sdk @spotify-confidence/openfeature-server-provider-local
 ```
 
-For **browser / React (client-side)**:
+For **React / Next.js** — use the local-resolve server provider with React subpath exports:
 ```bash
-yarn add @spotify-confidence/sdk @openfeature/web-sdk @spotify-confidence/openfeature-web-provider
+yarn add @openfeature/server-sdk @spotify-confidence/openfeature-server-provider-local
 ```
+When possible, avoid `@spotify-confidence/react`, `@spotify-confidence/sdk`, and `@openfeature/react-sdk` — these are being phased out. For event tracking in React / Next.js apps, use the server provider's built-in logging; if you need `confidence.track()`, install `@spotify-confidence/sdk` solely for that purpose.
 
 **Initialize the SDK** at the app's entry point. For server-side Node.js/Next.js:
 

--- a/skills/migrate-eppo/SKILL.md
+++ b/skills/migrate-eppo/SKILL.md
@@ -1932,7 +1932,18 @@ flagged the precomputed pattern, do NOT use the client ambient mapping.
 Confidence's JS local-resolve provider ships a Next.js/RSC integration
 that is the direct analogue (fetch the `JS` local-resolve guide in Step 2;
 imports from `@spotify-confidence/openfeature-server-provider-local/react-server`
-and `/react-client`). Map the three layers:
+and `/react-client`).
+
+**React Gotchas — When possible, avoid `@spotify-confidence/react`,
+`@spotify-confidence/sdk`, and `@openfeature/react-sdk` — these are
+being phased out.** Always use
+`@spotify-confidence/openfeature-server-provider-local` with its
+`/react-server` export (`ConfidenceProvider`, `getFlag`) and
+`/react-client` export (`useFlag`). Server Components use `getFlag`;
+Client Components use `useFlag` with a `'use client'` directive. Place
+the provider above any `<Suspense>` boundary.
+
+Map the three layers:
 
 | Eppo (precomputed) | Confidence (React local-resolve) |
 |--------------------|----------------------------------|

--- a/skills/migrate-optimizely/SKILL.md
+++ b/skills/migrate-optimizely/SKILL.md
@@ -3777,9 +3777,15 @@ is implicit). Map by how the result is used:
 - `getVariation` (no impression) has no separate Confidence form —
   Confidence logs exposure on resolve. Note the behavior change.
 
-**React SDK mapping.** `@optimizely/react-sdk` →
-`@spotify-confidence/react` (or the React local-resolve provider for
-RSC; fetch the JS guide in Step 2):
+**React SDK mapping.** `@optimizely/react-sdk` → Confidence React
+local-resolve provider (`@spotify-confidence/openfeature-server-provider-local`
+with `/react-server` and `/react-client` subpath exports; fetch the JS
+guide in Step 2). **When possible, avoid `@spotify-confidence/react`,
+`@spotify-confidence/sdk`, and `@openfeature/react-sdk` — these are
+being phased out.** Server Components use `getFlag` (from
+`/react-server`); Client Components use `useFlag` (from `/react-client`)
+with a `'use client'` directive. Place the `ConfidenceProvider` above any
+`<Suspense>` boundary:
 
 | Optimizely React | Confidence React |
 |------------------|------------------|

--- a/skills/migrate-statsig/SKILL.md
+++ b/skills/migrate-statsig/SKILL.md
@@ -2178,15 +2178,18 @@ user argument; emit a one-time context setup instead.
 | `client.getExperiment("e").get("p", d)` | `get<Type>Value("e.p", d)` | (same — set once) |
 
 **React mapping.** Statsig `@statsig/react-bindings` hooks map to
-Confidence's React `useFlag`. **Prefer the local-resolve React integration**
-(server-precomputed / RSC) — the standalone Confidence React SDK
-(`@spotify-confidence/react`) is being phased out. Imports come from
-`@spotify-confidence/openfeature-server-provider-local/react-server`
-(the `<ConfidenceProvider context flags>` RSC component + `getFlag`) and
-`/react-client` (`useFlag`/`useFlagDetails`). Register the provider once on
-the server with `createConfidenceServerProvider` + `OpenFeature.setProviderAndWait`
-(as in the server case). (Validated by typechecking migrated React code
-against provider `0.14.2` + React 19.)
+Confidence's React `useFlag`. **When possible, avoid
+`@spotify-confidence/react`, `@spotify-confidence/sdk`, and
+`@openfeature/react-sdk` — these are being phased out.**
+Always use the local-resolve React integration from
+`@spotify-confidence/openfeature-server-provider-local`: imports come from
+`/react-server` (the `<ConfidenceProvider context flags>` RSC component +
+`getFlag` for Server Components) and `/react-client` (`useFlag` /
+`useFlagDetails` for Client Components — requires `'use client'`
+directive). Place the provider above any `<Suspense>` boundary. Register
+the provider once on the server with `createConfidenceServerProvider` +
+`OpenFeature.setProviderAndWait` (as in the server case). (Validated by
+typechecking migrated React code against provider `0.14.2` + React 19.)
 
 | Statsig (React) | Confidence (React, local-resolve) |
 |-----------------|-----------------------------------|
@@ -2200,9 +2203,11 @@ against provider `0.14.2` + React 19.)
 ⚠️ **Resolve-mode shift:** Statsig React (client-precomputed) → Confidence
 **server-precomputed**. Client reads stay local/offline, but resolution moves
 to the server, so this needs an RSC server (e.g. Next.js App Router). For a
-pure SPA with no server, fall back to the (deprecated) cached-client web SDK
-`@spotify-confidence/react` (`ConfidenceProvider` + `useFlag` on top of
-`@spotify-confidence/sdk`).
+pure SPA that requires dynamic client-side context modifications the local
+resolve SDK cannot support, the cached-client web SDK
+(`@spotify-confidence/sdk` + `@spotify-confidence/react`) still works but is
+being phased out — prefer migrating to Next.js App Router with the
+local-resolve provider when possible.
 
 **Remove Statsig readiness scaffolding.** Statsig examples gate the
 first check behind `await statsig.initialize(...)` /


### PR DESCRIPTION
- Mentions `@spotify-confidence/react`, `@spotify-confidence/sdk`, and `@open
feature/react-sdk` being phased out
- Steers agents towards using `@spotify-confidence/openfeature-server-provider-local` (as per latest docs)
- Clarifies guidance about `getFlag` and `useFlag` for React / Next integrations